### PR TITLE
feat(agents): pipeline LangGraph orchestration + Postgres checkpointing

### DIFF
--- a/apps/api/models/__init__.py
+++ b/apps/api/models/__init__.py
@@ -10,6 +10,7 @@ from apps.api.models.integration_call import IntegrationCall
 from apps.api.models.onboarding_research import OnboardingResearch
 from apps.api.models.onboarding_response import OnboardingResponse
 from apps.api.models.organization import Organization
+from apps.api.models.post import PipelineStage, Post
 from apps.api.models.social_account import SocialAccount, SocialAccountStatus, SocialPlatform
 from apps.api.models.user import User, UserRole
 
@@ -25,6 +26,8 @@ __all__ = [
     "OnboardingResearch",
     "OnboardingResponse",
     "Organization",
+    "PipelineStage",
+    "Post",
     "SocialAccount",
     "SocialAccountStatus",
     "SocialPlatform",

--- a/apps/api/models/agent_run.py
+++ b/apps/api/models/agent_run.py
@@ -15,6 +15,12 @@ class AgentType(str, enum.Enum):
     CREATIVE = "creative"
     GENERATION = "generation"
     REVIEWER = "reviewer"
+    # Added by Issue #18 (pipeline orchestration) alongside the Post model —
+    # the remaining stub nodes in packages/agents/pipeline/graph.py.
+    HUMAN_REVIEW = "human_review"
+    SCHEDULER = "scheduler"
+    PUBLISHER = "publisher"
+    ANALYTICS_COLLECTOR = "analytics_collector"
 
 
 class AgentRun(Base):
@@ -23,8 +29,9 @@ class AgentRun(Base):
     id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
     )
-    # No FK yet — Post doesn't exist until a later issue (M3). Nullable so
-    # onboarding runs (not tied to any Post) can log here too.
+    # Still no FK constraint: Post now exists (Issue #18) but agent_runs
+    # predates it and onboarding runs aren't tied to any Post, so this
+    # stays a plain nullable UUID rather than a hard FK.
     post_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
 
     agent_type: Mapped[AgentType] = mapped_column(

--- a/apps/api/models/post.py
+++ b/apps/api/models/post.py
@@ -1,0 +1,55 @@
+import enum
+import uuid
+from datetime import datetime
+
+from sqlalchemy import DateTime, Enum, ForeignKey, func
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from apps.api.config.database import Base
+
+
+class PipelineStage(str, enum.Enum):
+    """Mirrors the node names in packages/agents/pipeline/graph.py, in
+    pipeline order. A Post's current_pipeline_stage always reflects the
+    graph's real position (see Issue #18) — set by the pipeline runner
+    immediately after each node completes, not just once at the end."""
+
+    RESEARCH = "research"
+    CREATIVE = "creative"
+    GENERATION = "generation"
+    REVIEWER = "reviewer"
+    HUMAN_REVIEW = "human_review"
+    SCHEDULER = "scheduler"
+    PUBLISHER = "publisher"
+    ANALYTICS_COLLECTOR = "analytics_collector"
+    COMPLETED = "completed"
+
+
+class Post(Base):
+    __tablename__ = "posts"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    brand_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("brands.id"), nullable=False
+    )
+    # Optional — a post can be generated ad hoc as well as from a scheduled
+    # calendar entry (Issue #26).
+    calendar_event_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("content_calendar_events.id"), nullable=True
+    )
+
+    current_pipeline_stage: Mapped[PipelineStage] = mapped_column(
+        Enum(PipelineStage, name="pipeline_stage"),
+        nullable=False,
+        default=PipelineStage.RESEARCH,
+    )
+
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
+    )

--- a/apps/api/requirements.txt
+++ b/apps/api/requirements.txt
@@ -20,6 +20,15 @@ python-multipart==0.0.20
 cryptography==50.0.0
 
 langgraph==1.2.11
+# Postgres checkpoint saver for the pipeline graph (Issue #18) — ships as a
+# separate package from core langgraph. psycopg[binary]/psycopg-pool are its
+# own (psycopg3) driver, used only by the checkpointer's dedicated
+# connection — unrelated to SQLAlchemy's psycopg2-binary driver above.
+# [binary] pulls in a self-contained libpq build so this doesn't depend on
+# a system libpq being present (CI runners / dev machines may not have one).
+langgraph-checkpoint-postgres==3.1.2
+psycopg[binary]==3.3.4
+psycopg-pool==3.3.1
 
 pytest==8.3.4
 pytest-cov==6.0.0

