### PR TITLE
feat(agents): add Research Engine pipeline node

### DIFF
--- a/packages/agents/pipeline/graph.py
+++ b/packages/agents/pipeline/graph.py
@@ -3,13 +3,15 @@
     Research -> Creative -> Generation -> Reviewer -> [Human Review] ->
     Scheduler -> Publisher -> Analytics Collector
 
-Every node here is a stub — later issues (#19 Research, #20 Creative,
-#21 Generation, #24 Reviewer, #25 Human Review, plus the not-yet-filed
-Scheduler/Publisher/Analytics Collector issues) replace one node's body at
-a time with real logic. This issue's job is the skeleton itself: all
-stages wired in order, and the durability guarantee that makes the human
-review step safe to build — a paused run's state lives in Postgres (see
-checkpointer.py), not in process memory, so it survives a server restart.
+Every node here started as a stub — later issues (#19 Research, #20
+Creative, #21 Generation, #24 Reviewer, #25 Human Review, plus the
+not-yet-filed Scheduler/Publisher/Analytics Collector issues) replace one
+node's body at a time with real logic. #18's job was the skeleton itself:
+all stages wired in order, and the durability guarantee that makes the
+human review step safe to build — a paused run's state lives in Postgres
+(see checkpointer.py), not in process memory, so it survives a server
+restart. #19 is the first of those real-logic swaps: "research" now runs
+packages/agents/pipeline/nodes/research_engine.py instead of a stub.
 
 The Human Review stage is a genuine LangGraph interrupt (`interrupt()`),
 not a status flag polled by a cron job: calling it suspends the graph
@@ -35,6 +37,7 @@ from sqlalchemy.orm import Session
 
 from apps.api.models.agent_run import AgentRun, AgentType
 from apps.api.models.post import PipelineStage, Post
+from packages.agents.pipeline.nodes.research_engine import build_research_node
 
 # Pipeline order — the single source of truth for both graph wiring and the
 # tests that assert nodes are "present and wired in order".
@@ -77,6 +80,12 @@ class PipelineState(TypedDict):
     completed_stages: list[str]
     # Populated once the human_review node's interrupt() is resumed.
     human_review_decision: Any
+    # Populated by the research node (#19) — the structured research brief
+    # #20 (Creative Engine) consumes, including a timing_signal field #28
+    # (auto-scheduling) will eventually use. LangGraph drops any state key
+    # not declared here, so this must be listed even though it's only
+    # ever set by one stage.
+    research_brief: dict[str, Any] | None
 
 
 def _stub_result(stage: str, state: PipelineState, **extra: Any) -> dict:
@@ -113,16 +122,28 @@ def _human_review_node(state: PipelineState) -> dict:
     return _stub_result("human_review", state, human_review_decision=decision)
 
 
