### PR TITLE
feat(integrations): add fal.ai image-generation adapter

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,11 +23,15 @@ OPENROUTER_API_KEY=
 # --- Search provider (used by the Research Engine, added in a later issue) ---
 TAVILY_API_KEY=
 
+# --- Image-generation provider (used by the Generation Engine's media hook) ---
+FAL_API_KEY=
+
 # --- Provider selection (packages/integrations/registry.py) ---
 SEARCH_PROVIDER=tavily
 LLM_PROVIDER=openrouter
 STORAGE_PROVIDER=supabase
 EMBEDDING_PROVIDER=openai
+IMAGE_PROVIDER=fal
 
 # --- Media storage (brand logos, generated images/video) ---
 SUPABASE_URL=

--- a/apps/api/config/__init__.py
+++ b/apps/api/config/__init__.py
@@ -21,6 +21,7 @@ class Settings(BaseSettings):
     anthropic_api_key: str | None = None
     openrouter_api_key: str | None = None
     tavily_api_key: str | None = None
+    fal_api_key: str | None = None
 
     linkedin_client_id: str | None = None
     linkedin_client_secret: str | None = None
@@ -30,6 +31,7 @@ class Settings(BaseSettings):
     llm_provider: str = "openrouter"
     storage_provider: str = "supabase"
     embedding_provider: str = "openai"
+    image_provider: str = "fal"
 
     # OpenRouter's free-models router — swap for a paid model slug (e.g.
     # "anthropic/claude-sonnet-4.5") once quality/latency needs outgrow it.

--- a/apps/api/models/post.py
+++ b/apps/api/models/post.py
@@ -57,6 +57,18 @@ class Post(Base):
     # post is regenerated.
     body_text: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
 
+    # Written by the Generation Engine's media hook (Issue #22 — image;
+    # Issue #23 will extend this for video) — a JSONB list of media
+    # references produced by this Post's latest generation run, e.g.
+    # [{"platform": "linkedin", "format": "image", "url": "..."}]. Follows
+    # the same "written by the Generation Engine, always reflects the
+    # latest run" convention as body_text above; unlike body_text it is
+    # only touched when a run actually produces new media (a run with no
+    # image/video/carousel platforms, or one where generation failed,
+    # leaves any previously-generated media untouched rather than wiping
+    # it to null).
+    media: Mapped[list | None] = mapped_column(JSONB, nullable=True)
+
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now()
     )