--- a/migrations/versions/75d69ba778a0_posts_and_pipeline_checkpoints.py
+++ b/migrations/versions/75d69ba778a0_posts_and_pipeline_checkpoints.py
@@ -1,0 +1,145 @@
+"""posts and pipeline checkpoints
+
+Revision ID: 75d69ba778a0
+Revises: b080bafe185d
+Create Date: 2026-08-24 21:16:11.745069
+
+Adds Issue #18's Post model plus the tables LangGraph's PostgresSaver
+needs for durable checkpoint persistence (checkpoints / checkpoint_blobs /
+checkpoint_writes / checkpoint_migrations). Schema for those four tables
+matches exactly what `PostgresSaver.setup()` would create at runtime
+(langgraph.checkpoint.postgres, package langgraph-checkpoint-postgres) —
+see packages/agents/pipeline/checkpointer.py for why this repo creates
+them via Alembic instead of calling `.setup()` at runtime. The
+concurrently-built indexes `.setup()` uses are created as plain
+(non-CONCURRENT) indexes here instead, since these tables are empty at
+migration time and CREATE INDEX CONCURRENTLY can't run inside Alembic's
+migration transaction. `checkpoint_migrations` is seeded with the same
+rows `.setup()` would leave behind, so nothing ever tries to re-run
+those migrations against this schema.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+# revision identifiers, used by Alembic.
+revision: str = '75d69ba778a0'
+down_revision: Union[str, None] = 'b080bafe185d'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+# Number of PostgresSaver.MIGRATIONS entries as of langgraph-checkpoint-postgres
+# 3.1.2 — kept in sync with checkpointer.py's docstring. Seeded into
+# checkpoint_migrations below so PostgresSaver.setup() is a no-op if it's
+# ever invoked against this schema.
+_CHECKPOINT_MIGRATION_COUNT = 10
+
+_NEW_AGENT_TYPES = ("HUMAN_REVIEW", "SCHEDULER", "PUBLISHER", "ANALYTICS_COLLECTOR")
+_ORIGINAL_AGENT_TYPES = ("ONBOARDING", "RESEARCH", "CREATIVE", "GENERATION", "REVIEWER")
+
+
+def upgrade() -> None:
+    # --- agent_type: add the stub pipeline stages introduced by this issue ---
+    for value in _NEW_AGENT_TYPES:
+        op.execute(f"ALTER TYPE agent_type ADD VALUE IF NOT EXISTS '{value}'")
+
+    # --- posts ---
+    op.create_table(
+        'posts',
+        sa.Column('id', sa.UUID(), nullable=False),
+        sa.Column('brand_id', sa.UUID(), nullable=False),
+        sa.Column('calendar_event_id', sa.UUID(), nullable=True),
+        sa.Column(
+            'current_pipeline_stage',
+            sa.Enum(
+                'RESEARCH', 'CREATIVE', 'GENERATION', 'REVIEWER', 'HUMAN_REVIEW',
+                'SCHEDULER', 'PUBLISHER', 'ANALYTICS_COLLECTOR', 'COMPLETED',
+                name='pipeline_stage',
+            ),
+            nullable=False,
+        ),
+        sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.text('now()'), nullable=False),
+        sa.Column('updated_at', sa.DateTime(timezone=True), server_default=sa.text('now()'), nullable=False),
+        sa.ForeignKeyConstraint(['brand_id'], ['brands.id']),
+        sa.ForeignKeyConstraint(['calendar_event_id'], ['content_calendar_events.id']),
+        sa.PrimaryKeyConstraint('id'),
+    )
+
+    # --- LangGraph Postgres checkpoint tables (PostgresSaver schema) ---
+    op.create_table(
+        'checkpoint_migrations',
+        sa.Column('v', sa.Integer(), nullable=False),
+        sa.PrimaryKeyConstraint('v'),
+    )
+
+    op.create_table(
+        'checkpoints',
+        sa.Column('thread_id', sa.Text(), nullable=False),
+        sa.Column('checkpoint_ns', sa.Text(), nullable=False, server_default=sa.text("''")),
+        sa.Column('checkpoint_id', sa.Text(), nullable=False),
+        sa.Column('parent_checkpoint_id', sa.Text(), nullable=True),
+        sa.Column('type', sa.Text(), nullable=True),
+        sa.Column('checkpoint', postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column('metadata', postgresql.JSONB(astext_type=sa.Text()), nullable=False, server_default=sa.text("'{}'")),
+        sa.PrimaryKeyConstraint('thread_id', 'checkpoint_ns', 'checkpoint_id'),
+    )
+    op.create_index('checkpoints_thread_id_idx', 'checkpoints', ['thread_id'])
+
+    op.create_table(
+        'checkpoint_blobs',
+        sa.Column('thread_id', sa.Text(), nullable=False),
+        sa.Column('checkpoint_ns', sa.Text(), nullable=False, server_default=sa.text("''")),
+        sa.Column('channel', sa.Text(), nullable=False),
+        sa.Column('version', sa.Text(), nullable=False),
+        sa.Column('type', sa.Text(), nullable=False),
+        sa.Column('blob', sa.LargeBinary(), nullable=True),
+        sa.PrimaryKeyConstraint('thread_id', 'checkpoint_ns', 'channel', 'version'),
+    )
+    op.create_index('checkpoint_blobs_thread_id_idx', 'checkpoint_blobs', ['thread_id'])
+
+    op.create_table(
+        'checkpoint_writes',
+        sa.Column('thread_id', sa.Text(), nullable=False),
+        sa.Column('checkpoint_ns', sa.Text(), nullable=False, server_default=sa.text("''")),
+        sa.Column('checkpoint_id', sa.Text(), nullable=False),
+        sa.Column('task_id', sa.Text(), nullable=False),
+        sa.Column('idx', sa.Integer(), nullable=False),
+        sa.Column('channel', sa.Text(), nullable=False),
+        sa.Column('type', sa.Text(), nullable=True),
+        sa.Column('blob', sa.LargeBinary(), nullable=False),
+        sa.Column('task_path', sa.Text(), nullable=False, server_default=sa.text("''")),
+        sa.PrimaryKeyConstraint('thread_id', 'checkpoint_ns', 'checkpoint_id', 'task_id', 'idx'),
+    )
+    op.create_index('checkpoint_writes_thread_id_idx', 'checkpoint_writes', ['thread_id'])
+
+    op.bulk_insert(
+        sa.table('checkpoint_migrations', sa.column('v', sa.Integer())),
+        [{'v': v} for v in range(_CHECKPOINT_MIGRATION_COUNT)],
+    )
+
+
+def downgrade() -> None:
+    op.drop_table('checkpoint_writes')
+    op.drop_table('checkpoint_blobs')
+    op.drop_table('checkpoints')
+    op.drop_table('checkpoint_migrations')
+
+    op.drop_table('posts')
+    sa.Enum(name='pipeline_stage').drop(op.get_bind(), checkfirst=True)
+
+    # Postgres has no ALTER TYPE ... DROP VALUE, so removing the four
+    # stub-stage agent_type values means rebuilding the enum from scratch.
+    # (Fails, as expected, if any row already uses one of those values —
+    # same lossy-on-downgrade tradeoff every enum migration in this repo
+    # makes.)
+    op.execute("ALTER TYPE agent_type RENAME TO agent_type_old")
+    new_type = sa.Enum(*_ORIGINAL_AGENT_TYPES, name='agent_type')
+    new_type.create(op.get_bind())
+    op.execute(
+        "ALTER TABLE agent_runs "
+        "ALTER COLUMN agent_type TYPE agent_type USING agent_type::text::agent_type"
+    )
+    op.execute("DROP TYPE agent_type_old")

--- a/packages/agents/pipeline/checkpointer.py
+++ b/packages/agents/pipeline/checkpointer.py
@@ -1,0 +1,40 @@
+"""Postgres-backed checkpoint persistence for the per-post pipeline graph.
+
+LangGraph 1.x ships its Postgres checkpoint saver as the separate
+``langgraph-checkpoint-postgres`` package (``langgraph.checkpoint.postgres``),
+not bundled with the core ``langgraph`` distribution — see
+apps/api/requirements.txt. This module wraps that saver rather than
+hand-rolling checkpoint storage, so the pipeline graph gets durable,
+resumable interrupts (Issue #18) for free.
+
+Schema ownership: PostgresSaver normally creates its own tables at runtime
+via ``PostgresSaver.setup()``. This repo instead manages all schema through
+Alembic (see migrations/versions for the checkpoints/checkpoint_blobs/
+checkpoint_writes/checkpoint_migrations tables), matching how every other
+table here is created — so this module deliberately never calls
+``.setup()``. The migration seeds ``checkpoint_migrations`` with the same
+rows ``.setup()`` would have written, so the schema PostgresSaver expects
+already exists by the time any pipeline code runs.
+"""
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+
+from langgraph.checkpoint.postgres import PostgresSaver
+
+from apps.api.config import get_settings
+
+
+@contextmanager
+def get_postgres_checkpointer(database_url: str | None = None) -> Iterator[PostgresSaver]:
+    """Yields a PostgresSaver bound to a fresh psycopg connection against
+    this repo's Postgres database (``Settings.database_url`` by default).
+
+    Callers are expected to use this as a short-lived context manager per
+    pipeline invocation (mirrors apps/api/config/database.py's get_db()
+    pattern) rather than holding one connection open for the process
+    lifetime — a paused pipeline run doesn't need a live connection while
+    it's waiting on a human, only when it's actually being advanced."""
+    conn_string = database_url or get_settings().database_url
+    with PostgresSaver.from_conn_string(conn_string) as checkpointer:
+        yield checkpointer

--- a/packages/agents/pipeline/graph.py
+++ b/packages/agents/pipeline/graph.py
@@ -1,0 +1,216 @@
+"""The seven-stage* per-post pipeline graph (Issue #18).
+
+    Research -> Creative -> Generation -> Reviewer -> [Human Review] ->
+    Scheduler -> Publisher -> Analytics Collector
+
+Every node here is a stub — later issues (#19 Research, #20 Creative,
+#21 Generation, #24 Reviewer, #25 Human Review, plus the not-yet-filed
+Scheduler/Publisher/Analytics Collector issues) replace one node's body at
+a time with real logic. This issue's job is the skeleton itself: all
+stages wired in order, and the durability guarantee that makes the human
+review step safe to build — a paused run's state lives in Postgres (see
+checkpointer.py), not in process memory, so it survives a server restart.
+
+The Human Review stage is a genuine LangGraph interrupt (`interrupt()`),
+not a status flag polled by a cron job: calling it suspends the graph
+mid-node and durably persists everything needed to resume exactly there,
+via the checkpointer. Resuming later — even from a freshly started process
+with a brand-new checkpointer instance pointed at the same database — replays
+up to the interrupt and continues with whatever value the resume provides.
+
+* The issue text calls this a "seven-step" pipeline while listing eight
+stage names. Reviewer (#24) and Human Review (#25) are tracked as
+separate future issues with distinct real logic, so this graph keeps them
+as two distinct nodes rather than forcing a miscount — PIPELINE_STAGES
+below is the source of truth for what's actually wired up.
+"""
+
+from collections.abc import Iterator
+from typing import Any, TypedDict
+
+from langgraph.graph import END, START, StateGraph
+from langgraph.graph.state import CompiledStateGraph
+from langgraph.types import Command, Interrupt, interrupt
+from sqlalchemy.orm import Session
+
+from apps.api.models.agent_run import AgentRun, AgentType
+from apps.api.models.post import PipelineStage, Post
+
+# Pipeline order — the single source of truth for both graph wiring and the
+# tests that assert nodes are "present and wired in order".
+PIPELINE_STAGES: tuple[str, ...] = (
+    "research",
+    "creative",
+    "generation",
+    "reviewer",
+    "human_review",
+    "scheduler",
+    "publisher",
+    "analytics_collector",
+)
+
+STAGE_TO_PIPELINE_STAGE: dict[str, PipelineStage] = {
+    "research": PipelineStage.RESEARCH,
+    "creative": PipelineStage.CREATIVE,
+    "generation": PipelineStage.GENERATION,
+    "reviewer": PipelineStage.REVIEWER,
+    "human_review": PipelineStage.HUMAN_REVIEW,
+    "scheduler": PipelineStage.SCHEDULER,
+    "publisher": PipelineStage.PUBLISHER,
+    "analytics_collector": PipelineStage.ANALYTICS_COLLECTOR,
+}
+
+STAGE_TO_AGENT_TYPE: dict[str, AgentType] = {
+    "research": AgentType.RESEARCH,
+    "creative": AgentType.CREATIVE,
+    "generation": AgentType.GENERATION,
+    "reviewer": AgentType.REVIEWER,
+    "human_review": AgentType.HUMAN_REVIEW,
+    "scheduler": AgentType.SCHEDULER,
+    "publisher": AgentType.PUBLISHER,
+    "analytics_collector": AgentType.ANALYTICS_COLLECTOR,
+}
+
+
+class PipelineState(TypedDict):
+    post_id: str
+    completed_stages: list[str]
+    # Populated once the human_review node's interrupt() is resumed.
+    human_review_decision: Any
+
+
+def _stub_result(stage: str, state: PipelineState, **extra: Any) -> dict:
+    """Common return shape for every stub node: append this stage to the
+    run's history so both tests and the pipeline runner can see it ran."""
+    return {
+        "completed_stages": [*state.get("completed_stages", []), stage],
+        **extra,
+    }
+
+
+def _make_stub_node(stage: str):
+    """Builds a plain stub node function for a pipeline stage that has no
+    real logic yet — it just records that it ran. Later issues replace
+    these one at a time with the real Research/Creative/Generation/etc.
+    agents; the graph wiring and node name stay the same."""
+
+    def _node(state: PipelineState) -> dict:
+        return _stub_result(stage, state)
+
+    _node.__name__ = f"{stage}_node"
+    return _node
+
+
+def _human_review_node(state: PipelineState) -> dict:
+    """The one real (non-stub) piece of behavior in this graph: a durable
+    interrupt. Calling interrupt() here pauses graph execution and persists
+    everything needed to resume via the checkpointer — the pipeline can sit
+    here for hours or days waiting on a human, across process restarts,
+    without any polling. Resuming with Command(resume=<decision>) re-enters
+    this node, interrupt() returns the decision instead of pausing again,
+    and the graph continues on to `scheduler`."""
+    decision = interrupt({"stage": "human_review", "post_id": state["post_id"]})
+    return _stub_result("human_review", state, human_review_decision=decision)
+
+
+def build_pipeline_graph(checkpointer) -> CompiledStateGraph:
+    """Assembles the pipeline StateGraph and compiles it with the given
+    checkpointer. The graph itself is stateless/reusable — it carries no
+    reference to any particular Post or DB session, so the same compiled
+    graph object could serve every run; callers select a run via the
+    per-invocation `thread_id` in the LangGraph config."""
+    graph = StateGraph(PipelineState)
+
+    for stage in PIPELINE_STAGES:
+        node = _human_review_node if stage == "human_review" else _make_stub_node(stage)
+        graph.add_node(stage, node)
+
+    graph.add_edge(START, PIPELINE_STAGES[0])
+    for upstream, downstream in zip(PIPELINE_STAGES, PIPELINE_STAGES[1:]):
+        graph.add_edge(upstream, downstream)
+    graph.add_edge(PIPELINE_STAGES[-1], END)
+
+    return graph.compile(checkpointer=checkpointer)
+
+
+def _thread_config(post: Post) -> dict:
+    return {"configurable": {"thread_id": str(post.id)}}
+
+
+def run_pipeline(
+    db: Session,
+    post: Post,
+    checkpointer,
+    *,
+    resume: Any = None,
+) -> Iterator[dict]:
+    """Advances `post` through the pipeline graph until it either finishes
+    or hits the human_review interrupt, updating Post.current_pipeline_stage
+    (and logging an AgentRun row) after every node that actually completes —
+    not just once at the end — so the column always reflects the graph's
+    real position, including for a run that's paused mid-pipeline.
+
+    Pass `resume=<value>` to continue a previously interrupted run (e.g. a
+    human's approve/reject decision) instead of starting a new one.
+
+    Yields each node's raw update dict as it completes, in case a caller
+    wants to observe progress; most callers can just ignore the return
+    value and inspect `post.current_pipeline_stage` afterwards.
+    """
+    graph = build_pipeline_graph(checkpointer)
+    config = _thread_config(post)
+
+    if resume is not None:
+        graph_input: Any = Command(resume=resume)
+    else:
+        graph_input = {"post_id": str(post.id), "completed_stages": []}
+
+    for update in graph.stream(graph_input, config=config, stream_mode="updates"):
+        for node_name, node_output in update.items():
+            if node_name == "__interrupt__":
+                # Nothing to persist for the interrupt marker itself — the
+                # node that raised it hasn't completed (that's the whole
+                # point of interrupt()), so there's no AgentRun to log yet.
+                # current_pipeline_stage for this case is set below, after
+                # the loop, from the checkpointer's own notion of what's
+                # pending — the authoritative source, not this marker.
+                continue
+
+            stage = STAGE_TO_PIPELINE_STAGE[node_name]
+            post.current_pipeline_stage = stage
+            db.add(
+                AgentRun(
+                    post_id=post.id,
+                    agent_type=STAGE_TO_AGENT_TYPE[node_name],
+                    input={"post_id": str(post.id)},
+                    output=node_output if isinstance(node_output, dict) else None,
+                )
+            )
+            db.flush()
+
+        yield update
+
+    # Sync current_pipeline_stage to the checkpointer's authoritative view
+    # of where the run actually stands now — not just the last node that
+    # finished. A run paused at human_review has *not* completed that node
+    # (interrupt() suspended it mid-execution), but the post is very much
+    # "at" human_review from a caller's perspective — that's the stage a
+    # UI should show as pending, not the "reviewer" stage that already
+    # finished and handed off to it.
+    state = graph.get_state(config)
+    if state.next:
+        post.current_pipeline_stage = STAGE_TO_PIPELINE_STAGE[state.next[0]]
+    else:
+        post.current_pipeline_stage = PipelineStage.COMPLETED
+    db.flush()
+    db.refresh(post)
+
+
+def get_pending_interrupt(checkpointer, post: Post) -> Interrupt | None:
+    """Returns the pending Interrupt for this post's run, if it's currently
+    paused at one (e.g. waiting on human review), else None. Useful for a
+    caller that wants to show the human reviewer what's being asked without
+    re-running the graph."""
+    graph = build_pipeline_graph(checkpointer)
+    state = graph.get_state(_thread_config(post))
+    return state.interrupts[0] if state.interrupts else None

--- a/packages/agents/tests/test_pipeline_graph.py
+++ b/packages/agents/tests/test_pipeline_graph.py
@@ -1,0 +1,206 @@
+"""Tests for the Issue #18 pipeline skeleton.
+
+Three things matter here, per the issue's acceptance criteria:
+  1. All pipeline stages are present and wired in the documented order.
+  2. The human_review stage is a *real* LangGraph interrupt — the graph
+     actually pauses (no polling), and resuming continues past it.
+  3. Checkpoint state survives a simulated process restart: a brand new
+     PostgresSaver/connection/compiled-graph, built fresh from nothing but
+     the Postgres database, can resume a run exactly where it left off.
+
+These use a real Postgres-backed checkpointer (not an in-memory stand-in)
+against this repo's test database, since the load-bearing behavior here —
+durable persistence across a restart — is specifically what an in-memory
+checkpointer cannot demonstrate.
+"""
+
+from sqlalchemy import text
+
+import pytest
+
+from apps.api.config.database import engine
+from apps.api.models import AgentRun, Brand, Organization, PipelineStage, Post
+from packages.agents.pipeline.checkpointer import get_postgres_checkpointer
+from packages.agents.pipeline.graph import (
+    PIPELINE_STAGES,
+    build_pipeline_graph,
+    get_pending_interrupt,
+    run_pipeline,
+)
+
+
+def _setup_post(db_session) -> Post:
+    org = Organization(name="Acme Agency")
+    db_session.add(org)
+    db_session.flush()
+
+    brand = Brand(organization_id=org.id, name="Acme Widgets")
+    db_session.add(brand)
+    db_session.flush()
+
+    post = Post(brand_id=brand.id)
+    db_session.add(post)
+    db_session.flush()
+    return post
+
+
+@pytest.fixture()
+def thread_cleanup():
+    """Pipeline checkpoint rows live in Postgres on a connection totally
+    separate from db_session's rolled-back transaction, so they need
+    explicit teardown — otherwise every test run leaves rows behind."""
+    thread_ids: list[str] = []
+    yield thread_ids
+    if not thread_ids:
+        return
+    with get_postgres_checkpointer() as checkpointer:
+        for thread_id in thread_ids:
+            checkpointer.delete_thread(thread_id)
+
+
+def test_all_pipeline_stages_present_and_wired_in_order() -> None:
+    assert PIPELINE_STAGES == (
+        "research",
+        "creative",
+        "generation",
+        "reviewer",
+        "human_review",
+        "scheduler",
+        "publisher",
+        "analytics_collector",
+    )
+
+    with get_postgres_checkpointer() as checkpointer:
+        graph = build_pipeline_graph(checkpointer)
+        drawable = graph.get_graph()
+
+    node_names = set(drawable.nodes) - {"__start__", "__end__"}
+    assert node_names == set(PIPELINE_STAGES)
+
+    edges = {(edge.source, edge.target) for edge in drawable.edges}
+    assert ("__start__", PIPELINE_STAGES[0]) in edges
+    for upstream, downstream in zip(PIPELINE_STAGES, PIPELINE_STAGES[1:]):
+        assert (upstream, downstream) in edges
+    assert (PIPELINE_STAGES[-1], "__end__") in edges
+
+
+def test_human_review_step_is_a_real_interrupt_not_a_polling_loop(
+    db_session, thread_cleanup
+) -> None:
+    post = _setup_post(db_session)
+    thread_cleanup.append(str(post.id))
+
+    with get_postgres_checkpointer() as checkpointer:
+        updates = list(run_pipeline(db_session, post, checkpointer))
+
+        # The graph actually suspended execution — get_state shows a
+        # pending task for human_review rather than the run having
+        # finished or raised.
+        pending = get_pending_interrupt(checkpointer, post)
+
+    assert pending is not None
+    assert pending.value["stage"] == "human_review"
+
+    completed_nodes = [name for update in updates for name in update if name != "__interrupt__"]
+    assert completed_nodes == ["research", "creative", "generation", "reviewer"]
+    assert any("__interrupt__" in update for update in updates)
+
+    # Nothing downstream of the interrupt ran.
+    assert "scheduler" not in completed_nodes
+    assert "publisher" not in completed_nodes
+    assert "analytics_collector" not in completed_nodes
+
+    db_session.refresh(post)
+    assert post.current_pipeline_stage == PipelineStage.HUMAN_REVIEW
+
+
+def test_checkpoint_rows_are_actually_written_to_postgres(db_session, thread_cleanup) -> None:
+    post = _setup_post(db_session)
+    thread_cleanup.append(str(post.id))
+
+    with get_postgres_checkpointer() as checkpointer:
+        list(run_pipeline(db_session, post, checkpointer))
+
+    with engine.connect() as conn:
+        checkpoint_count = conn.execute(
+            text("SELECT count(*) FROM checkpoints WHERE thread_id = :tid"),
+            {"tid": str(post.id)},
+        ).scalar()
+
+    assert checkpoint_count and checkpoint_count > 0
+
+
+def test_checkpoint_resumes_after_simulated_process_restart(
+    db_session, thread_cleanup
+) -> None:
+    """The important test: a run interrupted by one checkpointer/connection
+    can be resumed by a completely separate one built fresh afterward — the
+    only thing carried between them is what's durably in Postgres."""
+    post = _setup_post(db_session)
+    thread_cleanup.append(str(post.id))
+
+    # "Process 1": run until the human_review interrupt, then throw the
+    # checkpointer and its connection away entirely.
+    with get_postgres_checkpointer() as checkpointer_process_1:
+        list(run_pipeline(db_session, post, checkpointer_process_1))
+
+    assert post.current_pipeline_stage == PipelineStage.HUMAN_REVIEW
+    logged_before_restart = (
+        db_session.query(AgentRun).filter(AgentRun.post_id == post.id).count()
+    )
+    assert logged_before_restart == 4  # research, creative, generation, reviewer
+
+    # "Process 2": brand-new PostgresSaver instance over a brand-new psycopg
+    # connection and a freshly compiled graph — nothing here is shared with
+    # process 1 except the Postgres database itself.
+    with get_postgres_checkpointer() as checkpointer_process_2:
+        resumed_updates = list(
+            run_pipeline(db_session, post, checkpointer_process_2, resume="approved")
+        )
+
+    resumed_nodes = [
+        name for update in resumed_updates for name in update if name != "__interrupt__"
+    ]
+    assert resumed_nodes == ["human_review", "scheduler", "publisher", "analytics_collector"]
+
+    db_session.refresh(post)
+    assert post.current_pipeline_stage == PipelineStage.COMPLETED
+
+    # Every one of the 8 stages ran exactly once across both processes —
+    # proof this *resumed* the interrupted run rather than restarting the
+    # whole pipeline from scratch.
+    all_runs = db_session.query(AgentRun).filter(AgentRun.post_id == post.id).all()
+    assert len(all_runs) == 8
+    assert sorted(run.agent_type.value for run in all_runs) == sorted(PIPELINE_STAGES)
+
+    # The human_review node's interrupt() call returned the resume value.
+    with get_postgres_checkpointer() as checkpointer:
+        graph = build_pipeline_graph(checkpointer)
+        final_state = graph.get_state({"configurable": {"thread_id": str(post.id)}})
+    assert final_state.values["human_review_decision"] == "approved"
+    assert final_state.next == ()  # fully finished, nothing pending
+
+
+def test_post_current_pipeline_stage_tracks_progress_not_just_final_result(
+    db_session, thread_cleanup
+) -> None:
+    """Regression guard for the "at all times" part of the acceptance
+    criteria: current_pipeline_stage must move through each stage as the
+    graph advances, not jump straight from RESEARCH to whatever's last."""
+    post = _setup_post(db_session)
+    thread_cleanup.append(str(post.id))
+    assert post.current_pipeline_stage == PipelineStage.RESEARCH
+
+    seen_stages = []
+    with get_postgres_checkpointer() as checkpointer:
+        for update in run_pipeline(db_session, post, checkpointer):
+            if "__interrupt__" in update:
+                continue
+            seen_stages.append(post.current_pipeline_stage)
+
+    assert seen_stages == [
+        PipelineStage.RESEARCH,
+        PipelineStage.CREATIVE,
+        PipelineStage.GENERATION,
+        PipelineStage.REVIEWER,
+    ]


### PR DESCRIPTION
## What

Builds the per-post pipeline as a LangGraph `StateGraph`, with every stage
a stub node that later issues fill in one at a time:

```
Research -> Creative -> Generation -> Reviewer -> [Human Review] ->
Scheduler -> Publisher -> Analytics Collector
```

- `packages/agents/pipeline/graph.py` — the graph definition. Each stub
  node just records that it ran (appends to `completed_stages` in state).
  `human_review` is the one non-stub node: it calls LangGraph's
  `interrupt()`, a real pause-and-persist interrupt, not a status flag
  polled by a cron job. `run_pipeline()` drives the graph via
  `stream(..., stream_mode="updates")`, syncing `Post.current_pipeline_stage`
  and logging an `AgentRun` row after every node that actually completes —
  not just once at the end — so the column reflects the graph's real
  position at all times, including a run that's currently paused.
- `packages/agents/pipeline/checkpointer.py` — wraps LangGraph 1.x's
  Postgres checkpoint saver (`langgraph-checkpoint-postgres`, a separate
  package from core `langgraph`) as a short-lived context manager, matching
  `apps/api/config/database.py`'s `get_db()` pattern.
- `apps/api/models/post.py` — new `Post` model with `current_pipeline_stage`
  (a `PipelineStage` enum mirroring the graph's node names), `brand_id` FK,
  optional `calendar_event_id` FK.
- New Alembic migration (`75d69ba778a0_posts_and_pipeline_checkpoints.py`)
  creates `posts` plus the four tables `PostgresSaver` needs
  (`checkpoints`, `checkpoint_blobs`, `checkpoint_writes`,
  `checkpoint_migrations`) — matching `PostgresSaver.setup()`'s own schema
  exactly, seeded so `.setup()` is a no-op if ever called. Schema is
  Alembic-owned like everything else in this repo, rather than created at
  runtime. Also extends the `agent_type` enum with the four new stub
  stages (`HUMAN_REVIEW`, `SCHEDULER`, `PUBLISHER`, `ANALYTICS_COLLECTOR`).

## Why

The human-review step is a durable interrupt that can pause for hours or
days waiting on a human — that has to be built as real LangGraph
checkpointing from the start, not bolted on with cron jobs and status
flags later. This issue delivers that skeleton so #19-25 (and later
scheduler/publisher/analytics issues) can each replace one stub node with
real logic without touching orchestration or persistence.

Note: the issue text calls this a "seven-step" pipeline while naming eight
stages (Reviewer and Human Review are listed separately, and are tracked
as separate future issues — #24 and #25 respectively — with distinct real
logic). This PR keeps them as two distinct graph nodes rather than forcing
a miscount; `PIPELINE_STAGES` in `graph.py` is the source of truth.

## Test plan

- `pytest packages/agents/tests/test_pipeline_graph.py -v` — 5/5 passed.
  Covers: all 8 stage nodes present and wired in the documented order; the
  human_review interrupt actually suspends execution (not a polling loop)
  and nothing downstream runs until it's resumed; checkpoint rows are
  genuinely written to Postgres; and the key scenario — a run interrupted
  under one `PostgresSaver`/connection is resumed by a completely separate
  one built fresh afterward (simulating a process restart), continuing
  from exactly where it paused with every stage logged exactly once across
  both "processes".
- `alembic upgrade head` then `alembic downgrade -1` then `alembic upgrade
  head` again against a clean local Postgres — applies and reverses
  cleanly.
- Full suite: `pytest apps/api/tests packages/agents/tests -v --cov=apps/api
  --cov=packages --cov-fail-under=70` — 128/128 passed, 98.55% coverage.

Closes #18