### PR TITLE
fix(ci): add synchronize to issue-pr-sync trigger types

### DIFF
--- a/.github/workflows/issue-pr-sync.yml
+++ b/.github/workflows/issue-pr-sync.yml
@@ -8,7 +8,7 @@ name: issue-pr-sync
 
 on:
   pull_request:
-    types: [opened, reopened, edited, closed]
+    types: [opened, reopened, edited, synchronize, closed]
 
 permissions:
   contents: write

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -316,6 +316,29 @@ You don't need to touch labels or comment on the issue yourself — just get
 the branch name and `Closes #N` right (or let the bot fill in `Closes #N`
 for you) and the rest follows.
 
+### If a required check ever shows "Expected — waiting for status to be reported"
+
+This means GitHub is waiting for a check run against your PR's *current*
+commit that isn't coming — usually because the check ran once on an older
+commit and nothing re-triggered it for the latest one. It's not something
+to wait out; it will sit there forever until something fires a new event
+GitHub Actions listens for. To recover, do any one of these:
+
+- **Push a new commit** — an empty one works: `git commit --allow-empty -m "chore: retrigger checks" && git push`.
+- **Edit the PR title or description** — even a trivial change (GitHub
+  ignores true no-op edits, so change something real, e.g. add a comment
+  line) fires `pull_request.edited`, which every required check here
+  listens for.
+- **Use GitHub's "Update branch" button** on the PR — merges the base
+  branch in, which is a real new commit.
+
+If it happens repeatedly rather than as a one-off, the workflow's
+`on.pull_request.types` list is almost certainly missing an event it needs
+(this happened once already — `issue-pr-sync` was missing `synchronize`,
+so any PR that got a follow-up commit after opening got stuck exactly like
+this). Check `.github/workflows/*.yml`'s trigger types before assuming
+it's a one-off fluke.
+
 ## Questions
 
 If any of this is unclear or you hit a case it doesn't cover, ask in the


### PR DESCRIPTION
## Linked issue
Closes #43

## Why
sync is a required status check on main but its workflow never listened
for the synchronize event, so any PR that received a follow-up commit
after opening got permanently stuck waiting for a status report that
would never arrive. Hit this live on PRs #38, #40, #42 and had to work
around it manually by re-editing each PR body.

## What changed
- Added synchronize to issue-pr-sync.yml's pull_request trigger types.

## How I tested this
Pushing this commit to this PR is itself the test — confirms sync fires
correctly on a synchronize event once this fix is live in the branch.
(Note: since this is the fix being verified, this PR's own initial sync
check ran on `opened`, same as before — the real proof is that future
PRs with follow-up commits, once this merges to main, won't need the
manual workaround.)

## Checklist
- [x] No secrets, API keys, or .env values committed
- [x] I branched from main and am targeting main