### PR TITLE
feat(agents): add Generation Engine pipeline node

### DIFF
--- a/apps/api/models/__init__.py
+++ b/apps/api/models/__init__.py
@@ -11,6 +11,7 @@ from apps.api.models.onboarding_research import OnboardingResearch
 from apps.api.models.onboarding_response import OnboardingResponse
 from apps.api.models.organization import Organization
 from apps.api.models.post import PipelineStage, Post
+from apps.api.models.post_version import PostVersion
 from apps.api.models.social_account import SocialAccount, SocialAccountStatus, SocialPlatform
 from apps.api.models.user import User, UserRole
 
@@ -28,6 +29,7 @@ __all__ = [
     "Organization",
     "PipelineStage",
     "Post",
+    "PostVersion",
     "SocialAccount",
     "SocialAccountStatus",
     "SocialPlatform",

--- a/apps/api/models/post.py
+++ b/apps/api/models/post.py
@@ -3,7 +3,7 @@ import uuid
 from datetime import datetime
 
 from sqlalchemy import DateTime, Enum, ForeignKey, func
-from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import Mapped, mapped_column
 
 from apps.api.config.database import Base
@@ -46,6 +46,16 @@ class Post(Base):
         nullable=False,
         default=PipelineStage.RESEARCH,
     )
+
+    # Written by the Generation Engine (Issue #21) — a dict keyed by
+    # platform (e.g. {"linkedin": "...", "x": "..."}), matching
+    # creative_brief's per-platform shape, since a single Post carries
+    # copy for every platform its creative_brief targeted rather than
+    # just one. Always holds the *latest* generation; every version
+    # (including this one) is also appended to PostVersion
+    # (apps/api/models/post_version.py) so nothing is ever lost when a
+    # post is regenerated.
+    body_text: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
 
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now()

--- a/apps/api/models/post_version.py
+++ b/apps/api/models/post_version.py
@@ -1,0 +1,38 @@
+import uuid
+from datetime import datetime
+
+from sqlalchemy import DateTime, Float, ForeignKey, Integer, func
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from apps.api.config.database import Base
+
+
+class PostVersion(Base):
+    """Immutable version-history log for Post.body_text — one row appended
+    per Generation Engine (Issue #21) run, same "append a log row, never
+    overwrite" convention AgentRun already establishes (see
+    apps/api/models/agent_run.py). Post.body_text always holds the most
+    recent generation's output; this table preserves every earlier one, so
+    regenerating a post's copy never loses what came before it."""
+
+    __tablename__ = "post_versions"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    post_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("posts.id"), nullable=False
+    )
+    # Same shape as Post.body_text at the time this version was written —
+    # a dict keyed by platform, not just a single string, since one Post
+    # carries copy for every platform its creative_brief targeted.
+    body_text: Mapped[dict] = mapped_column(JSONB, nullable=False)
+
+    model: Mapped[str | None] = mapped_column(nullable=True)
+    tokens: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    cost: Mapped[float | None] = mapped_column(Float, nullable=True)
+
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )

