### PR TITLE
feat(agents): add onboarding LangGraph agent (brand_report synthesis)

### DIFF
--- a/apps/api/requirements.txt
+++ b/apps/api/requirements.txt
@@ -19,6 +19,8 @@ bcrypt==4.2.1
 python-multipart==0.0.20
 cryptography==50.0.0
 
+langgraph==1.2.11
+
 pytest==8.3.4
 pytest-cov==6.0.0
 httpx==0.28.1

--- a/apps/api/routers/onboarding.py
+++ b/apps/api/routers/onboarding.py
@@ -7,7 +7,10 @@ from apps.api.auth.dependencies import CurrentUser, get_current_user
 from apps.api.config.database import get_db
 from apps.api.middleware.rbac import require_role
 from apps.api.models import Brand, OnboardingResponse, UserRole
+from apps.api.schemas.brand import BrandRead
 from apps.api.schemas.onboarding import OnboardingRead, OnboardingUpsert
+from packages.agents.onboarding.graph import run_onboarding_agent
+from packages.agents.onboarding.research_step import run_onboarding_research
 
 router = APIRouter(prefix="/brands/{brand_id}/onboarding", tags=["onboarding"])
 
@@ -103,3 +106,29 @@ def complete_onboarding(
     db.flush()
     db.refresh(response)
     return response
+
+
+@router.post("/run-agent", response_model=BrandRead)
+def run_agent(
+    brand_id: uuid.UUID,
+    db: Session = Depends(get_db),
+    current_user: CurrentUser = Depends(require_role(*WRITE_ROLES)),
+) -> Brand:
+    """Runs the onboarding research step (#14) followed by the onboarding
+    LangGraph agent (#15), writing the resulting brand_report onto the
+    Brand row. Requires onboarding to already be complete — the agent
+    reads questionnaire answers that may still be missing otherwise."""
+    brand = _get_org_brand(db, brand_id, current_user.org_id)
+    response = _get_response_or_404(db, brand_id)
+
+    if not response.is_complete:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Onboarding must be completed before running the agent",
+        )
+
+    research = run_onboarding_research(db, brand, response)
+    # run_onboarding_agent already flushes brand.brand_report and refreshes
+    # brand itself before returning — nothing left to do here.
+    run_onboarding_agent(db, brand, response, research)
+    return brand

--- a/apps/api/tests/test_onboarding.py
+++ b/apps/api/tests/test_onboarding.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 import pytest
 from fastapi.testclient import TestClient
 
@@ -149,6 +151,65 @@ def test_cannot_edit_after_complete(db_session) -> None:
     )
 
     assert response.status_code == 409
+
+
+@uses_test_session
+def test_run_agent_requires_completed_onboarding(db_session) -> None:
+    brand, user = _setup_brand(db_session)
+    headers = _auth_headers(user)
+    client.put(f"/brands/{brand.id}/onboarding", json={"voice": "Playful"}, headers=headers)
+
+    response = client.post(f"/brands/{brand.id}/onboarding/run-agent", headers=headers)
+
+    assert response.status_code == 400
+
+
+@uses_test_session
+def test_run_agent_runs_research_then_graph_and_returns_brand_with_report(db_session) -> None:
+    brand, user = _setup_brand(db_session)
+    headers = _auth_headers(user)
+    full_payload = {
+        "voice": "Playful",
+        "audience": "Gen Z",
+        "product_catalog": {"items": ["A"]},
+        "competitors": ["X"],
+        "goals": ["Grow"],
+    }
+    client.put(f"/brands/{brand.id}/onboarding", json=full_payload, headers=headers)
+    client.post(f"/brands/{brand.id}/onboarding/complete", headers=headers)
+
+    report = {
+        "voice_and_tone": "Playful",
+        "audience": "Gen Z",
+        "product_catalog_summary": "A",
+        "competitive_positioning": "Ahead of X",
+    }
+    with patch("apps.api.routers.onboarding.run_onboarding_research") as mock_research, patch(
+        "apps.api.routers.onboarding.run_onboarding_agent"
+    ) as mock_agent:
+        mock_agent.side_effect = lambda db, brand_arg, response_arg, research_arg: (
+            setattr(brand_arg, "brand_report", report)
+        )
+        response = client.post(f"/brands/{brand.id}/onboarding/run-agent", headers=headers)
+
+    assert response.status_code == 200
+    assert response.json()["brand_report"] == report
+    mock_research.assert_called_once()
+    mock_agent.assert_called_once()
+
+
+@uses_test_session
+def test_viewer_cannot_run_agent(db_session) -> None:
+    brand, editor = _setup_brand(db_session, UserRole.EDITOR, suffix="-1")
+    _brand2, viewer = _setup_brand(db_session, UserRole.VIEWER, suffix="-2")
+    viewer.organization_id = editor.organization_id
+    db_session.flush()
+
+    response = client.post(
+        f"/brands/{brand.id}/onboarding/run-agent", headers=_auth_headers(viewer)
+    )
+
+    assert response.status_code == 403
 
 
 @uses_test_session