--- a/apps/api/tests/test_image_gen.py
+++ b/apps/api/tests/test_image_gen.py
@@ -1,0 +1,440 @@
+"""Tests for the Issue #22 fal.ai image-generation adapter and its wiring
+into the Generation Engine's media hook (packages/agents/pipeline/nodes/
+generation_engine.py, from Issue #21).
+
+Per the issue's acceptance criteria:
+  1. FalImageProvider implements ImageProvider and is reached only through
+     that interface — no other module imports fal.ai's SDK/URL/base path
+     directly (mirrors test_integrations_llm.py / test_storage.py's
+     "mock the HTTP layer, assert the adapter is the only caller" style).
+  2. A generated image is stored via StorageProvider (Issue #11) and
+     referenced on Post.media.
+  3. A generation/storage failure is caught, logged to integration_calls,
+     and degrades gracefully — it must not crash run_pipeline.
+"""
+
+import pathlib
+import uuid
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from apps.api.config import get_settings
+from apps.api.models import AgentType, Brand, IntegrationCall, Organization, Post
+from packages.agents.pipeline.checkpointer import get_postgres_checkpointer
+from packages.agents.pipeline.graph import run_pipeline
+from packages.agents.pipeline.nodes.generation_engine import (
+    build_generation_node,
+    generate_media_stub,
+)
+from packages.integrations.image_gen.base import ImageProvider, ImageResult
+from packages.integrations.image_gen.fal_provider import FalImageProvider
+from packages.integrations.registry import get_image_provider
+
+IMAGE_PATCH_TARGET = "packages.agents.pipeline.nodes.generation_engine.get_image_provider"
+STORAGE_PATCH_TARGET = "packages.agents.pipeline.nodes.generation_engine.get_storage_provider"
+LLM_PATCH_TARGET = "packages.agents.pipeline.nodes.generation_engine.get_llm_provider"
+SEARCH_PATCH_TARGET = "packages.agents.pipeline.nodes.research_engine.get_search_provider"
+EMBED_PATCH_TARGET = "apps.api.services.brand_retrieval.get_embedding_provider"
+CREATIVE_LLM_PATCH_TARGET = "packages.agents.pipeline.nodes.creative_engine.get_llm_provider"
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[3]
+FAL_PROVIDER_FILE = REPO_ROOT / "packages" / "integrations" / "image_gen" / "fal_provider.py"
+
+
+# --- FalImageProvider: interface conformance + HTTP layer mocked only ------
+
+
+def _fal_response(url: str = "https://fal.media/files/generated-abc123.png") -> MagicMock:
+    response = MagicMock()
+    response.raise_for_status.return_value = None
+    response.json.return_value = {"images": [{"url": url}]}
+    return response
+
+
+def test_fal_provider_implements_image_provider_interface() -> None:
+    provider = FalImageProvider(api_key="test-key")
+    assert isinstance(provider, ImageProvider)
+
+
+def test_fal_provider_generate_calls_fal_and_parses_result() -> None:
+    with patch("httpx.post", return_value=_fal_response()) as mock_post:
+        result = FalImageProvider(api_key="test-key").generate("a mountain at sunrise")
+
+    assert isinstance(result, ImageResult)
+    assert result.url == "https://fal.media/files/generated-abc123.png"
+    call_args, call_kwargs = mock_post.call_args
+    assert call_args[0].startswith("https://fal.run/")
+    assert call_kwargs["headers"]["Authorization"] == "Key test-key"
+    assert call_kwargs["json"]["prompt"] == "a mountain at sunrise"
+
+
+def test_fal_provider_raises_when_response_has_no_images() -> None:
+    response = MagicMock()
+    response.raise_for_status.return_value = None
+    response.json.return_value = {"images": []}
+
+    with patch("httpx.post", return_value=response):
+        with pytest.raises(ValueError, match="no generated image URL"):
+            FalImageProvider(api_key="test-key").generate("a mountain at sunrise")
+
+
+def test_fal_provider_logs_successful_call_to_integration_calls(db_session) -> None:
+    with patch("httpx.post", return_value=_fal_response()):
+        FalImageProvider(api_key="test-key").generate("a mountain at sunrise")
+
+    logged = (
+        db_session.query(IntegrationCall)
+        .filter_by(provider="fal", capability="image_gen")
+        .order_by(IntegrationCall.created_at.desc())
+        .first()
+    )
+    assert logged is not None
+    assert logged.success is True
+
+
+def test_fal_provider_propagates_and_logs_http_failures(db_session) -> None:
+    with patch("httpx.post", side_effect=Exception("fal.ai unreachable")):
+        with pytest.raises(Exception, match="fal.ai unreachable"):
+            FalImageProvider(api_key="test-key").generate("a mountain at sunrise")
+
+    logged = (
+        db_session.query(IntegrationCall)
+        .filter_by(provider="fal", capability="image_gen")
+        .order_by(IntegrationCall.created_at.desc())
+        .first()
+    )
+    assert logged is not None
+    assert logged.success is False
+    assert "fal.ai unreachable" in (logged.error_message or "")
+
+
+def test_no_module_other_than_fal_provider_references_fals_base_url() -> None:
+    """The adapter file is the only place allowed to know fal.ai's HTTP
+    endpoint — everything else (registry.py, generation_engine.py, ...)
+    must go through the ImageProvider interface only."""
+    skip_dir_markers = ("/.git/", "/.venv/", "/node_modules/", "/.claude/")
+    offenders = []
+    for path in REPO_ROOT.rglob("*.py"):
+        path_str = str(path)
+        if path == FAL_PROVIDER_FILE or "/tests/" in path_str:
+            continue
+        if any(marker in path_str for marker in skip_dir_markers):
+            continue
+        text = path.read_text(errors="ignore")
+        if "fal.run" in text or "fal-ai/flux" in text:
+            offenders.append(str(path.relative_to(REPO_ROOT)))
+    assert offenders == []
+
+
+# --- registry wiring ---------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _clear_settings_cache():
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+def test_get_image_provider_defaults_to_fal() -> None:
+    assert isinstance(get_image_provider(), FalImageProvider)
+
+
+def test_unknown_image_provider_raises(monkeypatch) -> None:
+    monkeypatch.setenv("IMAGE_PROVIDER", "midjourney")
+    with pytest.raises(ValueError, match="Unknown IMAGE_PROVIDER"):
+        get_image_provider()
+
+
+# --- Generation Engine wiring: image stored + referenced on Post.media -----
+
+
+def _setup_post(db_session) -> Post:
+    org = Organization(name="Acme Agency")
+    db_session.add(org)
+    db_session.flush()
+
+    brand = Brand(organization_id=org.id, name="Acme Widgets", industry="Outdoor gear")
+    db_session.add(brand)
+    db_session.flush()
+
+    post = Post(brand_id=brand.id)
+    db_session.add(post)
+    db_session.flush()
+    return post
+
+
+def _image_brief() -> dict:
+    return {
+        "platforms": {
+            "linkedin": {
+                "format": "image",
+                "angle": "product_launch",
+                "hook": "Our new pack just dropped.",
+                "cta": "Shop the collection.",
+                "tone": "confident",
+            },
+        }
+    }
+
+
+def _run_node(db_session, post: Post, creative_brief: dict) -> dict:
+    node = build_generation_node(db_session)
+    return node(
+        {
+            "post_id": str(post.id),
+            "completed_stages": [],
+            "creative_brief": creative_brief,
+        }
+    )
+
+
+def _mock_llm_for_copy():
+    from packages.integrations.llm.base import LLMResponse
+    import json
+
+    return LLMResponse(
+        text=json.dumps({"linkedin": "Our new pack just dropped. Shop the collection."}),
+        model="openrouter/free",
+        input_tokens=50,
+        output_tokens=20,
+    )
+
+
+def test_generate_media_stub_calls_image_provider_only_through_interface_for_image_format() -> None:
+    with patch(IMAGE_PATCH_TARGET) as mock_get_image, patch(STORAGE_PATCH_TARGET) as mock_get_storage:
+        mock_get_image.return_value.generate.return_value = ImageResult(
+            url="https://fal.media/files/generated-abc123.png"
+        )
+        mock_get_storage.return_value.upload.return_value = (
+            "https://project.supabase.co/storage/v1/object/public/brand-assets/generated/x.png"
+        )
+
+        with patch("httpx.get") as mock_httpx_get:
+            mock_httpx_get.return_value.raise_for_status.return_value = None
+            mock_httpx_get.return_value.content = b"fake-png-bytes"
+            mock_httpx_get.return_value.headers = {"content-type": "image/png"}
+
+            result = generate_media_stub(
+                "post-123", "linkedin", _image_brief()["platforms"]["linkedin"]
+            )
+
+    mock_get_image.return_value.generate.assert_called_once()
+    assert result["status"] == "generated"
+    assert result["url"] == (
+        "https://project.supabase.co/storage/v1/object/public/brand-assets/generated/x.png"
+    )
+    upload_args = mock_get_storage.return_value.upload.call_args.args
+    assert upload_args[1] == b"fake-png-bytes"
+    assert upload_args[2] == "image/png"
+
+
+def test_generation_engine_stores_image_and_references_it_on_post_media(db_session) -> None:
+    post = _setup_post(db_session)
+
+    with (
+        patch(LLM_PATCH_TARGET) as mock_llm,
+        patch(IMAGE_PATCH_TARGET) as mock_get_image,
+        patch(STORAGE_PATCH_TARGET) as mock_get_storage,
+    ):
+        mock_llm.return_value.complete.return_value = _mock_llm_for_copy()
+        mock_get_image.return_value.generate.return_value = ImageResult(
+            url="https://fal.media/files/generated-abc123.png"
+        )
+        stored_url = (
+            "https://project.supabase.co/storage/v1/object/public/brand-assets/"
+            f"generated/{post.id}/linkedin/img.png"
+        )
+        mock_get_storage.return_value.upload.return_value = stored_url
+
+        with patch("httpx.get") as mock_httpx_get:
+            mock_httpx_get.return_value.raise_for_status.return_value = None
+            mock_httpx_get.return_value.content = b"fake-png-bytes"
+            mock_httpx_get.return_value.headers = {"content-type": "image/png"}
+
+            result = _run_node(db_session, post, _image_brief())
+
+    # Stored via the storage adapter interface only.
+    mock_get_storage.return_value.upload.assert_called_once()
+
+    db_session.refresh(post)
+    assert post.media == [{"platform": "linkedin", "format": "image", "url": stored_url}]
+    assert result["generation_output"]["platforms"]["linkedin"]["media"]["url"] == stored_url
+    assert result["generation_output"]["platforms"]["linkedin"]["media"]["status"] == "generated"
+
+
+def test_generation_engine_does_not_touch_post_media_for_plain_text_format(db_session) -> None:
+    post = _setup_post(db_session)
+    brief = {
+        "platforms": {
+            "linkedin": {
+                "format": "text_post",
+                "angle": "thought_leadership",
+                "hook": "hook",
+                "cta": "cta",
+                "tone": "professional",
+            },
+        }
+    }
+
+    with patch(LLM_PATCH_TARGET) as mock_llm:
+        mock_llm.return_value.complete.return_value = _mock_llm_for_copy()
+        _run_node(db_session, post, brief)
+
+    db_session.refresh(post)
+    assert post.media is None
+
+
+# --- degrade-on-failure: caught, logged, never crashes the pipeline --------
+
+
+def test_image_generation_failure_is_caught_and_returns_failed_status(db_session) -> None:
+    with patch(IMAGE_PATCH_TARGET) as mock_get_image:
+        mock_get_image.return_value.generate.side_effect = Exception("fal.ai quota exceeded")
+
+        result = generate_media_stub("post-123", "linkedin", _image_brief()["platforms"]["linkedin"])
+
+    assert result["status"] == "failed"
+    assert result["platform"] == "linkedin"
+
+
+def test_image_generation_failure_logged_to_integration_calls(db_session) -> None:
+    """Uses the real FalImageProvider (only its HTTP layer mocked) so
+    track_integration_call actually runs and logs the failure, exactly
+    the same context manager every other adapter call in this codebase
+    uses."""
+    with (
+        patch(STORAGE_PATCH_TARGET),
+        patch(
+            "packages.agents.pipeline.nodes.generation_engine.get_image_provider",
+            return_value=FalImageProvider(api_key="test-key"),
+        ),
+        patch("httpx.post", side_effect=Exception("fal.ai unreachable")),
+    ):
+        result = generate_media_stub("post-123", "linkedin", _image_brief()["platforms"]["linkedin"])
+
+    assert result["status"] == "failed"
+
+    logged = (
+        db_session.query(IntegrationCall)
+        .filter_by(provider="fal", capability="image_gen")
+        .order_by(IntegrationCall.created_at.desc())
+        .first()
+    )
+    assert logged is not None
+    assert logged.success is False
+
+
+def test_storage_upload_failure_is_caught_and_does_not_propagate(db_session) -> None:
+    with patch(IMAGE_PATCH_TARGET) as mock_get_image, patch(STORAGE_PATCH_TARGET) as mock_get_storage:
+        mock_get_image.return_value.generate.return_value = ImageResult(
+            url="https://fal.media/files/generated-abc123.png"
+        )
+        mock_get_storage.return_value.upload.side_effect = Exception("supabase storage unreachable")
+
+        with patch("httpx.get") as mock_httpx_get:
+            mock_httpx_get.return_value.raise_for_status.return_value = None
+            mock_httpx_get.return_value.content = b"fake-png-bytes"
+            mock_httpx_get.return_value.headers = {"content-type": "image/png"}
+
+            result = generate_media_stub("post-123", "linkedin", _image_brief()["platforms"]["linkedin"])
+
+    assert result["status"] == "failed"
+
+
+@pytest.fixture()
+def thread_cleanup():
+    """Same teardown as test_generation_engine.py's fixture — pipeline
+    checkpoint rows live in Postgres on a connection separate from
+    db_session's rolled-back transaction, so they need explicit cleanup."""
+    thread_ids: list[str] = []
+    yield thread_ids
+    if not thread_ids:
+        return
+    with get_postgres_checkpointer() as checkpointer:
+        for thread_id in thread_ids:
+            checkpointer.delete_thread(thread_id)
+
+
+def test_image_generation_failure_does_not_crash_run_pipeline(db_session, thread_cleanup) -> None:
+    post = _setup_post(db_session)
+    thread_cleanup.append(str(post.id))
+
+    # No calendar_event_id on this Post, so Creative Engine falls back to
+    # SUPPORTED_PLATFORMS ("linkedin", "x") — both platform briefs must be
+    # mocked or Creative Engine's own parse-failure fallback kicks in.
+    with (
+        patch(SEARCH_PATCH_TARGET) as mock_search,
+        patch(EMBED_PATCH_TARGET) as mock_embed,
+        patch(CREATIVE_LLM_PATCH_TARGET) as mock_creative_llm,
+        patch(LLM_PATCH_TARGET) as mock_generation_llm,
+        patch(IMAGE_PATCH_TARGET) as mock_get_image,
+    ):
+        mock_search.return_value.search.return_value = []
+        mock_embed.return_value.embed.return_value = [0.0] * 1536
+        mock_creative_llm.return_value.complete.return_value = _two_platform_brief_llm_response()
+        mock_generation_llm.return_value.complete.return_value = _two_platform_copy_llm_response()
+        mock_get_image.return_value.generate.side_effect = Exception("fal.ai quota exceeded")
+
+        with get_postgres_checkpointer() as checkpointer:
+            # Must not raise — an image-gen failure degrades gracefully
+            # rather than crashing the whole pipeline run.
+            events = list(run_pipeline(db_session, post, checkpointer))
+
+    assert events  # the pipeline still ran to completion
+    db_session.refresh(post)
+    # Copy generation still succeeded (both platforms) even though
+    # linkedin's media generation failed.
+    assert post.body_text == {
+        "linkedin": "Our new pack just dropped. Shop the collection.",
+        "x": "Quick take on the new pack. Check it out.",
+    }
+    # No media was stored, since generation failed.
+    assert post.media is None
+    # Failure -> integration_calls logging is exercised directly against
+    # the real FalImageProvider in
+    # test_image_generation_failure_logged_to_integration_calls above
+    # (get_image_provider is mocked wholesale here to isolate "the
+    # pipeline survives a media failure" from "the adapter logs its own
+    # failures").
+
+
+def _two_platform_brief_llm_response():
+    from packages.integrations.llm.base import LLMResponse
+    import json
+
+    return LLMResponse(
+        text=json.dumps(
+            {
+                "linkedin": _image_brief()["platforms"]["linkedin"],
+                "x": {
+                    "format": "text_post",
+                    "angle": "hot_take",
+                    "hook": "Quick take on the new pack.",
+                    "cta": "Check it out.",
+                    "tone": "casual",
+                },
+            }
+        ),
+        model="openrouter/free",
+        input_tokens=50,
+        output_tokens=20,
+    )
+
+
+def _two_platform_copy_llm_response():
+    from packages.integrations.llm.base import LLMResponse
+    import json
+
+    return LLMResponse(
+        text=json.dumps(
+            {
+                "linkedin": "Our new pack just dropped. Shop the collection.",
+                "x": "Quick take on the new pack. Check it out.",
+            }
+        ),
+        model="openrouter/free",
+        input_tokens=50,
+        output_tokens=20,
+    )