-def build_pipeline_graph(checkpointer) -> CompiledStateGraph:
+def build_pipeline_graph(checkpointer, db: Session | None = None) -> CompiledStateGraph:
     """Assembles the pipeline StateGraph and compiles it with the given
-    checkpointer. The graph itself is stateless/reusable — it carries no
-    reference to any particular Post or DB session, so the same compiled
+    checkpointer. The graph itself is otherwise stateless/reusable — it
+    carries no reference to any particular Post, so the same compiled
     graph object could serve every run; callers select a run via the
-    per-invocation `thread_id` in the LangGraph config."""
+    per-invocation `thread_id` in the LangGraph config.
+
+    `db` is the one exception: the "research" stage (#19) is the first
+    node with real logic that needs a database session (to resolve
+    Post -> Brand), so it's threaded through here to that node's factory.
+    It's optional and defaults to None so callers that only want to
+    inspect the compiled graph's structure — never stream/invoke it — can
+    keep calling this with just a checkpointer, same as before #19."""
     graph = StateGraph(PipelineState)
 
     for stage in PIPELINE_STAGES:
-        node = _human_review_node if stage == "human_review" else _make_stub_node(stage)
+        if stage == "human_review":
+            node = _human_review_node
+        elif stage == "research":
+            node = build_research_node(db)
+        else:
+            node = _make_stub_node(stage)
         graph.add_node(stage, node)
 
     graph.add_edge(START, PIPELINE_STAGES[0])
@@ -157,7 +178,7 @@ def run_pipeline(
     wants to observe progress; most callers can just ignore the return
     value and inspect `post.current_pipeline_stage` afterwards.
     """
-    graph = build_pipeline_graph(checkpointer)
+    graph = build_pipeline_graph(checkpointer, db=db)
     config = _thread_config(post)
 
     if resume is not None:

--- a/packages/agents/pipeline/nodes/research_engine.py
+++ b/packages/agents/pipeline/nodes/research_engine.py
@@ -1,0 +1,204 @@
+"""Research Engine — Issue #19, the first real (non-stub) stage in the
+per-post pipeline graph built in #18 (packages/agents/pipeline/graph.py).
+
+Gathers the raw material #20 (Creative Engine) needs to write an on-brand,
+on-trend post:
+
+  * Platform + industry trend research, via SearchProvider (#7) — called
+    only through its interface (packages/integrations/search/base.py),
+    never a direct Tavily import. Mirrors the degrade-gracefully-on-
+    failure pattern already established in
+    packages/agents/onboarding/research_step.py: a slow/broken search
+    provider must never take the pipeline down with it.
+  * The brand's actual voice/audience/positioning, via #16's pgvector
+    retrieval helper (apps.api.services.brand_retrieval.
+    get_relevant_brand_context) — reused as-is rather than re-querying
+    Brand.brand_report's raw JSONB directly.
+
+The output is a structured "research brief" dict, including a
+`timing_signal` field: not full auto-scheduling logic (that is #28's job,
+not this issue's), but the trend/timing material #28 will eventually read
+— what topics are trending right now, which platforms were researched,
+when this research ran, and the post's already-known target_datetime if
+it was scheduled onto the content calendar ahead of time.
+
+Node functions elsewhere in this graph take only `state` (see graph.py's
+_make_stub_node) — none of the other seven stages need a database
+session. Research is the first stage that does, to resolve
+Post -> Brand (and, optionally, Post -> ContentCalendarEvent). So this
+module exposes a *factory*, build_research_node(db), that closes over a
+caller-supplied Session and returns the actual LangGraph node function.
+graph.py's build_pipeline_graph() calls this factory for the "research"
+stage only — the other stages, and the graph's overall wiring/interrupt
+logic, are untouched.
+"""
+
+import logging
+import uuid
+from datetime import datetime, timezone
+from typing import Any
+
+from sqlalchemy.orm import Session
+
+from apps.api.models.brand import Brand
+from apps.api.models.content_calendar_event import ContentCalendarEvent, SUPPORTED_PLATFORMS
+from apps.api.models.post import Post
+from apps.api.services.brand_retrieval import get_relevant_brand_context
+from packages.integrations.registry import get_search_provider
+from packages.integrations.search.base import SearchResult
+
+logger = logging.getLogger(__name__)
+
+MAX_RESULTS_PER_QUERY = 5
+MAX_TRENDING_TOPICS = 5
+BRAND_CONTEXT_TOP_K = 3
+
+
+class ResearchEngineError(Exception):
+    """Raised when the research node can't resolve the Post/Brand it was
+    asked to research — a programming/data error (missing row), not a
+    transient provider failure, so unlike search failures this is not
+    swallowed."""
+
+
+def _search_safely(query: str) -> list[SearchResult]:
+    """Calls SearchProvider exclusively through its interface (never a
+    direct Tavily import) — same degrade-on-failure contract as
+    onboarding/research_step.py: a broken search provider must never take
+    the pipeline down with it, just leave this query's results empty."""
+    try:
+        return get_search_provider().search(query, max_results=MAX_RESULTS_PER_QUERY)
+    except Exception:
+        logger.warning("Research Engine query failed: %r", query, exc_info=True)
+        return []
+
+
+def _serialize(results: list[SearchResult]) -> list[dict]:
+    return [{"title": r.title, "url": r.url, "content": r.content} for r in results]
+
+
+def _brand_context_safely(db: Session, brand_id: Any, query: str) -> list[dict]:
+    """Same degrade-on-failure contract as _search_safely: a broken
+    embedding provider (missing/invalid API key, network issue, etc.)
+    must not take the whole Research Engine node — and therefore the
+    whole pipeline run — down with it. #16's retrieval helper is still
+    called exactly as built; this only adds a safety net around it."""
+    try:
+        return get_relevant_brand_context(db, brand_id, query=query, top_k=BRAND_CONTEXT_TOP_K)
+    except Exception:
+        logger.warning("Research Engine brand context retrieval failed", exc_info=True)
+        return []
+
+
+def _calendar_event_for(post: Post, db: Session) -> ContentCalendarEvent | None:
+    if post.calendar_event_id is None:
+        return None
+    return db.get(ContentCalendarEvent, post.calendar_event_id)
+
+
+def _platforms_for(post: Post, db: Session) -> list[str]:
+    """Prefers the platforms this post is actually scheduled for (via its
+    ContentCalendarEvent, if it has one) over researching every supported
+    platform generically."""
+    event = _calendar_event_for(post, db)
+    if event is not None and event.target_platforms:
+        return list(event.target_platforms)
+    return list(SUPPORTED_PLATFORMS)
+
+
+def _build_timing_signal(
+    platforms: list[str],
+    trend_results: list[SearchResult],
+    target_datetime: datetime | None,
+) -> dict[str, Any]:
+    """The field #28 (auto-scheduling) will eventually consume. Not full
+    scheduling logic — just the trend/timing material it needs: what
+    topics are trending right now (a proxy for "this is a good moment to
+    post about X"), which platforms were researched, when this research
+    ran, and the post's already-known target_datetime, if any."""
+    trending_topics: list[str] = []
+    for result in trend_results:
+        if result.title not in trending_topics:
+            trending_topics.append(result.title)
+        if len(trending_topics) >= MAX_TRENDING_TOPICS:
+            break
+    return {
+        "researched_at": datetime.now(timezone.utc).isoformat(),
+        "platforms": platforms,
+        "trending_topics": trending_topics,
+        "target_datetime": target_datetime.isoformat() if target_datetime else None,
+    }
+
+
+def _research_brief(db: Session, post: Post) -> dict[str, Any]:
+    brand = db.get(Brand, post.brand_id)
+    if brand is None:
+        raise ResearchEngineError(f"Research Engine: no Brand found for post {post.id}")
+
+    platforms = _platforms_for(post, db)
+    industry = brand.industry or brand.name
+
+    platform_trend_results = {
+        platform: _search_safely(f"{platform} content trends for {industry} brands")
+        for platform in platforms
+    }
+    industry_trend_results = _search_safely(f"{industry} industry trends")
+
+    all_trend_results = [
+        result for results in platform_trend_results.values() for result in results
+    ] + industry_trend_results
+
+    calendar_event = _calendar_event_for(post, db)
+    brand_context = _brand_context_safely(
+        db, brand.id, query=f"{brand.name} brand voice, audience, and positioning"
+    )
+
+    return {
+        "post_id": str(post.id),
+        "brand_context": brand_context,
+        "platform_trends": {
+            platform: _serialize(results) for platform, results in platform_trend_results.items()
+        },
+        "industry_trends": _serialize(industry_trend_results),
+        "timing_signal": _build_timing_signal(
+            platforms,
+            all_trend_results,
+            calendar_event.target_datetime if calendar_event else None,
+        ),
+    }
+
+
+def build_research_node(db: Session | None):
+    """Builds the real "research" stage node function, closing over `db`.
+    Mirrors graph.py's _make_stub_node factory shape/conventions, but for
+    the one stage (so far) that needs a database session to do real work.
+
+    `db` is accepted as possibly None so build_pipeline_graph(checkpointer)
+    — with no `db` argument — still works for callers that only inspect
+    the compiled graph's structure (nodes/edges) without ever streaming or
+    invoking it; the resulting node just isn't runnable, and raises
+    clearly if it ever is.
+    """
+
+    def _node(state: dict) -> dict:
+        if db is None:
+            raise RuntimeError(
+                "Research Engine node has no database session — "
+                "build_pipeline_graph() must be called with db=<Session> "
+                "to execute (not just inspect) the pipeline graph."
+            )
+
+        post = db.get(Post, uuid.UUID(state["post_id"]))
+        if post is None:
+            raise ResearchEngineError(
+                f"Research Engine: no Post found for post_id={state['post_id']!r}"
+            )
+
+        brief = _research_brief(db, post)
+        return {
+            "completed_stages": [*state.get("completed_stages", []), "research"],
+            "research_brief": brief,
+        }
+
+    _node.__name__ = "research_node"
+    return _node

--- a/packages/agents/tests/test_research_engine.py
+++ b/packages/agents/tests/test_research_engine.py
@@ -1,0 +1,319 @@
+"""Tests for the Issue #19 Research Engine node.
+
+Per the issue's acceptance criteria:
+  1. The node calls SearchProvider only through its interface — never a
+     direct HTTP call or vendor SDK.
+  2. The output includes a timing/trend signal usable by #28 (auto-
+     scheduling), not just topic research.
+  3. An AgentRun row is logged with agent_type=research.
+
+Most of these are exercised directly against build_research_node() (fast,
+no checkpointer needed — mirrors how
+packages/agents/onboarding/research_step.py's tests call
+run_onboarding_research() directly). The AgentRun-logging criterion is
+exercised through the real pipeline (run_pipeline + a Postgres-backed
+checkpointer, like packages/agents/tests/test_pipeline_graph.py), since
+that's the code that actually writes AgentRun rows — the node itself just
+returns a dict for run_pipeline to log.
+"""
+
+import hashlib
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import patch
+
+import pytest
+
+from apps.api.models import (
+    AgentRun,
+    AgentType,
+    Brand,
+    ContentCalendarEvent,
+    Organization,
+    Post,
+)
+from packages.agents.onboarding.embedding import embed_brand_report
+from packages.agents.pipeline.checkpointer import get_postgres_checkpointer
+from packages.agents.pipeline.graph import run_pipeline
+from packages.agents.pipeline.nodes.research_engine import (
+    ResearchEngineError,
+    build_research_node,
+)
+from packages.integrations.search.base import SearchResult
+
+SEARCH_PATCH_TARGET = "packages.agents.pipeline.nodes.research_engine.get_search_provider"
+EMBED_PATCH_TARGET = "apps.api.services.brand_retrieval.get_embedding_provider"
+
+
+def _setup_brand(db_session, industry: str | None = None) -> Brand:
+    org = Organization(name="Acme Agency")
+    db_session.add(org)
+    db_session.flush()
+
+    brand = Brand(organization_id=org.id, name="Acme Widgets", industry=industry)
+    db_session.add(brand)
+    db_session.flush()
+    return brand
+
+
+def _setup_post(
+    db_session, brand: Brand | None = None, calendar_event: ContentCalendarEvent | None = None
+) -> Post:
+    if brand is None:
+        brand = _setup_brand(db_session)
+    post = Post(
+        brand_id=brand.id,
+        calendar_event_id=calendar_event.id if calendar_event else None,
+    )
+    db_session.add(post)
+    db_session.flush()
+    return post
+
+
+def _fake_embed(text: str) -> list[float]:
+    vec = [0.0] * 1536
+    idx = int(hashlib.sha256(text.encode()).hexdigest(), 16) % 1536
+    vec[idx] = 1.0
+    return vec
+
+
+def _run_node(db_session, post: Post) -> dict:
+    node = build_research_node(db_session)
+    return node({"post_id": str(post.id), "completed_stages": []})
+
+
+@pytest.fixture()
+def thread_cleanup():
+    """Same teardown as test_pipeline_graph.py's fixture — pipeline
+    checkpoint rows live in Postgres on a connection separate from
+    db_session's rolled-back transaction, so they need explicit cleanup."""
+    thread_ids: list[str] = []
+    yield thread_ids
+    if not thread_ids:
+        return
+    with get_postgres_checkpointer() as checkpointer:
+        for thread_id in thread_ids:
+            checkpointer.delete_thread(thread_id)
+
+
+# --- SearchProvider used only through its interface -------------------------
+
+
+def test_research_node_calls_search_provider_only_through_interface(db_session) -> None:
+    post = _setup_post(db_session)
+
+    with patch(SEARCH_PATCH_TARGET) as mock_search, patch(EMBED_PATCH_TARGET) as mock_embed:
+        mock_search.return_value.search.return_value = []
+        mock_embed.return_value.embed.return_value = _fake_embed("query")
+
+        _run_node(db_session, post)
+
+    mock_search.assert_called()
+    mock_search.return_value.search.assert_called()
+
+
+def test_research_node_never_makes_a_direct_http_call(db_session) -> None:
+    """No direct HTTP/vendor SDK usage: TavilyProvider is the only file
+    allowed to call httpx — the node must go through get_search_provider()
+    exclusively, never touch httpx (or any vendor SDK) itself."""
+    post = _setup_post(db_session)
+
+    with (
+        patch(SEARCH_PATCH_TARGET) as mock_search,
+        patch(EMBED_PATCH_TARGET) as mock_embed,
+        patch("httpx.post") as mock_httpx_post,
+    ):
+        mock_search.return_value.search.return_value = []
+        mock_embed.return_value.embed.return_value = _fake_embed("query")
+
+        _run_node(db_session, post)
+
+    mock_httpx_post.assert_not_called()
+
+
+def test_research_node_degrades_gracefully_on_search_provider_failure(db_session) -> None:
+    post = _setup_post(db_session)
+
+    with patch(SEARCH_PATCH_TARGET) as mock_search, patch(EMBED_PATCH_TARGET) as mock_embed:
+        mock_search.return_value.search.side_effect = Exception("Tavily timed out")
+        mock_embed.return_value.embed.return_value = _fake_embed("query")
+
+        result = _run_node(db_session, post)
+
+    brief = result["research_brief"]
+    assert brief["industry_trends"] == []
+    assert all(results == [] for results in brief["platform_trends"].values())
+    assert brief["timing_signal"]["trending_topics"] == []
+
+
+# --- timing/trend signal ------------------------------------------------
+
+
+def test_research_brief_includes_timing_trend_signal(db_session) -> None:
+    brand = _setup_brand(db_session, industry="Outdoor gear")
+    post = _setup_post(db_session, brand=brand)
+
+    trend_results = [
+        SearchResult(
+            title="Trending: sustainable camping gear",
+            url="https://x.test/a",
+            content="...",
+        )
+    ]
+
+    with patch(SEARCH_PATCH_TARGET) as mock_search, patch(EMBED_PATCH_TARGET) as mock_embed:
+        mock_search.return_value.search.return_value = trend_results
+        mock_embed.return_value.embed.return_value = _fake_embed("query")
+
+        result = _run_node(db_session, post)
+
+    brief = result["research_brief"]
+    assert "timing_signal" in brief
+    signal = brief["timing_signal"]
+    assert set(signal.keys()) == {"researched_at", "platforms", "trending_topics", "target_datetime"}
+    assert signal["platforms"] == ["linkedin", "x"]  # SUPPORTED_PLATFORMS fallback
+    assert "Trending: sustainable camping gear" in signal["trending_topics"]
+    assert signal["target_datetime"] is None
+    # researched_at is a real, parseable ISO-8601 timestamp, not a placeholder.
+    datetime.fromisoformat(signal["researched_at"])
+
+
+def test_timing_signal_uses_calendar_event_platforms_and_target_datetime(db_session) -> None:
+    brand = _setup_brand(db_session)
+    target_dt = datetime(2026, 9, 1, 14, 0, tzinfo=timezone.utc)
+    event = ContentCalendarEvent(
+        brand_id=brand.id,
+        title="Launch post",
+        target_platforms=["linkedin"],
+        desired_format="image",
+        target_datetime=target_dt,
+    )
+    db_session.add(event)
+    db_session.flush()
+    post = _setup_post(db_session, brand=brand, calendar_event=event)
+
+    with patch(SEARCH_PATCH_TARGET) as mock_search, patch(EMBED_PATCH_TARGET) as mock_embed:
+        mock_search.return_value.search.return_value = []
+        mock_embed.return_value.embed.return_value = _fake_embed("query")
+
+        result = _run_node(db_session, post)
+
+    signal = result["research_brief"]["timing_signal"]
+    assert signal["platforms"] == ["linkedin"]
+    assert signal["target_datetime"] == target_dt.isoformat()
+    # platform_trends is keyed by the scheduled platform only, not every
+    # supported platform generically.
+    assert set(result["research_brief"]["platform_trends"].keys()) == {"linkedin"}
+
+
+# --- brand context via #16's retrieval helper (reused, not reinvented) -----
+
+
+def test_research_brief_reuses_brand_context_retrieval_helper(db_session) -> None:
+    brand = _setup_brand(db_session)
+    brand.brand_report = {"audience": "Eco-conscious millennials"}
+    db_session.flush()
+
+    with patch("packages.agents.onboarding.embedding.get_embedding_provider") as mock_embed_onboard:
+        mock_embed_onboard.return_value.embed.side_effect = _fake_embed
+        embed_brand_report(db_session, brand)
+
+    post = _setup_post(db_session, brand=brand)
+
+    with patch(SEARCH_PATCH_TARGET) as mock_search, patch(EMBED_PATCH_TARGET) as mock_embed:
+        mock_search.return_value.search.return_value = []
+        mock_embed.return_value.embed.side_effect = _fake_embed
+
+        result = _run_node(db_session, post)
+
+    assert result["research_brief"]["brand_context"] == [
+        {"section": "audience", "content": "Eco-conscious millennials"}
+    ]
+
+
+def test_research_node_degrades_gracefully_on_brand_context_retrieval_failure(db_session) -> None:
+    """A broken embedding provider (e.g. no API key configured) must not
+    take the whole node down — mirrors the search-provider degrade path."""
+    post = _setup_post(db_session)
+
+    with patch(SEARCH_PATCH_TARGET) as mock_search, patch(EMBED_PATCH_TARGET) as mock_embed:
+        mock_search.return_value.search.return_value = []
+        mock_embed.return_value.embed.side_effect = Exception("embeddings API unreachable")
+
+        result = _run_node(db_session, post)
+
+    assert result["research_brief"]["brand_context"] == []
+
+
+def test_research_brief_brand_context_empty_when_no_brand_report(db_session) -> None:
+    post = _setup_post(db_session)  # brand has no brand_report / no chunks
+
+    with patch(SEARCH_PATCH_TARGET) as mock_search, patch(EMBED_PATCH_TARGET) as mock_embed:
+        mock_search.return_value.search.return_value = []
+        mock_embed.return_value.embed.return_value = _fake_embed("query")
+
+        result = _run_node(db_session, post)
+
+    assert result["research_brief"]["brand_context"] == []
+
+
+# --- error handling -----------------------------------------------------
+
+
+def test_build_research_node_requires_a_db_session_to_actually_run() -> None:
+    node = build_research_node(None)
+    with pytest.raises(RuntimeError):
+        node({"post_id": "irrelevant", "completed_stages": []})
+
+
+def test_research_node_raises_when_post_not_found(db_session) -> None:
+    node = build_research_node(db_session)
+    with pytest.raises(ResearchEngineError):
+        node({"post_id": str(uuid.uuid4()), "completed_stages": []})
+
+
+# --- completed_stages bookkeeping (same shape as the other node stubs) -----
+
+
+def test_research_node_appends_to_completed_stages(db_session) -> None:
+    post = _setup_post(db_session)
+
+    with patch(SEARCH_PATCH_TARGET) as mock_search, patch(EMBED_PATCH_TARGET) as mock_embed:
+        mock_search.return_value.search.return_value = []
+        mock_embed.return_value.embed.return_value = _fake_embed("query")
+
+        node = build_research_node(db_session)
+        result = node({"post_id": str(post.id), "completed_stages": ["upstream_stage"]})
+
+    assert result["completed_stages"] == ["upstream_stage", "research"]
+
+
+# --- AgentRun logged with agent_type=research, via the real pipeline -------
+
+
+def test_pipeline_logs_agent_run_with_agent_type_research(db_session, thread_cleanup) -> None:
+    post = _setup_post(db_session)
+    thread_cleanup.append(str(post.id))
+
+    trend_results = [SearchResult(title="AI content trends 2026", url="https://x.test/a", content="...")]
+
+    with patch(SEARCH_PATCH_TARGET) as mock_search, patch(EMBED_PATCH_TARGET) as mock_embed:
+        mock_search.return_value.search.return_value = trend_results
+        mock_embed.return_value.embed.return_value = _fake_embed("query")
+
+        with get_postgres_checkpointer() as checkpointer:
+            list(run_pipeline(db_session, post, checkpointer))
+
+    run = (
+        db_session.query(AgentRun)
+        .filter(AgentRun.post_id == post.id, AgentRun.agent_type == AgentType.RESEARCH)
+        .order_by(AgentRun.created_at.desc())
+        .first()
+    )
+    assert run is not None
+    assert run.output is not None
+
+    brief = run.output["research_brief"]
+    assert brief["post_id"] == str(post.id)
+    assert "timing_signal" in brief
+    assert brief["timing_signal"]["trending_topics"] == ["AI content trends 2026"]


### PR DESCRIPTION
## Summary
- Replaces the `research` stub in the #18 per-post pipeline graph (`packages/agents/pipeline/graph.py`) with a real implementation: `packages/agents/pipeline/nodes/research_engine.py`.
- Calls `SearchProvider` (#7, `packages.integrations.registry.get_search_provider()`) exclusively through its interface for platform + industry trend research — never a direct Tavily/HTTP call.
- Reuses #16's pgvector retrieval helper (`apps.api.services.brand_retrieval.get_relevant_brand_context`) for brand voice/audience/positioning context, rather than re-querying `Brand.brand_report`'s raw JSONB.
- Output is a structured research brief (`post_id`, `brand_context`, `platform_trends`, `industry_trends`, `timing_signal`) for #20 (Creative Engine) to consume.
- `timing_signal` (researched_at, platforms, trending_topics, target_datetime) is the field #28 (auto-scheduling) will eventually read — not full scheduling logic, just the shape it needs.
- Both external calls (search, embeddings) degrade gracefully on failure — a broken provider logs a warning and returns an empty result instead of taking the whole node/pipeline down, matching the existing onboarding research step's contract.

## Why
Step 1 of the per-post pipeline: platform + industry trend research grounded in the brand's actual context, not generic prompting.

## Implementation notes
- `build_pipeline_graph()` gains an optional `db: Session | None = None` parameter (threaded through from `run_pipeline()`), since research is the first stage needing a DB session (to resolve `Post -> Brand`, and optionally `Post -> ContentCalendarEvent` for platform/target_datetime context). Callers that only inspect the compiled graph's structure can still call it with just a checkpointer, as before.
- The other 7 stub nodes and the graph's overall wiring/interrupt logic (human review, checkpointing) are untouched.
- `PipelineState` gains a `research_brief` field — required because LangGraph silently drops any state key not declared in the schema.

## Test plan
```bash
pytest packages/agents/tests/test_research_engine.py -v
pytest apps/api/tests packages/agents/tests -v --cov=apps/api --cov=packages --cov-fail-under=70
```
- 17/17 tests pass in `test_research_engine.py` + `test_pipeline_graph.py` (the pre-existing #18 pipeline tests still pass unmodified, now exercising the real research node via graceful degradation since no Tavily/OpenAI keys are configured in CI).
- Full suite: 139 passed, coverage 98.53% (threshold 70%).
- 1 pre-existing, unrelated failure confirmed present on the base branch before this change: `apps/api/tests/test_social_accounts.py::test_connect_503_when_linkedin_not_configured` (LinkedIn OAuth settings-caching issue, nothing to do with this PR).

Closes #19