--- a/packages/agents/onboarding/graph.py
+++ b/packages/agents/onboarding/graph.py
@@ -1,0 +1,128 @@
+import json
+import time
+from typing import TypedDict
+
+from langgraph.graph import END, START, StateGraph
+from sqlalchemy.orm import Session
+
+from apps.api.models.agent_run import AgentRun, AgentType
+from apps.api.models.brand import Brand
+from apps.api.models.onboarding_research import OnboardingResearch
+from apps.api.models.onboarding_response import OnboardingResponse
+from packages.agents.onboarding.prompts import REQUIRED_REPORT_KEYS, build_synthesis_prompt
+from packages.integrations.registry import get_llm_provider
+
+# OpenRouter model slug — free to swap since LLMProvider (#7) is
+# model-agnostic per-call; this is just this agent's default.
+LLM_MODEL = "anthropic/claude-sonnet-4.5"
+
+
+class OnboardingSynthesisError(Exception):
+    """Raised when the LLM's output can't be parsed into a usable brand_report."""
+
+
+class _GraphState(TypedDict):
+    prompt: str
+    llm_text: str
+    model: str
+    tokens: int
+    brand_report: dict
+
+
+def _strip_code_fence(text: str) -> str:
+    cleaned = text.strip()
+    if not cleaned.startswith("```"):
+        return cleaned
+    cleaned = cleaned.strip("`")
+    if cleaned.startswith("json"):
+        cleaned = cleaned[len("json"):]
+    return cleaned.strip()
+
+
+def _parse_report(text: str) -> dict:
+    try:
+        report = json.loads(_strip_code_fence(text))
+    except json.JSONDecodeError as exc:
+        raise OnboardingSynthesisError(f"LLM output was not valid JSON: {exc}") from exc
+
+    if not isinstance(report, dict):
+        raise OnboardingSynthesisError("LLM output was valid JSON but not an object")
+
+    missing = [key for key in REQUIRED_REPORT_KEYS if key not in report]
+    if missing:
+        raise OnboardingSynthesisError(f"brand_report missing required keys: {missing}")
+    return report
+
+
+def _synthesize_node(state: _GraphState) -> dict:
+    llm = get_llm_provider()
+    response = llm.complete(prompt=state["prompt"], model=LLM_MODEL, temperature=0.4)
+    report = _parse_report(response.text)
+    return {
+        "llm_text": response.text,
+        "model": response.model,
+        "tokens": response.input_tokens + response.output_tokens,
+        "brand_report": report,
+    }
+
+
+def _build_graph():
+    graph = StateGraph(_GraphState)
+    graph.add_node("synthesize", _synthesize_node)
+    graph.add_edge(START, "synthesize")
+    graph.add_edge("synthesize", END)
+    return graph.compile()
+
+
+_COMPILED_GRAPH = _build_graph()
+
+
+def run_onboarding_agent(
+    db: Session,
+    brand: Brand,
+    onboarding_response: OnboardingResponse,
+    research: OnboardingResearch | None,
+) -> dict:
+    """Runs the onboarding LangGraph graph end-to-end: questionnaire +
+    research in, structured brand_report out, written onto the Brand row.
+    Always logs an AgentRun — including on failure, where output is left
+    None but latency/timing is still captured — before letting the
+    exception (if any) propagate."""
+    prompt = build_synthesis_prompt(
+        brand_name=brand.name,
+        onboarding_response={
+            "voice": onboarding_response.voice,
+            "audience": onboarding_response.audience,
+            "product_catalog": onboarding_response.product_catalog,
+            "competitors": onboarding_response.competitors,
+            "goals": onboarding_response.goals,
+        },
+        research={
+            "brand_overview": research.brand_overview if research else [],
+            "competitor_positioning": research.competitor_positioning if research else {},
+        },
+    )
+
+    start = time.perf_counter()
+    result_state: _GraphState | None = None
+    try:
+        result_state = _COMPILED_GRAPH.invoke({"prompt": prompt})
+    finally:
+        latency_ms = (time.perf_counter() - start) * 1000
+        db.add(
+            AgentRun(
+                agent_type=AgentType.ONBOARDING,
+                input={"brand_id": str(brand.id)},
+                output=result_state.get("brand_report") if result_state else None,
+                model=result_state.get("model") if result_state else LLM_MODEL,
+                tokens=result_state.get("tokens") if result_state else None,
+                latency_ms=latency_ms,
+            )
+        )
+        db.flush()
+
+    report = result_state["brand_report"]
+    brand.brand_report = report
+    db.flush()
+    db.refresh(brand)
+    return report