--- a/migrations/versions/104119cc2693_post_media.py
+++ b/migrations/versions/104119cc2693_post_media.py
@@ -1,0 +1,41 @@
+"""post media
+
+Revision ID: 104119cc2693
+Revises: ec24a3325404
+Create Date: 2026-08-24 21:58:19.362081
+
+Issue #22 (fal.ai image-generation adapter) needs somewhere to link the
+Generation Engine's generated media onto the Post it belongs to. Adds:
+
+  * posts.media — a nullable JSONB column holding a list of media
+    references produced by the *latest* generation run that actually
+    produced media (e.g. [{"platform": "linkedin", "format": "image",
+    "url": "..."}]), mirroring posts.body_text's "written by the
+    Generation Engine" convention (see migrations/versions/
+    ec24a3325404_post_body_text_and_post_versions.py) but, unlike
+    body_text, only touched when a run produces new media rather than
+    unconditionally overwritten every run.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+# revision identifiers, used by Alembic.
+revision: str = '104119cc2693'
+down_revision: Union[str, None] = 'ec24a3325404'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        'posts',
+        sa.Column('media', postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column('posts', 'media')

--- a/packages/agents/pipeline/nodes/generation_engine.py
+++ b/packages/agents/pipeline/nodes/generation_engine.py
@@ -22,10 +22,15 @@ LLM-produced) creative brief's hook + CTA rather than raising.
 
 Also defines generate_media_stub(): the image/video-generation hook
 called (unconditionally, whenever a platform's brief calls for it) when a
-platform's `format` is image/video/carousel. Issues #22 (image) and #23
-(video) will replace/extend this stub with real adapters — this issue's
-job is only to guarantee the call site exists and is genuinely reached
-under the right conditions, not to build those adapters.
+platform's `format` is image/video/carousel. Issue #22 has replaced the
+`image` branch of this hook with a real fal.ai-backed adapter (through
+ImageProvider only — packages/integrations/registry.get_image_provider())
+plus storage (packages/integrations/registry.get_storage_provider()); the
+`video`/`carousel` branches remain the #21 stub for Issue #23 to extend.
+Same interface-only, degrade-on-failure contract as the rest of this
+module: an image-gen or storage failure is caught here and turned into a
+{"status": "failed", ...} result rather than propagating and taking the
+pipeline down with it.
 
 Output handling — Post.body_text with version history preserved:
   * Post.body_text (apps/api/models/post.py) is written with this run's
@@ -36,6 +41,10 @@ Output handling — Post.body_text with version history preserved:
     convention AgentRun already establishes — so regenerating a post's
     copy (e.g. after a human-review rejection) never loses the version
     that came before it.
+  * Post.media (added in #22) is written with this run's successfully
+    generated media, a list of {"platform", "format", "url"} dicts. Only
+    touched when this run actually produced new media — see Post.media's
+    own docstring in apps/api/models/post.py for why.
 
 AgentRun token/cost fields: run_pipeline (graph.py) already logs one
 AgentRun row per completed node generically, from whatever dict the node
@@ -60,12 +69,17 @@ import time
 import uuid
 from typing import Any
 
+import httpx
 from sqlalchemy.orm import Session
 
 from apps.api.config import get_settings
 from apps.api.models.post import Post
 from apps.api.models.post_version import PostVersion
-from packages.integrations.registry import get_llm_provider
+from packages.integrations.registry import (
+    get_image_provider,
+    get_llm_provider,
+    get_storage_provider,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -105,14 +119,75 @@ def _requires_media(platform_brief: dict[str, Any]) -> bool:
     return any(keyword in fmt for keyword in MEDIA_FORMAT_KEYWORDS)
 
 
+def _build_image_prompt(platform_brief: dict[str, Any]) -> str:
+    """Composes a fal.ai prompt straight from the creative brief's own
+    fields — same "no new invented content, just reshape what the brief
+    already decided" spirit as _fallback_copy_for below."""
+    angle = str(platform_brief.get("angle") or "").strip()
+    hook = str(platform_brief.get("hook") or "").strip()
+    tone = str(platform_brief.get("tone") or "").strip()
+    parts = [part for part in (hook, angle, tone) if part]
+    if parts:
+        return "Social media post image. " + "; ".join(parts)
+    return "Social media post image."
+
+
+def _download_image_bytes(url: str) -> tuple[bytes, str]:
+    """Fetches the generated image's bytes from the (temporary) URL the
+    ImageProvider returned, so it can be re-uploaded through
+    StorageProvider for durable hosting. A plain, vendor-agnostic GET
+    against whatever URL the interface handed back — not a fal.ai API
+    call, so it belongs here rather than inside fal_provider.py."""
+    response = httpx.get(url, timeout=30.0)
+    response.raise_for_status()
+    content_type = response.headers.get("content-type", "image/png").split(";")[0].strip()
+    return response.content, content_type
+
+
+def _generate_image_media(post_id: str, platform: str, platform_brief: dict[str, Any]) -> dict[str, Any]:
+    """The real (Issue #22) image branch of the media hook: calls
+    ImageProvider exclusively through its interface
+    (packages.integrations.registry.get_image_provider()) — never fal.ai's
+    HTTP API directly — then stores the result via StorageProvider
+    (packages.integrations.registry.get_storage_provider()), same
+    interface-only contract as every other adapter call in this pipeline.
+    Any failure (image-gen or storage) is caught and turned into a
+    {"status": "failed"} result instead of propagating, so a broken/
+    unconfigured image provider can't take the whole pipeline run down —
+    same degrade-on-failure contract as _generate_copy above."""
+    fmt = platform_brief.get("format")
+    try:
+        prompt = _build_image_prompt(platform_brief)
+        result = get_image_provider().generate(prompt=prompt)
+        content, content_type = _download_image_bytes(result.url)
+
+        extension = "png" if "png" in content_type else content_type.split("/")[-1] or "png"
+        path = f"generated/{post_id}/{platform}/{uuid.uuid4().hex}.{extension}"
+        stored_url = get_storage_provider().upload(path, content, content_type)
+    except Exception:
+        logger.warning(
+            "Generation Engine: image generation failed for post=%s platform=%s; "
+            "degrading gracefully (no media attached)",
+            post_id,
+            platform,
+            exc_info=True,
+        )
+        return {"status": "failed", "platform": platform, "format": fmt}
+
+    return {"status": "generated", "platform": platform, "format": fmt, "url": stored_url}
+
+
 def generate_media_stub(post_id: str, platform: str, platform_brief: dict[str, Any]) -> dict[str, Any]:
-    """Placeholder image/video-generation hook. Deliberately a plain
-    function (not yet an interface like LLMProvider/SearchProvider) since
-    #22 (image) and #23 (video) haven't defined that interface yet — this
-    issue's job is only to guarantee the *call site* exists in the
-    pipeline, genuinely reached when a platform's format calls for it, for
-    #22/#23 to plug into (replace/extend) rather than having to invent the
-    wiring themselves."""
+    """Image/video-generation hook. For `image` formats this now calls the
+    real fal.ai-backed adapter (#22, see _generate_image_media above);
+    `video`/`carousel` formats still return the original #21 placeholder
+    below, left as the call site for #23 to replace/extend — this issue's
+    job is only the image branch, narrowly scoped so #23's eventual
+    rebase against this stays small."""
+    fmt = str(platform_brief.get("format", "")).lower()
+    if "image" in fmt:
+        return _generate_image_media(post_id, platform, platform_brief)
+
     logger.info(
         "Generation Engine: media hook stub called for post=%s platform=%s format=%r",
         post_id,
@@ -242,6 +317,18 @@ def _generation_output(db: Session, post: Post, creative_brief: dict[str, Any]) 
 
     body_text = {platform: result["body_text"] for platform, result in platform_results.items()}
     cost = _estimate_cost(tokens)
+
+    # Collect this run's successfully generated media (status="generated")
+    # onto Post.media — see Post.media's docstring (apps/api/models/post.py)
+    # for why a run that produced no new media leaves any prior media
+    # untouched rather than wiping it to null.
+    media_items = [
+        {"platform": platform, "format": result["media"]["format"], "url": result["media"]["url"]}
+        for platform, result in platform_results.items()
+        if result["media"] and result["media"].get("status") == "generated"
+    ]
+    if media_items:
+        post.media = media_items
 
     # Write the generated copy onto the Post itself, and append an
     # immutable version-history row (see module docstring) so a second

--- a/packages/integrations/image_gen/fal_provider.py
+++ b/packages/integrations/image_gen/fal_provider.py
@@ -1,0 +1,44 @@
+import httpx
+
+from packages.integrations.image_gen.base import ImageProvider, ImageResult
+from packages.integrations.observability import track_integration_call
+
+
+class FalImageProvider(ImageProvider):
+    """The only file allowed to call fal.ai directly (Issue #22). Every
+    other module — including generation_engine.py's media hook — must
+    reach fal.ai only through the ImageProvider interface
+    (packages/integrations/image_gen/base.py), resolved via
+    packages.integrations.registry.get_image_provider(), same
+    interface-only contract every other adapter in this package follows.
+    """
+
+    # fal.ai's synchronous inference endpoint — one HTTP call in, one
+    # generated image out. Model id is configurable (constructor arg) so a
+    # different fal model can be swapped in via settings without touching
+    # this adapter's request/response handling.
+    BASE_URL = "https://fal.run"
+    DEFAULT_MODEL = "fal-ai/flux/dev"
+
+    def __init__(
+        self, api_key: str, model: str = DEFAULT_MODEL, timeout: float = 60.0
+    ) -> None:
+        self.api_key = api_key
+        self.model = model
+        self.timeout = timeout
+
+    def generate(self, prompt: str, **kwargs: object) -> ImageResult:
+        with track_integration_call("fal", "image_gen"):
+            response = httpx.post(
+                f"{self.BASE_URL}/{self.model}",
+                headers={"Authorization": f"Key {self.api_key}"},
+                json={"prompt": prompt, **kwargs},
+                timeout=self.timeout,
+            )
+            response.raise_for_status()
+            data = response.json()
+
+        images = data.get("images") or []
+        if not images or not images[0].get("url"):
+            raise ValueError("fal.ai response contained no generated image URL")
+        return ImageResult(url=images[0]["url"])

--- a/packages/integrations/registry.py
+++ b/packages/integrations/registry.py
@@ -1,6 +1,8 @@
 from apps.api.config import get_settings
 from packages.integrations.embedding.base import EmbeddingProvider
 from packages.integrations.embedding.openai_provider import OpenAIEmbeddingProvider
+from packages.integrations.image_gen.base import ImageProvider
+from packages.integrations.image_gen.fal_provider import FalImageProvider
 from packages.integrations.llm.base import LLMProvider
 from packages.integrations.llm.openai_provider import OpenAIProvider
 from packages.integrations.llm.openrouter_provider import OpenRouterProvider
@@ -39,6 +41,10 @@ _STORAGE_PROVIDERS = {
         service_key=settings.supabase_service_key or "",
         bucket=settings.supabase_storage_bucket,
     ),
+}
+
+_IMAGE_PROVIDERS = {
+    "fal": lambda settings: FalImageProvider(api_key=settings.fal_api_key or ""),
 }
 
 
