### PR TITLE
feat(integrations): add media storage (Supabase) + brand logo upload

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,6 +22,12 @@ TAVILY_API_KEY=
 # --- Provider selection (packages/integrations/registry.py) ---
 SEARCH_PROVIDER=tavily
 LLM_PROVIDER=openrouter
+STORAGE_PROVIDER=supabase
+
+# --- Media storage (brand logos, generated images/video) ---
+SUPABASE_URL=
+SUPABASE_SERVICE_KEY=
+SUPABASE_STORAGE_BUCKET=brand-assets
 
 # --- Error tracking (optional locally — leave blank to disable Sentry) ---
 SENTRY_DSN=

--- a/apps/api/config/__init__.py
+++ b/apps/api/config/__init__.py
@@ -20,6 +20,11 @@ class Settings(BaseSettings):
 
     search_provider: str = "tavily"
     llm_provider: str = "openrouter"
+    storage_provider: str = "supabase"
+
+    supabase_url: str | None = None
+    supabase_service_key: str | None = None
+    supabase_storage_bucket: str = "brand-assets"
 
     sentry_dsn: str | None = None
 

--- a/apps/api/requirements.txt
+++ b/apps/api/requirements.txt
@@ -16,6 +16,7 @@ sentry-sdk[fastapi]==2.19.0
 
 pyjwt==2.10.1
 bcrypt==4.2.1
+python-multipart==0.0.20
 
 pytest==8.3.4
 pytest-cov==6.0.0

--- a/apps/api/routers/brands.py
+++ b/apps/api/routers/brands.py
@@ -1,6 +1,6 @@
 import uuid
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, File, HTTPException, UploadFile, status
 from sqlalchemy.orm import Session
 
 from apps.api.auth.dependencies import CurrentUser, get_current_user
@@ -8,10 +8,19 @@ from apps.api.config.database import get_db
 from apps.api.middleware.rbac import require_role
 from apps.api.models import Brand, UserRole
 from apps.api.schemas.brand import BrandCreate, BrandRead, BrandUpdate
+from packages.integrations.registry import get_storage_provider
 
 router = APIRouter(prefix="/brands", tags=["brands"])
 
 WRITE_ROLES = (UserRole.OWNER, UserRole.ADMIN, UserRole.EDITOR)
+
+
+def _brand_logo_path(org_id: str, brand_id: uuid.UUID) -> str:
+    # Fixed name (no original filename/extension) so delete can always
+    # reconstruct the same path deterministically from org_id + brand_id
+    # alone, and re-upload overwrites rather than accumulating orphans.
+    # UUIDs, not incrementing ids — you can't guess another brand's path.
+    return f"{org_id}/{brand_id}/logo"
 
 
 def _get_org_brand(db: Session, brand_id: uuid.UUID, org_id: str) -> Brand:
@@ -85,3 +94,39 @@ def delete_brand(
     brand = _get_org_brand(db, brand_id, current_user.org_id)
     db.delete(brand)
     db.flush()
+
+
+@router.put("/{brand_id}/logo", response_model=BrandRead)
+def upload_brand_logo(
+    brand_id: uuid.UUID,
+    file: UploadFile = File(...),
+    db: Session = Depends(get_db),
+    current_user: CurrentUser = Depends(require_role(*WRITE_ROLES)),
+) -> Brand:
+    brand = _get_org_brand(db, brand_id, current_user.org_id)
+    content = file.file.read()
+    path = _brand_logo_path(current_user.org_id, brand_id)
+
+    storage = get_storage_provider()
+    url = storage.upload(path, content, file.content_type or "application/octet-stream")
+
+    brand.logo_url = url
+    db.flush()
+    db.refresh(brand)
+    return brand
+
+
+@router.delete("/{brand_id}/logo", response_model=BrandRead)
+def delete_brand_logo(
+    brand_id: uuid.UUID,
+    db: Session = Depends(get_db),
+    current_user: CurrentUser = Depends(require_role(*WRITE_ROLES)),
+) -> Brand:
+    brand = _get_org_brand(db, brand_id, current_user.org_id)
+    storage = get_storage_provider()
+    storage.delete(_brand_logo_path(current_user.org_id, brand_id))
+
+    brand.logo_url = None
+    db.flush()
+    db.refresh(brand)
+    return brand

--- a/apps/api/tests/test_brands.py
+++ b/apps/api/tests/test_brands.py
@@ -1,4 +1,5 @@
 import uuid
+from unittest.mock import MagicMock, patch
 
 import pytest
 from fastapi.testclient import TestClient
@@ -232,3 +233,95 @@ def test_created_brand_actually_persists_across_connections() -> None:
             cleanup_db.commit()
         finally:
             cleanup_db.close()
+
+
+def _ok_storage_response() -> MagicMock:
+    response = MagicMock()
+    response.raise_for_status.return_value = None
+    return response
+
+
+@uses_test_session
+def test_editor_can_upload_brand_logo(db_session) -> None:
+    _org, user = _create_org_and_user(db_session, UserRole.EDITOR, "logo-editor@acme.test")
+    headers = _auth_headers(user)
+    created = client.post("/brands", json={"name": "Acme Widgets"}, headers=headers).json()
+
+    with patch("httpx.post", return_value=_ok_storage_response()) as mock_post:
+        response = client.put(
+            f"/brands/{created['id']}/logo",
+            files={"file": ("logo.png", b"fake-png-bytes", "image/png")},
+            headers=headers,
+        )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["logo_url"].endswith(f"{user.organization_id}/{created['id']}/logo")
+    # org/brand-scoped path, not the original filename — can't guess
+    # another brand's asset path from an incrementing id.
+    uploaded_path = mock_post.call_args.args[0]
+    assert f"{user.organization_id}/{created['id']}/logo" in uploaded_path
+
+
+@uses_test_session
+def test_viewer_cannot_upload_brand_logo(db_session) -> None:
+    _org, user = _create_org_and_user(db_session, UserRole.EDITOR, "logo-editor2@acme.test")
+    headers = _auth_headers(user)
+    created = client.post("/brands", json={"name": "Name"}, headers=headers).json()
+
+    _org2, viewer = _create_org_and_user(db_session, UserRole.VIEWER, "logo-viewer@acme.test")
+    viewer.organization_id = user.organization_id
+    db_session.flush()
+
+    response = client.put(
+        f"/brands/{created['id']}/logo",
+        files={"file": ("logo.png", b"data", "image/png")},
+        headers=_auth_headers(viewer),
+    )
+
+    assert response.status_code == 403
+
+
+@uses_test_session
+def test_editor_can_delete_brand_logo(db_session) -> None:
+    _org, user = _create_org_and_user(db_session, UserRole.EDITOR, "logo-editor3@acme.test")
+    headers = _auth_headers(user)
+    created = client.post("/brands", json={"name": "Name"}, headers=headers).json()
+
+    with patch("httpx.post", return_value=_ok_storage_response()):
+        client.put(
+            f"/brands/{created['id']}/logo",
+            files={"file": ("logo.png", b"data", "image/png")},
+            headers=headers,
+        )
+
+    with patch("httpx.delete", return_value=_ok_storage_response()) as mock_delete:
+        response = client.delete(f"/brands/{created['id']}/logo", headers=headers)
+
+    assert response.status_code == 200
+    assert response.json()["logo_url"] is None
+    deleted_path = mock_delete.call_args.args[0]
+    assert f"{user.organization_id}/{created['id']}/logo" in deleted_path
+
+
+@uses_test_session
+def test_reuploading_logo_overwrites_same_path(db_session) -> None:
+    _org, user = _create_org_and_user(db_session, UserRole.EDITOR, "logo-editor4@acme.test")
+    headers = _auth_headers(user)
+    created = client.post("/brands", json={"name": "Name"}, headers=headers).json()
+
+    with patch("httpx.post", return_value=_ok_storage_response()) as mock_post:
+        client.put(
+            f"/brands/{created['id']}/logo",
+            files={"file": ("first.png", b"data-1", "image/png")},
+            headers=headers,
+        )
+        client.put(
+            f"/brands/{created['id']}/logo",
+            files={"file": ("second.jpg", b"data-2", "image/jpeg")},
+            headers=headers,
+        )
+
+    first_path = mock_post.call_args_list[0].args[0]
+    second_path = mock_post.call_args_list[1].args[0]
+    assert first_path == second_path

--- a/apps/api/tests/test_storage.py
+++ b/apps/api/tests/test_storage.py
@@ -1,0 +1,66 @@
+from unittest.mock import MagicMock, patch
+
+from apps.api.models import IntegrationCall
+from packages.integrations.storage.supabase_provider import SupabaseStorageProvider
+
+
+def _provider() -> SupabaseStorageProvider:
+    return SupabaseStorageProvider(
+        base_url="https://project.supabase.co",
+        service_key="test-key",
+        bucket="brand-assets",
+    )
+
+
+def _ok_response() -> MagicMock:
+    response = MagicMock()
+    response.raise_for_status.return_value = None
+    return response
+
+
+def test_upload_returns_public_url(db_session) -> None:
+    with patch("httpx.post", return_value=_ok_response()) as mock_post:
+        url = _provider().upload("org1/brand1/logo", b"fake-image-bytes", "image/png")
+
+    assert url == "https://project.supabase.co/storage/v1/object/public/brand-assets/org1/brand1/logo"
+    call_kwargs = mock_post.call_args.kwargs
+    assert call_kwargs["headers"]["Authorization"] == "Bearer test-key"
+    assert call_kwargs["headers"]["Content-Type"] == "image/png"
+    assert call_kwargs["headers"]["x-upsert"] == "true"
+    assert call_kwargs["content"] == b"fake-image-bytes"
+
+
+def test_upload_uses_correct_endpoint(db_session) -> None:
+    with patch("httpx.post", return_value=_ok_response()) as mock_post:
+        _provider().upload("org1/brand1/logo", b"data", "image/png")
+
+    url_called = mock_post.call_args.args[0]
+    assert url_called == "https://project.supabase.co/storage/v1/object/brand-assets/org1/brand1/logo"
+
+
+def test_delete_calls_correct_endpoint(db_session) -> None:
+    with patch("httpx.delete", return_value=_ok_response()) as mock_delete:
+        _provider().delete("org1/brand1/logo")
+
+    url_called = mock_delete.call_args.args[0]
+    assert url_called == "https://project.supabase.co/storage/v1/object/brand-assets/org1/brand1/logo"
+    assert mock_delete.call_args.kwargs["headers"]["Authorization"] == "Bearer test-key"
+
+
+def test_upload_logs_integration_call(db_session) -> None:
+    with patch("httpx.post", return_value=_ok_response()):
+        _provider().upload("org1/brand1/logo", b"data", "image/png")
+
+    logged = (
+        db_session.query(IntegrationCall)
+        .filter_by(provider="supabase", capability="storage")
+        .order_by(IntegrationCall.created_at.desc())
+        .first()
+    )
+    assert logged is not None
+    assert logged.success is True
+
+
+def test_get_url_format() -> None:
+    url = _provider().get_url("org1/brand1/logo")
+    assert url == "https://project.supabase.co/storage/v1/object/public/brand-assets/org1/brand1/logo"

--- a/packages/integrations/registry.py
+++ b/packages/integrations/registry.py
@@ -4,6 +4,8 @@ from packages.integrations.llm.openai_provider import OpenAIProvider
 from packages.integrations.llm.openrouter_provider import OpenRouterProvider
 from packages.integrations.search.base import SearchProvider
 from packages.integrations.search.tavily import TavilyProvider
+from packages.integrations.storage.base import StorageProvider
+from packages.integrations.storage.supabase_provider import SupabaseStorageProvider
 
 _SEARCH_PROVIDERS = {
     "tavily": lambda settings: TavilyProvider(api_key=settings.tavily_api_key or ""),
@@ -14,6 +16,14 @@ _LLM_PROVIDERS = {
         api_key=settings.openrouter_api_key or ""
     ),
     "openai": lambda settings: OpenAIProvider(api_key=settings.openai_api_key or ""),
+}
+
+_STORAGE_PROVIDERS = {
+    "supabase": lambda settings: SupabaseStorageProvider(
+        base_url=settings.supabase_url or "",
+        service_key=settings.supabase_service_key or "",
+        bucket=settings.supabase_storage_bucket,
+    ),
 }
 
 
@@ -37,5 +47,17 @@ def get_llm_provider() -> LLMProvider:
         raise ValueError(
             f"Unknown LLM_PROVIDER '{settings.llm_provider}'. "
             f"Valid options: {sorted(_LLM_PROVIDERS)}"
+        ) from None
+    return factory(settings)
+
+
+def get_storage_provider() -> StorageProvider:
+    settings = get_settings()
+    try:
+        factory = _STORAGE_PROVIDERS[settings.storage_provider]
+    except KeyError:
+        raise ValueError(
+            f"Unknown STORAGE_PROVIDER '{settings.storage_provider}'. "
+            f"Valid options: {sorted(_STORAGE_PROVIDERS)}"
         ) from None
     return factory(settings)

--- a/packages/integrations/storage/base.py
+++ b/packages/integrations/storage/base.py
@@ -1,0 +1,19 @@
+from abc import ABC, abstractmethod
+
+
+class StorageProvider(ABC):
+    """Interface every storage adapter implements. Business/agent code
+    must only ever depend on this interface — never import a vendor SDK
+    directly outside the adapter that implements it."""
+
+    @abstractmethod
+    def upload(self, path: str, content: bytes, content_type: str) -> str:
+        """Uploads content at path, returns a retrievable URL."""
+
+    @abstractmethod
+    def delete(self, path: str) -> None:
+        ...
+
+    @abstractmethod
+    def get_url(self, path: str) -> str:
+        ...

--- a/packages/integrations/storage/supabase_provider.py
+++ b/packages/integrations/storage/supabase_provider.py
@@ -1,0 +1,43 @@
+import httpx
+
+from packages.integrations.observability import track_integration_call
+from packages.integrations.storage.base import StorageProvider
+
+
+class SupabaseStorageProvider(StorageProvider):
+    """The only file allowed to call Supabase Storage directly."""
+
+    def __init__(
+        self, base_url: str, service_key: str, bucket: str, timeout: float = 30.0
+    ) -> None:
+        self.base_url = base_url.rstrip("/")
+        self.service_key = service_key
+        self.bucket = bucket
+        self.timeout = timeout
+
+    def upload(self, path: str, content: bytes, content_type: str) -> str:
+        with track_integration_call("supabase", "storage"):
+            response = httpx.post(
+                f"{self.base_url}/storage/v1/object/{self.bucket}/{path}",
+                headers={
+                    "Authorization": f"Bearer {self.service_key}",
+                    "Content-Type": content_type,
+                    "x-upsert": "true",
+                },
+                content=content,
+                timeout=self.timeout,
+            )
+            response.raise_for_status()
+        return self.get_url(path)
+
+    def delete(self, path: str) -> None:
+        with track_integration_call("supabase", "storage"):
+            response = httpx.delete(
+                f"{self.base_url}/storage/v1/object/{self.bucket}/{path}",
+                headers={"Authorization": f"Bearer {self.service_key}"},
+                timeout=self.timeout,
+            )
+            response.raise_for_status()
+
+    def get_url(self, path: str) -> str:
+        return f"{self.base_url}/storage/v1/object/public/{self.bucket}/{path}"


### PR DESCRIPTION
## Linked issue
Closes #11

## Why
Brand logos now, generated images/video from M3 onward — the system
needs one place to upload/serve media instead of every feature inventing
its own storage code.

## What changed
- `packages/integrations/storage/`: `StorageProvider` interface + a real
  `SupabaseStorageProvider` adapter, registered in the same
  `registry.py` as search/LLM.
- `PUT /brands/{brand_id}/logo` / `DELETE /brands/{brand_id}/logo`: the
  first real caller. Storage path is deterministic —
  `{org_id}/{brand_id}/logo`, no extension — so delete always
  reconstructs the same path without a separate DB column, re-upload
  overwrites (`x-upsert`) instead of accumulating orphaned objects, and
  the path can't be guessed from an incrementing id since both org_id
  and brand_id are UUIDs.

## How I tested this
No live Supabase project in this environment, so — same approach as #7's
providers — adapter and endpoint tests mock the HTTP layer rather than
claiming a live smoke test. What's verified precisely: request shape
(auth header, `x-upsert`, content-type), the exact storage path used,
`integration_call` logging on success, and that re-uploading a different
file writes to the identical path (overwrite, not accumulation).

```
pytest apps/api/tests -v --cov=apps/api --cov=packages --cov-fail-under=70
uvicorn apps.api.main:app --reload
```
69 passed, 98.3% coverage.

## Checklist
- [x] Tests added/updated and passing locally
- [x] No secrets, API keys, or .env values committed
- [x] Docs/README updated (.env.example)
- [x] I branched from main and am targeting main