--- a/packages/agents/onboarding/prompts.py
+++ b/packages/agents/onboarding/prompts.py
@@ -1,0 +1,45 @@
+import json
+
+SYSTEM_PROMPT = (
+    "You are a senior brand strategist synthesizing a Brand Report from a "
+    "client's onboarding questionnaire and public web research. Respond "
+    "with strict JSON only — no markdown, no commentary, no code fences."
+)
+
+REQUIRED_REPORT_KEYS = (
+    "voice_and_tone",
+    "audience",
+    "product_catalog_summary",
+    "competitive_positioning",
+)
+
+
+def build_synthesis_prompt(
+    brand_name: str, onboarding_response: dict, research: dict
+) -> str:
+    return f"""{SYSTEM_PROMPT}
+
+## Brand
+{brand_name}
+
+## Questionnaire answers
+Voice: {onboarding_response.get("voice")}
+Audience: {onboarding_response.get("audience")}
+Product catalog: {json.dumps(onboarding_response.get("product_catalog"))}
+Competitors: {", ".join(onboarding_response.get("competitors") or [])}
+Goals: {", ".join(onboarding_response.get("goals") or [])}
+
+## Web research
+Brand overview: {json.dumps(research.get("brand_overview"))}
+Competitor positioning: {json.dumps(research.get("competitor_positioning"))}
+
+## Task
+Produce a JSON object with exactly these top-level string keys:
+- "voice_and_tone": 2-3 sentences describing the brand's voice and tone
+- "audience": 2-3 sentences describing the target audience
+- "product_catalog_summary": a summary of the product catalog
+- "competitive_positioning": how this brand is positioned against its
+  competitors, grounded in the web research above
+
+Respond with ONLY the JSON object. No markdown code fences, no extra text.
+"""