@@ -102,5 +108,17 @@ def get_storage_provider() -> StorageProvider:
         raise ValueError(
             f"Unknown STORAGE_PROVIDER '{settings.storage_provider}'. "
             f"Valid options: {sorted(_STORAGE_PROVIDERS)}"
+        ) from None
+    return factory(settings)
+
+
+def get_image_provider() -> ImageProvider:
+    settings = get_settings()
+    try:
+        factory = _IMAGE_PROVIDERS[settings.image_provider]
+    except KeyError:
+        raise ValueError(
+            f"Unknown IMAGE_PROVIDER '{settings.image_provider}'. "
+            f"Valid options: {sorted(_IMAGE_PROVIDERS)}"
         ) from None
     return factory(settings)


### PR DESCRIPTION
## Summary
- Implements the `ImageProvider` interface stubbed in #7 with a real fal.ai adapter (`packages/integrations/image_gen/fal_provider.py`), the only file that talks to fal.ai's HTTP API directly.
- Registers it in `packages/integrations/registry.py` alongside the existing `_LLM_PROVIDERS`/`_STORAGE_PROVIDERS` pattern (`_IMAGE_PROVIDERS` + `get_image_provider()`), reading `FAL_API_KEY`/`IMAGE_PROVIDER` from `Settings`.
- Wires it into the Generation Engine's `generate_media_stub()` media hook (from #21): for the `image` format case, it now calls `ImageProvider.generate()` through the interface only, downloads the resulting bytes, and re-uploads them through the existing `StorageProvider` adapter (#11) — never a direct fal.ai call outside the adapter file.
- Adds `Post.media` (nullable JSONB, Alembic migration `104119cc2693`) so the stored image URL is linked back onto the Post, following the same style as `Post.body_text` from #21.
- The `video`/`carousel` branches of `generate_media_stub()` are left exactly as they were for #23 — this PR only touches the `image` case, kept narrowly scoped since #23 (video generation) is being built concurrently against the same hook on a separate branch off the same base and will very likely need a rebase against whichever of us lands second.