--- a/migrations/versions/ec24a3325404_post_body_text_and_post_versions.py
+++ b/migrations/versions/ec24a3325404_post_body_text_and_post_versions.py
@@ -1,0 +1,56 @@
+"""post body_text and post_versions
+
+Revision ID: ec24a3325404
+Revises: 75d69ba778a0
+Create Date: 2026-08-24 21:49:15.347638
+
+Issue #21 (Generation Engine) needs somewhere to write its generated copy,
+with version history preserved across regenerations. Adds:
+
+  * posts.body_text — a nullable JSONB column holding the *latest*
+    generation's copy, keyed by platform (e.g. {"linkedin": "...", "x":
+    "..."}), matching creative_brief's per-platform shape.
+  * post_versions — an append-only log table, one row per Generation
+    Engine run, mirroring agent_runs' "append a log row, never overwrite"
+    convention (see migrations/versions/002_agent_runs.py) so an earlier
+    generation is never lost when a post is regenerated.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'ec24a3325404'
+down_revision: Union[str, None] = '75d69ba778a0'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        'posts',
+        sa.Column('body_text', postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+    )
+
+    op.create_table(
+        'post_versions',
+        sa.Column('id', sa.UUID(), nullable=False),
+        sa.Column('post_id', sa.UUID(), nullable=False),
+        sa.Column('body_text', postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column('model', sa.String(), nullable=True),
+        sa.Column('tokens', sa.Integer(), nullable=True),
+        sa.Column('cost', sa.Float(), nullable=True),
+        sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.text('now()'), nullable=False),
+        sa.ForeignKeyConstraint(['post_id'], ['posts.id']),
+        sa.PrimaryKeyConstraint('id'),
+    )
+    op.create_index('post_versions_post_id_idx', 'post_versions', ['post_id'])
+
+
+def downgrade() -> None:
+    op.drop_index('post_versions_post_id_idx', table_name='post_versions')
+    op.drop_table('post_versions')
+    op.drop_column('posts', 'body_text')

--- a/packages/agents/pipeline/graph.py
+++ b/packages/agents/pipeline/graph.py
@@ -11,7 +11,9 @@ all stages wired in order, and the durability guarantee that makes the
 human review step safe to build — a paused run's state lives in Postgres
 (see checkpointer.py), not in process memory, so it survives a server
 restart. #19 is the first of those real-logic swaps: "research" now runs
-packages/agents/pipeline/nodes/research_engine.py instead of a stub.
+packages/agents/pipeline/nodes/research_engine.py instead of a stub. #20
+and #21 followed the same pattern for "creative"
+(nodes/creative_engine.py) and "generation" (nodes/generation_engine.py).
 
 The Human Review stage is a genuine LangGraph interrupt (`interrupt()`),
 not a status flag polled by a cron job: calling it suspends the graph
@@ -38,6 +40,7 @@ from sqlalchemy.orm import Session
 from apps.api.models.agent_run import AgentRun, AgentType
 from apps.api.models.post import PipelineStage, Post
 from packages.agents.pipeline.nodes.creative_engine import build_creative_node
+from packages.agents.pipeline.nodes.generation_engine import build_generation_node
 from packages.agents.pipeline.nodes.research_engine import build_research_node
 
 # Pipeline order — the single source of truth for both graph wiring and the
@@ -91,6 +94,13 @@ class PipelineState(TypedDict):
     # (format/angle/hook/CTA per target platform) #21 (Generation Engine)
     # consumes to actually write copy.
     creative_brief: dict[str, Any] | None
+    # Populated by the generation node (#21) — the generated copy per
+    # platform (written onto Post.body_text), plus model/tokens/cost/
+    # latency_ms metadata that run_pipeline below reads onto this stage's
+    # AgentRun row. LangGraph drops any state key not declared here (see
+    # research_brief's comment above), so this must be listed even though
+    # it's only ever set by this one stage.
+    generation_output: dict[str, Any] | None
 
 
 def _stub_result(stage: str, state: PipelineState, **extra: Any) -> dict:
@@ -134,13 +144,14 @@ def build_pipeline_graph(checkpointer, db: Session | None = None) -> CompiledSta
     graph object could serve every run; callers select a run via the
     per-invocation `thread_id` in the LangGraph config.
 
-    `db` is the one exception: the "research" (#19) and "creative" (#20)
-    stages are the first nodes with real logic that need a database
-    session (to resolve Post -> Brand), so it's threaded through here to
-    those nodes' factories. It's optional and defaults to None so callers
-    that only want to inspect the compiled graph's structure — never
-    stream/invoke it — can keep calling this with just a checkpointer,
-    same as before #19."""
+    `db` is the one exception: the "research" (#19), "creative" (#20), and
+    "generation" (#21) stages are the first nodes with real logic that
+    need a database session (to resolve Post -> Brand, and, for
+    generation, to write Post.body_text/PostVersion), so it's threaded
+    through here to those nodes' factories. It's optional and defaults to
+    None so callers that only want to inspect the compiled graph's
+    structure — never stream/invoke it — can keep calling this with just a
+    checkpointer, same as before #19."""
     graph = StateGraph(PipelineState)
 
     for stage in PIPELINE_STAGES:
@@ -150,6 +161,8 @@ def build_pipeline_graph(checkpointer, db: Session | None = None) -> CompiledSta
             node = build_research_node(db)
         elif stage == "creative":
             node = build_creative_node(db)
+        elif stage == "generation":
+            node = build_generation_node(db)
         else:
             node = _make_stub_node(stage)
         graph.add_node(stage, node)
@@ -207,12 +220,33 @@ def run_pipeline(
 
             stage = STAGE_TO_PIPELINE_STAGE[node_name]
             post.current_pipeline_stage = stage
+
+            # Every stage gets exactly one AgentRun row here, from
+            # whatever dict the node returned — this is the single
+            # AgentRun-logging path for the whole pipeline (see
+            # test_pipeline_graph.py's exact per-stage row-count
+            # assertions). Most stages' output dicts carry no model/
+            # tokens/cost info, so those columns stay None for them, same
+            # as before #21. The generation node (#21) is the first to
+            # populate them — via a "generation_output" entry with
+            # model/tokens/cost/latency_ms keys — because it's the first
+            # stage whose LLM usage this repo tracks a cost for.
+            run_metadata: dict[str, Any] = {}
+            if isinstance(node_output, dict):
+                candidate = node_output.get("generation_output")
+                if isinstance(candidate, dict):
+                    run_metadata = candidate
+
             db.add(
                 AgentRun(
                     post_id=post.id,
                     agent_type=STAGE_TO_AGENT_TYPE[node_name],
                     input={"post_id": str(post.id)},
                     output=node_output if isinstance(node_output, dict) else None,
+                    model=run_metadata.get("model"),
+                    tokens=run_metadata.get("tokens"),
+                    cost=run_metadata.get("cost"),
+                    latency_ms=run_metadata.get("latency_ms"),
                 )
             )
             db.flush()

--- a/packages/agents/pipeline/nodes/generation_engine.py
+++ b/packages/agents/pipeline/nodes/generation_engine.py
@@ -1,0 +1,306 @@
+"""Generation Engine — Issue #21, the third real (non-stub) stage in the
+per-post pipeline graph (packages/agents/pipeline/graph.py), running right
+after Creative (#20).
+
+Turns the Creative Engine's brief (see
+packages/agents/pipeline/nodes/creative_engine.py —
+{"post_id", "platforms": {"<platform>": {"format", "angle", "hook", "cta",
+"tone"}}}) into actual, publish-ready copy: not more strategy, the words
+themselves. This is the first pipeline node built directly on top of
+LLMProvider whose output gets *persisted* onto the Post — earlier stages
+(#19/#20) only ever hand a brief to the next stage in memory.
+
+Same interface-only contract as research_engine.py/creative_engine.py:
+copy generation goes through LLMProvider
+(packages/integrations/registry.get_llm_provider()) exclusively — never a
+direct vendor SDK import — with the model read fresh from
+apps.api.config.get_settings().llm_default_model on every call, never a
+hardcoded model slug. Same degrade-on-failure contract too: a broken/
+unconfigured LLM provider must not take the pipeline down with it, so a
+failed call/parse falls back to simple copy composed from the (already
+LLM-produced) creative brief's hook + CTA rather than raising.
+
+Also defines generate_media_stub(): the image/video-generation hook
+called (unconditionally, whenever a platform's brief calls for it) when a
+platform's `format` is image/video/carousel. Issues #22 (image) and #23
+(video) will replace/extend this stub with real adapters — this issue's
+job is only to guarantee the call site exists and is genuinely reached
+under the right conditions, not to build those adapters.
+
+Output handling — Post.body_text with version history preserved:
+  * Post.body_text (apps/api/models/post.py) is written with this run's
+    generated copy, a dict keyed by platform, matching creative_brief's
+    per-platform shape.
+  * A PostVersion row (apps/api/models/post_version.py) is appended for
+    every generation run — the same "append a log row, never overwrite"
+    convention AgentRun already establishes — so regenerating a post's
+    copy (e.g. after a human-review rejection) never loses the version
+    that came before it.
+
+AgentRun token/cost fields: run_pipeline (graph.py) already logs one
+AgentRun row per completed node generically, from whatever dict the node
+returns — this module doesn't add a second row itself (that would double-
+count against packages/agents/tests/test_pipeline_graph.py's exact
+per-stage row-count assertions). Instead this node's return dict includes
+a "generation_output" entry with "model"/"tokens"/"cost"/"latency_ms"
+keys, and graph.py's run_pipeline reads those (when present) onto the one
+AgentRun row it already writes for this stage.
+
+Mirrors research_engine.py/creative_engine.py's shape: a factory,
+build_generation_node(db), closing over a caller-supplied Session (needed
+to resolve Post -> Post.body_text/PostVersion, same as the earlier
+stages), returning the actual LangGraph node function. graph.py's
+build_pipeline_graph() calls this factory for the "generation" stage
+only.
+"""
+
+import json
+import logging
+import time
+import uuid
+from typing import Any
+
+from sqlalchemy.orm import Session
+
+from apps.api.config import get_settings
+from apps.api.models.post import Post
+from apps.api.models.post_version import PostVersion
+from packages.integrations.registry import get_llm_provider
+
+logger = logging.getLogger(__name__)
+
+# A platform's creative-brief `format` is free text (e.g. "text_post",
+# "carousel", "short_video") rather than a closed enum, so this matches by
+# substring rather than exact value — "short_video" and "carousel_post"
+# both still need the media hook.
+MEDIA_FORMAT_KEYWORDS = ("image", "video", "carousel")
+
+# Rough, provider-agnostic per-token estimate used only to keep
+# AgentRun.cost/PostVersion.cost populated (per #21's acceptance criteria)
+# until a real pricing/billing feed exists — not tied to any specific
+# model's actual price.
+_COST_PER_1K_TOKENS = 0.002
+
+
+class GenerationEngineError(Exception):
+    """Raised when the generation node can't resolve the Post it was asked
+    to generate copy for — a programming/data error (missing row), not a
+    transient LLM-provider failure, so unlike LLM failures this is not
+    swallowed."""
+
+
+def _default_model() -> str:
+    """Reads LLM_DEFAULT_MODEL fresh on every call (not a module constant)
+    so tests and per-environment overrides take effect without a reimport
+    — same convention as research_engine.py/creative_engine.py."""
+    return get_settings().llm_default_model
+
+
+def _estimate_cost(tokens: int) -> float:
+    return round((tokens / 1000) * _COST_PER_1K_TOKENS, 6)
+
+
+def _requires_media(platform_brief: dict[str, Any]) -> bool:
+    fmt = str(platform_brief.get("format", "")).lower()
+    return any(keyword in fmt for keyword in MEDIA_FORMAT_KEYWORDS)
+
+
+def generate_media_stub(post_id: str, platform: str, platform_brief: dict[str, Any]) -> dict[str, Any]:
+    """Placeholder image/video-generation hook. Deliberately a plain
+    function (not yet an interface like LLMProvider/SearchProvider) since
+    #22 (image) and #23 (video) haven't defined that interface yet — this
+    issue's job is only to guarantee the *call site* exists in the
+    pipeline, genuinely reached when a platform's format calls for it, for
+    #22/#23 to plug into (replace/extend) rather than having to invent the
+    wiring themselves."""
+    logger.info(
+        "Generation Engine: media hook stub called for post=%s platform=%s format=%r",
+        post_id,
+        platform,
+        platform_brief.get("format"),
+    )
+    return {
+        "status": "stubbed",
+        "platform": platform,
+        "format": platform_brief.get("format"),
+    }
+
+
+def _strip_code_fence(text: str) -> str:
+    cleaned = text.strip()
+    if not cleaned.startswith("```"):
+        return cleaned
+    cleaned = cleaned.strip("`")
+    if cleaned.startswith("json"):
+        cleaned = cleaned[len("json"):]
+    return cleaned.strip()
+
+
+def _parse_platform_copy(text: str, platforms: list[str]) -> dict[str, str]:
+    parsed = json.loads(_strip_code_fence(text))
+    if not isinstance(parsed, dict):
+        raise ValueError("Generation Engine LLM output was valid JSON but not an object")
+
+    result: dict[str, str] = {}
+    for platform in platforms:
+        value = parsed.get(platform)
+        if not isinstance(value, str) or not value.strip():
+            raise ValueError(f"Generation Engine LLM output missing copy for platform {platform!r}")
+        result[platform] = value
+    return result
+
+
+def _fallback_copy_for(platform_brief: dict[str, Any], platform: str) -> str:
+    """Used only when the LLM call/parse fails (see module docstring) —
+    composed straight from the creative brief's hook + CTA so the fallback
+    is still usable copy rather than a blank/placeholder string."""
+    hook = str(platform_brief.get("hook") or "").strip()
+    cta = str(platform_brief.get("cta") or "").strip()
+    parts = [part for part in (hook, cta) if part]
+    if parts:
+        return "\n\n".join(parts)
+    return f"[Generation Engine fallback] Unable to generate copy for {platform}."
+
+
+def _build_prompt(platform_briefs: dict[str, dict[str, str]], platforms: list[str]) -> str:
+    briefs_json = json.dumps({platform: platform_briefs.get(platform, {}) for platform in platforms})
+    return f"""You are a senior social media copywriter turning an
+already-approved creative brief into the final, publish-ready post copy —
+the actual words that will be posted, not more strategy. Respond with
+strict JSON only — no markdown, no commentary, no code fences.
+
+## Creative briefs per platform
+{briefs_json}
+
+## Task
+For EACH of these target platforms — {", ".join(platforms)} — write the
+final post copy that follows that platform's brief (format, angle, hook,
+cta, tone) exactly: open with (or clearly incorporate) that platform's
+hook, end with (or clearly incorporate) its CTA, and match its tone. Each
+platform's copy must be genuinely distinct — reflecting that platform's
+own brief — not the same text reused across platforms.
+
+Respond with a single JSON object whose keys are exactly the platform
+names listed above, and whose values are the final copy text (a plain
+string) for that platform.
+
+Respond with ONLY the JSON object. No markdown code fences, no extra text.
+"""
+
+
+def _generate_copy(
+    platform_briefs: dict[str, dict[str, str]], platforms: list[str]
+) -> tuple[dict[str, str], str, int]:
+    """Calls LLMProvider exclusively through its interface (never a direct
+    vendor SDK import) — same degrade-on-failure contract as
+    research_engine.py/creative_engine.py: a broken/unconfigured LLM
+    provider, or a response that doesn't parse into usable copy, must
+    never take the pipeline down with it, just fall back to simple copy
+    composed from the creative brief."""
+    model = _default_model()
+    prompt = _build_prompt(platform_briefs, platforms)
+    try:
+        response = get_llm_provider().complete(prompt=prompt, model=model, temperature=0.7)
+        copy_by_platform = _parse_platform_copy(response.text, platforms)
+        return copy_by_platform, response.model, response.input_tokens + response.output_tokens
+    except Exception:
+        logger.warning("Generation Engine LLM call/parse failed; using fallback copy", exc_info=True)
+        fallback = {
+            platform: _fallback_copy_for(platform_briefs.get(platform, {}), platform)
+            for platform in platforms
+        }
+        return fallback, model, 0
+
+
+def _platforms_for(creative_brief: dict[str, Any]) -> tuple[list[str], dict[str, dict[str, str]]]:
+    platform_briefs = creative_brief.get("platforms") or {}
+    if not platform_briefs:
+        # No upstream creative_brief (e.g. node invoked directly in a
+        # test) — fall back to a single generic platform so this node is
+        # still exercisable without a full creative_brief.
+        return ["default"], {"default": {}}
+    return list(platform_briefs.keys()), platform_briefs
+
+
+def _generation_output(db: Session, post: Post, creative_brief: dict[str, Any]) -> dict[str, Any]:
+    platforms, platform_briefs = _platforms_for(creative_brief)
+
+    start = time.perf_counter()
+    copy_by_platform, model, tokens = _generate_copy(platform_briefs, platforms)
+    latency_ms = (time.perf_counter() - start) * 1000
+
+    platform_results: dict[str, Any] = {}
+    for platform in platforms:
+        platform_brief = platform_briefs.get(platform, {})
+        media_result = None
+        if _requires_media(platform_brief):
+            media_result = generate_media_stub(str(post.id), platform, platform_brief)
+        platform_results[platform] = {
+            "body_text": copy_by_platform[platform],
+            "media": media_result,
+        }
+
+    body_text = {platform: result["body_text"] for platform, result in platform_results.items()}
+    cost = _estimate_cost(tokens)
+
+    # Write the generated copy onto the Post itself, and append an
+    # immutable version-history row (see module docstring) so a second
+    # generation call never clobbers/loses the first version.
+    post.body_text = body_text
+    db.add(
+        PostVersion(
+            post_id=post.id,
+            body_text=body_text,
+            model=model,
+            tokens=tokens,
+            cost=cost,
+        )
+    )
+    db.flush()
+    db.refresh(post)
+
+    return {
+        "post_id": str(post.id),
+        "platforms": platform_results,
+        "model": model,
+        "tokens": tokens,
+        "cost": cost,
+        "latency_ms": latency_ms,
+    }
+
+
+def build_generation_node(db: Session | None):
+    """Builds the real "generation" stage node function, closing over
+    `db`. Mirrors research_engine.py/creative_engine.py's factory shape
+    exactly.
+
+    `db` is accepted as possibly None so build_pipeline_graph(checkpointer)
+    — with no `db` argument — still works for callers that only inspect
+    the compiled graph's structure (nodes/edges) without ever streaming or
+    invoking it; the resulting node just isn't runnable, and raises
+    clearly if it ever is.
+    """
+
+    def _node(state: dict) -> dict:
+        if db is None:
+            raise RuntimeError(
+                "Generation Engine node has no database session — "
+                "build_pipeline_graph() must be called with db=<Session> "
+                "to execute (not just inspect) the pipeline graph."
+            )
+
+        post = db.get(Post, uuid.UUID(state["post_id"]))
+        if post is None:
+            raise GenerationEngineError(
+                f"Generation Engine: no Post found for post_id={state['post_id']!r}"
+            )
+
+        creative_brief = state.get("creative_brief") or {}
+        output = _generation_output(db, post, creative_brief)
+        return {
+            "completed_stages": [*state.get("completed_stages", []), "generation"],
+            "generation_output": output,
+        }
+
+    _node.__name__ = "generation_node"
+    return _node

--- a/packages/agents/tests/test_generation_engine.py
+++ b/packages/agents/tests/test_generation_engine.py
@@ -1,0 +1,394 @@
+"""Tests for the Issue #21 Generation Engine node.
+
+Per the issue's acceptance criteria:
+  1. Copy generation uses LLMProvider exclusively — no direct OpenAI/
+     OpenRouter SDK/httpx calls.
+  2. Output is written to Post.body_text, with version history preserved
+     (a second generation call must not overwrite/lose the first
+     version — PostVersion keeps both).
+  3. The image/video generation hook is actually invoked (even though
+     it's a stub) when a platform's brief calls for image/video/carousel,
+     and NOT invoked for a plain text format.
+  4. An AgentRun row is logged with agent_type=generation, including
+     token/cost fields.
+
+Mirrors test_creative_engine.py's structure: most cases exercised
+directly against build_generation_node() (fast, no checkpointer needed),
+with LLMProvider mocked through
+packages.agents.pipeline.nodes.generation_engine.get_llm_provider — never
+a direct vendor SDK call. The AgentRun-logging criterion is exercised
+through the real pipeline (run_pipeline + a Postgres-backed
+checkpointer), since that's the code that actually writes AgentRun rows.
+"""
+
+import json
+import uuid
+from unittest.mock import patch
+
+import pytest
+
+from apps.api.models import (
+    AgentRun,
+    AgentType,
+    Brand,
+    ContentCalendarEvent,
+    Organization,
+    Post,
+    PostVersion,
+)
+from packages.agents.pipeline.checkpointer import get_postgres_checkpointer
+from packages.agents.pipeline.graph import run_pipeline
+from packages.agents.pipeline.nodes.generation_engine import (
+    GenerationEngineError,
+    build_generation_node,
+)
+from packages.integrations.llm.base import LLMResponse
+
+LLM_PATCH_TARGET = "packages.agents.pipeline.nodes.generation_engine.get_llm_provider"
+MEDIA_PATCH_TARGET = "packages.agents.pipeline.nodes.generation_engine.generate_media_stub"
+SEARCH_PATCH_TARGET = "packages.agents.pipeline.nodes.research_engine.get_search_provider"
+EMBED_PATCH_TARGET = "apps.api.services.brand_retrieval.get_embedding_provider"
+CREATIVE_LLM_PATCH_TARGET = "packages.agents.pipeline.nodes.creative_engine.get_llm_provider"
+
+
+def _setup_brand(db_session) -> Brand:
+    org = Organization(name="Acme Agency")
+    db_session.add(org)
+    db_session.flush()
+
+    brand = Brand(organization_id=org.id, name="Acme Widgets", industry="Outdoor gear")
+    db_session.add(brand)
+    db_session.flush()
+    return brand
+
+
+def _setup_post(
+    db_session, brand: Brand | None = None, calendar_event: ContentCalendarEvent | None = None
+) -> Post:
+    if brand is None:
+        brand = _setup_brand(db_session)
+    post = Post(
+        brand_id=brand.id,
+        calendar_event_id=calendar_event.id if calendar_event else None,
+    )
+    db_session.add(post)
+    db_session.flush()
+    return post
+
+
+def _llm_response(payload: dict) -> LLMResponse:
+    return LLMResponse(
+        text=json.dumps(payload),
+        model="openrouter/free",
+        input_tokens=120,
+        output_tokens=80,
+    )
+
+
+def _creative_brief(*, linkedin_format: str = "text_post", x_format: str = "short_thread") -> dict:
+    return {
+        "platforms": {
+            "linkedin": {
+                "format": linkedin_format,
+                "angle": "thought_leadership",
+                "hook": "Most brands get sustainability messaging backwards.",
+                "cta": "What's your take? Share below.",
+                "tone": "professional, authoritative",
+            },
+            "x": {
+                "format": x_format,
+                "angle": "hot_take",
+                "hook": "unpopular opinion: your camping gear is overengineered",
+                "cta": "reply if you agree (or don't)",
+                "tone": "casual, punchy",
+            },
+        }
+    }
+
+
+def _copy_payload() -> dict:
+    return {
+        "linkedin": "Most brands get sustainability messaging backwards. Here's why...\n\nWhat's your take? Share below.",
+        "x": "unpopular opinion: your camping gear is overengineered\n\nreply if you agree (or don't)",
+    }
+
+
+def _run_node(db_session, post: Post, creative_brief: dict | None = None) -> dict:
+    node = build_generation_node(db_session)
+    return node(
+        {
+            "post_id": str(post.id),
+            "completed_stages": [],
+            "creative_brief": creative_brief if creative_brief is not None else {},
+        }
+    )
+
+
+@pytest.fixture()
+def thread_cleanup():
+    """Same teardown as test_pipeline_graph.py's fixture — pipeline
+    checkpoint rows live in Postgres on a connection separate from
+    db_session's rolled-back transaction, so they need explicit cleanup."""
+    thread_ids: list[str] = []
+    yield thread_ids
+    if not thread_ids:
+        return
+    with get_postgres_checkpointer() as checkpointer:
+        for thread_id in thread_ids:
+            checkpointer.delete_thread(thread_id)
+
+
+# --- LLMProvider used exclusively, never a direct SDK/httpx call -----------
+
+
+def test_generation_engine_calls_llm_provider_only_through_interface(db_session) -> None:
+    post = _setup_post(db_session)
+
+    with patch(LLM_PATCH_TARGET) as mock_llm, patch("httpx.post") as mock_httpx_post:
+        mock_llm.return_value.complete.return_value = _llm_response(_copy_payload())
+        _run_node(db_session, post, _creative_brief())
+
+    mock_llm.return_value.complete.assert_called_once()
+    mock_httpx_post.assert_not_called()
+
+
+def test_generation_engine_reads_model_from_settings_not_hardcoded(db_session) -> None:
+    post = _setup_post(db_session)
+
+    with (
+        patch(LLM_PATCH_TARGET) as mock_llm,
+        patch(
+            "packages.agents.pipeline.nodes.generation_engine.get_settings"
+        ) as mock_settings,
+    ):
+        mock_settings.return_value.llm_default_model = "some/custom-model"
+        mock_llm.return_value.complete.return_value = _llm_response(_copy_payload())
+        _run_node(db_session, post, _creative_brief())
+
+    _, kwargs = mock_llm.return_value.complete.call_args
+    assert kwargs["model"] == "some/custom-model"
+
+
+# --- Post.body_text written, version history preserved ---------------------
+
+
+def test_generation_writes_post_body_text(db_session) -> None:
+    post = _setup_post(db_session)
+
+    with patch(LLM_PATCH_TARGET) as mock_llm:
+        mock_llm.return_value.complete.return_value = _llm_response(_copy_payload())
+        result = _run_node(db_session, post, _creative_brief())
+
+    db_session.refresh(post)
+    assert post.body_text == _copy_payload()
+    assert result["generation_output"]["platforms"]["linkedin"]["body_text"] == _copy_payload()["linkedin"]
+    assert result["generation_output"]["platforms"]["x"]["body_text"] == _copy_payload()["x"]
+
+
+def test_generation_creates_a_post_version_row(db_session) -> None:
+    post = _setup_post(db_session)
+
+    with patch(LLM_PATCH_TARGET) as mock_llm:
+        mock_llm.return_value.complete.return_value = _llm_response(_copy_payload())
+        _run_node(db_session, post, _creative_brief())
+
+    versions = db_session.query(PostVersion).filter(PostVersion.post_id == post.id).all()
+    assert len(versions) == 1
+    assert versions[0].body_text == _copy_payload()
+    assert versions[0].model == "openrouter/free"
+    assert versions[0].tokens == 200
+    assert versions[0].cost is not None
+
+
+def test_second_generation_preserves_first_version_instead_of_losing_it(db_session) -> None:
+    post = _setup_post(db_session)
+
+    first_payload = _copy_payload()
+    second_payload = {
+        "linkedin": "A completely different second draft for linkedin.",
+        "x": "A completely different second draft for x.",
+    }
+
+    with patch(LLM_PATCH_TARGET) as mock_llm:
+        mock_llm.return_value.complete.return_value = _llm_response(first_payload)
+        _run_node(db_session, post, _creative_brief())
+
+        mock_llm.return_value.complete.return_value = _llm_response(second_payload)
+        _run_node(db_session, post, _creative_brief())
+
+    db_session.refresh(post)
+    # Post.body_text reflects the latest generation only.
+    assert post.body_text == second_payload
+
+    # But both versions still exist in history, oldest first.
+    versions = (
+        db_session.query(PostVersion)
+        .filter(PostVersion.post_id == post.id)
+        .order_by(PostVersion.created_at.asc())
+        .all()
+    )
+    assert len(versions) == 2
+    assert versions[0].body_text == first_payload
+    assert versions[1].body_text == second_payload
+
+
+# --- image/video generation hook --------------------------------------------
+
+
+def test_media_hook_invoked_for_image_format(db_session) -> None:
+    post = _setup_post(db_session)
+    brief = _creative_brief(linkedin_format="image", x_format="short_thread")
+
+    with patch(LLM_PATCH_TARGET) as mock_llm, patch(MEDIA_PATCH_TARGET) as mock_media:
+        mock_llm.return_value.complete.return_value = _llm_response(_copy_payload())
+        mock_media.return_value = {"status": "stubbed"}
+        result = _run_node(db_session, post, brief)
+
+    mock_media.assert_called_once()
+    args, _ = mock_media.call_args
+    assert args[1] == "linkedin"
+    assert result["generation_output"]["platforms"]["linkedin"]["media"] == {"status": "stubbed"}
+    # x stayed plain text — no media call for it.
+    assert result["generation_output"]["platforms"]["x"]["media"] is None
+
+
+def test_media_hook_invoked_for_video_and_carousel_formats(db_session) -> None:
+    post = _setup_post(db_session)
+    brief = _creative_brief(linkedin_format="short_video", x_format="carousel")
+
+    with patch(LLM_PATCH_TARGET) as mock_llm, patch(MEDIA_PATCH_TARGET) as mock_media:
+        mock_llm.return_value.complete.return_value = _llm_response(_copy_payload())
+        mock_media.return_value = {"status": "stubbed"}
+        _run_node(db_session, post, brief)
+
+    assert mock_media.call_count == 2
+    called_platforms = {call.args[1] for call in mock_media.call_args_list}
+    assert called_platforms == {"linkedin", "x"}
+
+
+def test_media_hook_not_invoked_for_plain_text_formats(db_session) -> None:
+    post = _setup_post(db_session)
+    brief = _creative_brief(linkedin_format="text_post", x_format="short_thread")
+
+    with patch(LLM_PATCH_TARGET) as mock_llm, patch(MEDIA_PATCH_TARGET) as mock_media:
+        mock_llm.return_value.complete.return_value = _llm_response(_copy_payload())
+        result = _run_node(db_session, post, brief)
+
+    mock_media.assert_not_called()
+    assert result["generation_output"]["platforms"]["linkedin"]["media"] is None
+    assert result["generation_output"]["platforms"]["x"]["media"] is None
+
+
+# --- degrade-on-failure ------------------------------------------------
+
+
+def test_generation_falls_back_to_hook_and_cta_on_llm_failure(db_session) -> None:
+    post = _setup_post(db_session)
+    brief = _creative_brief()
+
+    with patch(LLM_PATCH_TARGET) as mock_llm:
+        mock_llm.return_value.complete.side_effect = Exception("LLM provider unreachable")
+        result = _run_node(db_session, post, brief)
+
+    platforms = result["generation_output"]["platforms"]
+    assert "Most brands get sustainability messaging backwards." in platforms["linkedin"]["body_text"]
+    assert "What's your take? Share below." in platforms["linkedin"]["body_text"]
+    db_session.refresh(post)
+    assert post.body_text is not None
+
+
+def test_generation_degrades_gracefully_on_unparseable_llm_output(db_session) -> None:
+    post = _setup_post(db_session)
+    brief = _creative_brief()
+
+    with patch(LLM_PATCH_TARGET) as mock_llm:
+        mock_llm.return_value.complete.return_value = LLMResponse(
+            text="not valid json at all",
+            model="openrouter/free",
+            input_tokens=1,
+            output_tokens=1,
+        )
+        result = _run_node(db_session, post, brief)
+
+    platforms = result["generation_output"]["platforms"]
+    assert set(platforms.keys()) == {"linkedin", "x"}
+
+
+# --- error handling -----------------------------------------------------
+
+
+def test_build_generation_node_requires_a_db_session_to_actually_run() -> None:
+    node = build_generation_node(None)
+    with pytest.raises(RuntimeError):
+        node({"post_id": "irrelevant", "completed_stages": [], "creative_brief": {}})
+
+
+def test_generation_node_raises_when_post_not_found(db_session) -> None:
+    node = build_generation_node(db_session)
+    with pytest.raises(GenerationEngineError):
+        node({"post_id": str(uuid.uuid4()), "completed_stages": [], "creative_brief": {}})
+
+
+# --- completed_stages bookkeeping (same shape as the other node stubs) -----
+
+
+def test_generation_node_appends_to_completed_stages(db_session) -> None:
+    post = _setup_post(db_session)
+
+    with patch(LLM_PATCH_TARGET) as mock_llm:
+        mock_llm.return_value.complete.return_value = _llm_response(_copy_payload())
+        node = build_generation_node(db_session)
+        result = node(
+            {
+                "post_id": str(post.id),
+                "completed_stages": ["research", "creative"],
+                "creative_brief": _creative_brief(),
+            }
+        )
+
+    assert result["completed_stages"] == ["research", "creative", "generation"]
+
+
+# --- AgentRun logged with agent_type=generation, including token/cost ------
+
+
+def test_pipeline_logs_agent_run_with_agent_type_generation_including_token_and_cost(
+    db_session, thread_cleanup
+) -> None:
+    post = _setup_post(db_session)
+    thread_cleanup.append(str(post.id))
+
+    with (
+        patch(SEARCH_PATCH_TARGET) as mock_search,
+        patch(EMBED_PATCH_TARGET) as mock_embed,
+        patch(CREATIVE_LLM_PATCH_TARGET) as mock_creative_llm,
+        patch(LLM_PATCH_TARGET) as mock_generation_llm,
+    ):
+        mock_search.return_value.search.return_value = []
+        mock_embed.return_value.embed.return_value = [0.0] * 1536
+        mock_creative_llm.return_value.complete.return_value = _llm_response(
+            {
+                "linkedin": _creative_brief()["platforms"]["linkedin"],
+                "x": _creative_brief()["platforms"]["x"],
+            }
+        )
+        mock_generation_llm.return_value.complete.return_value = _llm_response(_copy_payload())
+
+        with get_postgres_checkpointer() as checkpointer:
+            list(run_pipeline(db_session, post, checkpointer))
+
+    run = (
+        db_session.query(AgentRun)
+        .filter(AgentRun.post_id == post.id, AgentRun.agent_type == AgentType.GENERATION)
+        .order_by(AgentRun.created_at.desc())
+        .first()
+    )
+    assert run is not None
+    assert run.output is not None
+    assert run.model == "openrouter/free"
+    assert run.tokens == 200
+    assert run.cost is not None
+    assert run.cost > 0
+
+    db_session.refresh(post)
+    assert post.body_text == _copy_payload()


### PR DESCRIPTION
## Summary
- Adds the Generation Engine — the third real (non-stub) stage in the per-post pipeline graph (`packages/agents/pipeline/graph.py`), wired in right after Creative (#20).
- Turns the Creative Engine's `creative_brief` (`{"post_id", "platforms": {"<platform>": {"format","angle","hook","cta","tone"}}}`) into publish-ready copy, calling `LLMProvider` exclusively via `packages.integrations.registry.get_llm_provider()`, with the model read fresh from `apps.api.config.get_settings().llm_default_model` on every call (never hardcoded). Same degrade-on-failure contract as Research/Creative: a broken/unconfigured LLM provider falls back to copy composed from the brief's hook+CTA rather than taking the pipeline down.
- Adds `generate_media_stub()` — the image/video-generation hook, called unconditionally whenever a platform's brief `format` is image/video/carousel — for Issues #22/#23 to replace/extend later.
- Extends the `Post` model with a `body_text` JSONB column (per-platform copy, matching `creative_brief`'s shape) and adds a new `PostVersion` table — one immutable row appended per generation run, same "append a log row, never overwrite" convention `AgentRun` already establishes — so regenerating a post's copy never loses an earlier version. Migration: `migrations/versions/ec24a3325404_post_body_text_and_post_versions.py` (down_revision `75d69ba778a0`, the Issue #18 posts/checkpoints migration).
- `run_pipeline`'s existing per-stage `AgentRun` logging now also reads `model`/`tokens`/`cost`/`latency_ms` from a node's `generation_output` (when present), so the generation stage's `AgentRun` row carries token/cost data — without adding a second row per stage, which would have broken `test_pipeline_graph.py`'s exact per-stage row-count assertions. Research/Creative are unaffected (their output dicts have no `generation_output` key, so those columns stay `None`, same as before).

## Why
Step 3 of the per-post pipeline — turns the creative brief into actual copy, and triggers image/video generation when the brief calls for it. First node built directly on `LLMProvider` from #7. `#22`/`#23` plug into the media hook this issue defines; `#24` (Reviewer) reviews this node's output.

## Test plan
- [x] `pytest packages/agents/tests/test_generation_engine.py -v` — 14 new tests: LLMProvider-only interface (no direct SDK/httpx calls), model read from settings not hardcoded, `Post.body_text` written, `PostVersion` row created per generation (second generation preserves the first version), media hook invoked for image/video/carousel formats and not for plain text, degrade-on-failure fallback copy, unparseable-output handling, `build_generation_node(None)`/missing-post error handling, `completed_stages` bookkeeping, and `AgentRun` logged with `agent_type=generation` including populated `model`/`tokens`/`cost`.
- [x] `alembic upgrade head` / `downgrade -1` / `upgrade head` cycle verified clean against a fresh scratch DB.
- [x] Full suite: `pytest apps/api/tests packages/agents/tests -v --cov=apps/api --cov=packages --cov-fail-under=70` — 166 passed, 1 pre-existing unrelated failure (`test_social_accounts.py::test_connect_503_when_linkedin_not_configured`, a local `.env`/settings-caching artifact, confirmed pre-existing across multiple branches), coverage 98.19%.

Closes #21