--- a/packages/agents/tests/test_onboarding_agent.py
+++ b/packages/agents/tests/test_onboarding_agent.py
@@ -1,0 +1,138 @@
+import json
+from unittest.mock import patch
+
+import pytest
+
+from apps.api.models import AgentRun, AgentType, Brand, OnboardingResearch, OnboardingResponse, Organization
+from packages.agents.onboarding.graph import OnboardingSynthesisError, run_onboarding_agent
+from packages.integrations.llm.base import LLMResponse
+
+VALID_REPORT = {
+    "voice_and_tone": "Playful and direct.",
+    "audience": "Gen Z consumers who value sustainability.",
+    "product_catalog_summary": "A line of eco-friendly widgets.",
+    "competitive_positioning": "Positioned as the premium, sustainable alternative to Widgetron.",
+}
+
+
+def _setup(db_session) -> tuple[Brand, OnboardingResponse, OnboardingResearch]:
+    org = Organization(name="Acme Agency")
+    db_session.add(org)
+    db_session.flush()
+
+    brand = Brand(organization_id=org.id, name="Acme Widgets")
+    db_session.add(brand)
+    db_session.flush()
+
+    response = OnboardingResponse(
+        brand_id=brand.id,
+        voice="Playful",
+        audience="Gen Z",
+        product_catalog={"items": ["Widget A"]},
+        competitors=["Widgetron"],
+        goals=["Grow"],
+        is_complete=True,
+    )
+    research = OnboardingResearch(
+        brand_id=brand.id,
+        brand_overview=[{"title": "Acme raises Series A", "url": "https://x.test", "content": "..."}],
+        competitor_positioning={"Widgetron": [{"title": "Widgetron review", "url": "https://x.test", "content": "..."}]},
+    )
+    db_session.add_all([response, research])
+    db_session.flush()
+    return brand, response, research
+
+
+def _mock_llm(text: str) -> LLMResponse:
+    return LLMResponse(text=text, model="anthropic/claude-sonnet-4.5", input_tokens=500, output_tokens=150)
+
+
+def test_graph_runs_end_to_end_and_writes_brand_report(db_session) -> None:
+    brand, response, research = _setup(db_session)
+
+    with patch("packages.agents.onboarding.graph.get_llm_provider") as mock_get_llm:
+        mock_get_llm.return_value.complete.return_value = _mock_llm(json.dumps(VALID_REPORT))
+        report = run_onboarding_agent(db_session, brand, response, research)
+
+    assert report == VALID_REPORT
+    db_session.refresh(brand)
+    assert brand.brand_report == VALID_REPORT
+
+
+def test_graph_logs_agent_run_with_tokens_model_latency(db_session) -> None:
+    brand, response, research = _setup(db_session)
+
+    with patch("packages.agents.onboarding.graph.get_llm_provider") as mock_get_llm:
+        mock_get_llm.return_value.complete.return_value = _mock_llm(json.dumps(VALID_REPORT))
+        run_onboarding_agent(db_session, brand, response, research)
+
+    run = (
+        db_session.query(AgentRun)
+        .filter(AgentRun.agent_type == AgentType.ONBOARDING)
+        .order_by(AgentRun.created_at.desc())
+        .first()
+    )
+    assert run is not None
+    assert run.tokens == 650
+    assert run.model == "anthropic/claude-sonnet-4.5"
+    assert run.latency_ms is not None and run.latency_ms >= 0
+    assert run.output == VALID_REPORT
+
+
+def test_graph_uses_llm_provider_interface_not_direct_sdk(db_session) -> None:
+    brand, response, research = _setup(db_session)
+
+    with patch("packages.agents.onboarding.graph.get_llm_provider") as mock_get_llm:
+        mock_get_llm.return_value.complete.return_value = _mock_llm(json.dumps(VALID_REPORT))
+        run_onboarding_agent(db_session, brand, response, research)
+
+    mock_get_llm.assert_called_once()
+    mock_get_llm.return_value.complete.assert_called_once()
+
+
+def test_graph_raises_and_still_logs_agent_run_on_malformed_json(db_session) -> None:
+    brand, response, research = _setup(db_session)
+
+    with patch("packages.agents.onboarding.graph.get_llm_provider") as mock_get_llm:
+        mock_get_llm.return_value.complete.return_value = _mock_llm("not json at all")
+        with pytest.raises(OnboardingSynthesisError):
+            run_onboarding_agent(db_session, brand, response, research)
+
+    run = (
+        db_session.query(AgentRun)
+        .filter(AgentRun.agent_type == AgentType.ONBOARDING)
+        .order_by(AgentRun.created_at.desc())
+        .first()
+    )
+    assert run is not None
+    assert run.output is None
+
+    db_session.refresh(brand)
+    assert brand.brand_report is None  # untouched on failure
+
+
+def test_graph_raises_on_missing_required_keys(db_session) -> None:
+    brand, response, research = _setup(db_session)
+    incomplete = {"voice_and_tone": "Playful"}
+
+    with patch("packages.agents.onboarding.graph.get_llm_provider") as mock_get_llm:
+        mock_get_llm.return_value.complete.return_value = _mock_llm(json.dumps(incomplete))
+        with pytest.raises(OnboardingSynthesisError, match="missing required keys"):
+            run_onboarding_agent(db_session, brand, response, research)
+
+
+def test_graph_strips_markdown_code_fences() -> None:
+    from packages.agents.onboarding.graph import _parse_report
+
+    fenced = "```json\n" + json.dumps(VALID_REPORT) + "\n```"
+    assert _parse_report(fenced) == VALID_REPORT
+
+
+def test_graph_handles_missing_research(db_session) -> None:
+    brand, response, _research = _setup(db_session)
+
+    with patch("packages.agents.onboarding.graph.get_llm_provider") as mock_get_llm:
+        mock_get_llm.return_value.complete.return_value = _mock_llm(json.dumps(VALID_REPORT))
+        report = run_onboarding_agent(db_session, brand, response, research=None)
+
+    assert report == VALID_REPORT