## Why
Completes the "image" branch of `desired_format` that #21's Generation Engine stubbed out, per #22.

## Failure handling
- fal.ai/storage failures inside the image branch are caught and turned into `{"status": "failed", ...}` instead of propagating — same degrade-on-failure contract `research_engine.py`/`creative_engine.py`/`generation_engine.py` already use for their own external calls, so a misconfigured/broken image provider can't take the whole pipeline run down.
- Every fal.ai call is logged to `integration_calls` via the same `track_integration_call` context manager every other adapter uses.

## Test plan
- New `apps/api/tests/test_image_gen.py` (15 tests): `FalImageProvider` implements `ImageProvider` and is reached only through the interface (HTTP layer mocked; a repo-wide scan asserts no other module references fal.ai's base URL); registry wiring defaults to `fal`; the media hook stores a generated image via the storage adapter and references it on `Post.media`; a plain-text format leaves `Post.media` untouched; image-gen and storage failures are caught, logged to `integration_calls`, and don't crash `run_pipeline`.
- Ran locally against a fresh `raindeer_test_issue22` Postgres DB (not the shared `raindeer_test`, to avoid conflicting migration history from concurrent branches):
  - `alembic upgrade head` / `downgrade -1` / `upgrade head` — migration applies and reverses cleanly.
  - `pytest apps/api/tests packages/agents/tests -v --cov=apps/api --cov=packages --cov-fail-under=70` → **182 passed**, coverage **98.37%** (well above the 70% gate).
  - The one known pre-existing/unrelated test (`test_social_accounts.py::test_connect_503_when_linkedin_not_configured`) actually passed locally too — no action needed there.

Closes #22