### PR DESCRIPTION
Closes #15

Stacked on #61 (issue #14) → #60 (issue #10) → #59 (issue #26) — diff will show the combined chain until those merge, at which point GitHub retargets this to `main` automatically.

## What
A LangGraph graph (`packages/agents/onboarding/graph.py`) that takes `onboarding_response` + `onboarding_research` (#14) as input and produces the structured `brand_report` JSONB, written back onto the `Brand` row. Wired up behind a new `POST /brands/{brand_id}/onboarding/run-agent` trigger endpoint that runs #14's research step then this agent in one call — requires onboarding to already be `is_complete`.

- Single-node graph built with `langgraph.graph.StateGraph` — this is the first real graph in the codebase; #18 extends this pattern into the full multi-node per-post pipeline with checkpoint persistence
- Uses `LLMProvider` (#7) exclusively via `get_llm_provider()` — never a direct Anthropic/OpenAI/OpenRouter SDK call
- Every run logs an `AgentRun` row (`agent_type=onboarding`, tokens, model, latency) via try/finally, **including on failure** — a malformed LLM response still gets logged (`output=None`) before the error propagates, so failed runs stay visible in `agent_runs` too
- Requires `brand_report` to include `voice_and_tone`, `audience`, `product_catalog_summary`, `competitive_positioning` (the acceptance criteria's minimum) — anything else from the LLM raises `OnboardingSynthesisError` rather than silently writing a thin/broken report that every later M3 agent would read as shared context
- Strips markdown code fences before JSON-parsing (LLMs routinely wrap JSON in ` ```json ` blocks despite explicit instructions not to)

## How I tested this
```bash
alembic upgrade head   # no-op, confirms no schema drift — brand_report/report_embedding were already reserved on Brand back in #4
pytest apps/api/tests packages/agents/tests -v --cov=apps/api --cov=packages --cov-report=term-missing --cov-fail-under=70
# 113 passed, 98% coverage
```
No live OpenRouter credentials — tested against a mocked `LLMProvider`, covering both the graph's happy path and its failure/malformed-JSON paths (asserting the `AgentRun` row still gets written even when synthesis fails), same approach as the existing adapter tests.