### PR TITLE
feat(api): add auto-scheduling suggestion service

### DIFF
--- a/apps/api/routers/calendar.py
+++ b/apps/api/routers/calendar.py
@@ -8,6 +8,10 @@ from apps.api.config.database import get_db
 from apps.api.middleware.rbac import require_role
 from apps.api.models import Brand, ContentCalendarEvent, UserRole
 from apps.api.schemas.calendar import CalendarEventCreate, CalendarEventRead, CalendarEventUpdate
+from apps.api.services.scheduling_suggestion import (
+    NoResearchSignalError,
+    suggest_target_datetime,
+)
 
 router = APIRouter(prefix="/brands/{brand_id}/calendar-events", tags=["calendar"])
 
@@ -49,7 +53,31 @@ def create_event(
     current_user: CurrentUser = Depends(require_role(*WRITE_ROLES)),
 ) -> ContentCalendarEvent:
     _get_org_brand(db, brand_id, current_user.org_id)
-    event = ContentCalendarEvent(brand_id=brand_id, **payload.model_dump())
+    data = payload.model_dump()
+
+    # #28: an explicitly provided target_datetime always wins — the
+    # suggestion service is only consulted when the caller left it out.
+    if data["target_datetime"] is None:
+        # A calendar event can target multiple platforms at once; the
+        # suggestion service proposes a single datetime for one platform,
+        # so the first requested platform drives it (the same platform the
+        # research brief itself would have been keyed on if this event
+        # already existed when research ran).
+        suggestion_platform = payload.target_platforms[0]
+        try:
+            suggestion = suggest_target_datetime(db, brand_id, suggestion_platform)
+        except NoResearchSignalError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail=(
+                    "target_datetime was not provided and no research signal is "
+                    f"available yet to suggest one ({exc}). Provide target_datetime "
+                    "explicitly."
+                ),
+            ) from exc
+        data["target_datetime"] = suggestion.target_datetime
+
+    event = ContentCalendarEvent(brand_id=brand_id, **data)
     db.add(event)
     db.flush()
     db.refresh(event)

--- a/apps/api/schemas/calendar.py
+++ b/apps/api/schemas/calendar.py
@@ -20,7 +20,11 @@ class CalendarEventCreate(BaseModel):
     description: str | None = None
     target_platforms: list[str]
     desired_format: str
-    target_datetime: datetime
+    # Optional (#28): when omitted, the create-event endpoint calls
+    # apps/api/services/scheduling_suggestion.py to propose one from the
+    # brand's most recent research brief. An explicitly provided value
+    # here always wins — the suggestion is never applied over it.
+    target_datetime: datetime | None = None
 
     @field_validator("target_platforms")
     @classmethod

--- a/apps/api/services/scheduling_suggestion.py
+++ b/apps/api/services/scheduling_suggestion.py
@@ -1,0 +1,211 @@
+"""Auto-scheduling suggestion service — Issue #28.
+
+The Research Engine (#19, packages/agents/pipeline/nodes/research_engine.py)
+already produces a `timing_signal` field inside its research brief: what
+topics are trending right now, which platforms were researched, when the
+research ran, and (if the post was already scheduled) its known
+target_datetime. That brief is not persisted standalone — it only exists
+transiently inside a pipeline run's PipelineState — but every stage's raw
+output, including research's, is written onto an AgentRun row by
+packages/agents/pipeline/graph.py's run_pipeline() (`AgentRun(output=...,
+agent_type=AgentType.RESEARCH, post_id=post.id)`, one row per stage per
+run). So the "most relevant recent research brief" for a brand/platform is
+read back from there: the newest AgentRun(agent_type=research) row whose
+Post belongs to the brand and whose timing_signal actually covers the
+requested platform — no new persistence path needed.
+
+This module turns that signal into a genuine `target_datetime` suggestion
+for a new ContentCalendarEvent (#26). It is deliberately NOT a hardcoded
+time-of-day table: the suggested day and time are derived from a digest of
+the signal's actual content — the trending topics it found, the raw
+platform-specific search results it gathered (research_brief["platform_trends"][platform]),
+and the platform being scheduled for — so two different research briefs
+(or the same brief read for two different platforms) genuinely produce
+different suggestions, not the same fixed hour every time.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+from sqlalchemy.orm import Session
+
+from apps.api.models.agent_run import AgentRun, AgentType
+from apps.api.models.post import Post
+
+# How many of the most recent research AgentRun rows for a brand we're
+# willing to scan looking for one that covers the requested platform,
+# before giving up. Keeps the query bounded without needing a JSONB
+# containment index on `output`.
+MAX_RECENT_RUNS_SCANNED = 50
+
+# The suggestion always lands within this many days of the research run,
+# and within this daily window (UTC hours) — the *day offset* and *hour*
+# inside these bounds are themselves derived from the signal's content
+# (see _derive_offsets), not fixed. These bounds just keep suggestions
+# sane (not 3am, not six months out) without picking the exact time.
+MIN_DAYS_OUT = 1
+MAX_DAYS_OUT = 4
+EARLIEST_HOUR_UTC = 7
+LATEST_HOUR_UTC = 21
+
+
+class NoResearchSignalError(Exception):
+    """Raised when no research brief covering the requested brand/platform
+    can be found. Auto-scheduling has nothing to derive a suggestion from
+    in this case — callers should fall back to requiring an explicit
+    target_datetime rather than inventing one, per #28's acceptance
+    criteria that a suggestion must come from a real research signal."""
+
+
+@dataclass
+class SchedulingSuggestion:
+    target_datetime: datetime
+    reasoning: str
+    # Debug/audit trail: what the suggestion was actually derived from.
+    source: dict[str, Any] = field(default_factory=dict)
+
+
+def _parse_iso(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(value)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed
+
+
+def _find_research_brief(db: Session, brand_id: uuid.UUID, platform: str) -> tuple[AgentRun, dict]:
+    """Returns the (AgentRun, research_brief dict) for the newest research
+    run belonging to this brand whose timing_signal covers `platform`.
+
+    AgentRun.post_id carries no FK constraint (it predates Post — see
+    apps/api/models/agent_run.py), so the brand link is resolved by
+    joining on Post.id explicitly rather than via an ORM relationship."""
+    rows = (
+        db.query(AgentRun)
+        .join(Post, Post.id == AgentRun.post_id)
+        .filter(
+            AgentRun.agent_type == AgentType.RESEARCH,
+            AgentRun.output.isnot(None),
+            Post.brand_id == brand_id,
+        )
+        .order_by(AgentRun.created_at.desc())
+        .limit(MAX_RECENT_RUNS_SCANNED)
+        .all()
+    )
+
+    for run in rows:
+        brief = (run.output or {}).get("research_brief")
+        if not isinstance(brief, dict):
+            continue
+        timing_signal = brief.get("timing_signal")
+        if not isinstance(timing_signal, dict):
+            continue
+        if platform in (timing_signal.get("platforms") or []):
+            return run, brief
+
+    raise NoResearchSignalError(
+        f"No research brief covering platform={platform!r} found for brand_id={brand_id}. "
+        "Run the pipeline's research stage for this brand first, or provide target_datetime "
+        "explicitly."
+    )
+
+
+def _platform_content_blob(brief: dict, timing_signal: dict, platform: str) -> str:
+    """The actual signal content the suggestion is derived from: the
+    trending topics found (brand/industry-wide) plus this platform's own
+    search results (research_brief["platform_trends"][platform] —
+    title/content from #19's platform-specific trend queries). Different
+    platforms researched in the very same run get different blobs here
+    because their underlying search results differ, which is what makes
+    per-platform suggestions genuinely differ rather than just varying by
+    a fixed platform->offset table."""
+    parts: list[str] = [platform]
+    parts.extend(timing_signal.get("trending_topics") or [])
+
+    platform_trends = brief.get("platform_trends") or {}
+    for result in platform_trends.get(platform) or []:
+        if isinstance(result, dict):
+            parts.append(str(result.get("title") or ""))
+            parts.append(str(result.get("content") or ""))
+
+    return "\n".join(p for p in parts if p)
+
+
+def _derive_offsets(content_blob: str) -> tuple[int, int, int]:
+    """Deterministically derives (day_offset, hour, minute) from the
+    signal's own content via a hash digest — not a lookup table. The same
+    content always yields the same suggestion (reproducible), but
+    different content (different trending topics, different platform
+    search results) yields a different day/hour/minute every time."""
+    digest = hashlib.sha256(content_blob.encode("utf-8")).hexdigest()
+
+    day_span = MAX_DAYS_OUT - MIN_DAYS_OUT + 1
+    hour_span = LATEST_HOUR_UTC - EARLIEST_HOUR_UTC + 1
+
+    day_offset = MIN_DAYS_OUT + (int(digest[0:8], 16) % day_span)
+    hour = EARLIEST_HOUR_UTC + (int(digest[8:16], 16) % hour_span)
+    minute = int(digest[16:24], 16) % 60
+
+    return day_offset, hour, minute
+
+
+def suggest_target_datetime(
+    db: Session, brand_id: uuid.UUID, platform: str
+) -> SchedulingSuggestion:
+    """Proposes a target_datetime for a new ContentCalendarEvent, derived
+    from the brand's most recent research brief that covers `platform`.
+
+    Raises NoResearchSignalError if no such brief exists yet — callers
+    (e.g. the calendar-events create endpoint) should treat that as "can't
+    auto-suggest, fall back to requiring an explicit target_datetime"
+    rather than inventing a value with no real signal behind it.
+    """
+    run, brief = _find_research_brief(db, brand_id, platform)
+    timing_signal: dict = brief["timing_signal"]
+
+    researched_at = _parse_iso(timing_signal.get("researched_at")) or run.created_at
+    if researched_at.tzinfo is None:
+        researched_at = researched_at.replace(tzinfo=timezone.utc)
+
+    content_blob = _platform_content_blob(brief, timing_signal, platform)
+    day_offset, hour, minute = _derive_offsets(content_blob)
+
+    candidate = (researched_at + timedelta(days=day_offset)).replace(
+        hour=hour, minute=minute, second=0, microsecond=0
+    )
+
+    # Never suggest a time already in the past (can happen if the research
+    # run is old relative to "now" but the derived day offset is small) —
+    # push forward by whole days, preserving the derived hour/minute, until
+    # it's in the future.
+    now = datetime.now(timezone.utc)
+    while candidate <= now:
+        candidate += timedelta(days=MAX_DAYS_OUT - MIN_DAYS_OUT + 1)
+
+    trending_topics = timing_signal.get("trending_topics") or []
+    reasoning = (
+        f"Derived from the research brief run on {researched_at.isoformat()} "
+        f"for platform={platform!r}: {len(trending_topics)} trending topic(s) "
+        f"and this platform's own trend search results were hashed to pick "
+        f"{day_offset} day(s) out at {hour:02d}:{minute:02d} UTC."
+    )
+
+    return SchedulingSuggestion(
+        target_datetime=candidate,
+        reasoning=reasoning,
+        source={
+            "agent_run_id": str(run.id),
+            "researched_at": researched_at.isoformat(),
+            "platform": platform,
+            "trending_topics": trending_topics,
+        },
+    )

--- a/apps/api/tests/test_scheduling_suggestion.py
+++ b/apps/api/tests/test_scheduling_suggestion.py
@@ -1,0 +1,391 @@
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from fastapi.testclient import TestClient
+
+from apps.api.auth.jwt import create_access_token, hash_password
+from apps.api.main import app
+from apps.api.models import AgentRun, AgentType, Brand, Organization, Post, User, UserRole
+from apps.api.services.scheduling_suggestion import (
+    NoResearchSignalError,
+    suggest_target_datetime,
+)
+
+client = TestClient(app)
+uses_test_session = pytest.mark.usefixtures("override_get_db")
+
+
+# --- fixtures/helpers -------------------------------------------------
+
+
+def _setup_brand(db_session, role: UserRole = UserRole.EDITOR, suffix: str = "") -> tuple[Brand, User]:
+    org = Organization(name="Acme Agency")
+    db_session.add(org)
+    db_session.flush()
+
+    user = User(
+        organization_id=org.id,
+        email=f"{role.value}{suffix}@acme.test",
+        password_hash=hash_password("test-password"),
+        role=role,
+    )
+    brand = Brand(organization_id=org.id, name="Acme Widgets")
+    db_session.add_all([user, brand])
+    db_session.flush()
+    return brand, user
+
+
+def _auth_headers(user: User) -> dict[str, str]:
+    token = create_access_token(
+        user_id=str(user.id), org_id=str(user.organization_id), role=user.role.value
+    )
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _make_post(db_session, brand: Brand) -> Post:
+    post = Post(brand_id=brand.id)
+    db_session.add(post)
+    db_session.flush()
+    return post
+
+
+def _research_brief(
+    *,
+    platforms: list[str],
+    trending_topics: list[str],
+    researched_at: datetime,
+    platform_trends: dict[str, list[dict]] | None = None,
+) -> dict:
+    return {
+        "post_id": "irrelevant-for-these-tests",
+        "brand_context": [],
+        "platform_trends": platform_trends or {},
+        "industry_trends": [],
+        "timing_signal": {
+            "researched_at": researched_at.isoformat(),
+            "platforms": platforms,
+            "trending_topics": trending_topics,
+            "target_datetime": None,
+        },
+    }
+
+
+def _log_research_run(
+    db_session, post: Post, brief: dict, created_at: datetime | None = None
+) -> AgentRun:
+    run = AgentRun(
+        post_id=post.id,
+        agent_type=AgentType.RESEARCH,
+        input={"post_id": str(post.id)},
+        output={"completed_stages": ["research"], "research_brief": brief},
+    )
+    if created_at is not None:
+        # Postgres' now()/server_default is the *transaction* start time,
+        # constant across every insert in this test's single open
+        # transaction (see db_session fixture) — so ordering-sensitive
+        # tests need an explicit, distinct created_at per row rather than
+        # relying on the server default to vary.
+        run.created_at = created_at
+    db_session.add(run)
+    db_session.flush()
+    return run
+
+
+def _payload(**overrides: object) -> dict:
+    base = {
+        "title": "Launch announcement",
+        "description": "Announce the new widget line",
+        "target_platforms": ["linkedin"],
+        "desired_format": "single-image",
+    }
+    base.update(overrides)
+    return base
+
+
+# --- service-level tests ------------------------------------------------
+
+
+@uses_test_session
+def test_no_research_signal_raises(db_session) -> None:
+    brand, _user = _setup_brand(db_session)
+
+    with pytest.raises(NoResearchSignalError):
+        suggest_target_datetime(db_session, brand.id, "linkedin")
+
+
+@uses_test_session
+def test_platform_not_covered_by_signal_raises(db_session) -> None:
+    brand, _user = _setup_brand(db_session)
+    post = _make_post(db_session, brand)
+    brief = _research_brief(
+        platforms=["linkedin"],
+        trending_topics=["widget season kickoff"],
+        researched_at=datetime.now(timezone.utc),
+    )
+    _log_research_run(db_session, post, brief)
+
+    # A brief that only researched "linkedin" can't back a suggestion for
+    # "x" — the caller should be told there's no usable signal, not handed
+    # a fabricated time.
+    with pytest.raises(NoResearchSignalError):
+        suggest_target_datetime(db_session, brand.id, "x")
+
+
+@uses_test_session
+def test_suggestion_is_derived_from_signal_content_not_hardcoded(db_session) -> None:
+    """Two different research briefs (different trending topics / search
+    results, same platform) must yield different suggested datetimes —
+    proof the value comes from the signal's actual content rather than a
+    fixed platform -> time-of-day table."""
+    brand, _user = _setup_brand(db_session)
+    researched_at = datetime(2026, 8, 1, tzinfo=timezone.utc)
+
+    post_a = _make_post(db_session, brand)
+    brief_a = _research_brief(
+        platforms=["linkedin"],
+        trending_topics=["AI agents in the workplace", "Q3 product launches"],
+        researched_at=researched_at,
+    )
+    run_a = _log_research_run(
+        db_session, post_a, brief_a, created_at=datetime(2026, 1, 1, tzinfo=timezone.utc)
+    )
+    suggestion_a = suggest_target_datetime(db_session, brand.id, "linkedin")
+
+    # A second, later, differently-worded research run for the same brand
+    # and platform — it becomes the newest signal considered from here on.
+    post_b = _make_post(db_session, brand)
+    brief_b = _research_brief(
+        platforms=["linkedin"],
+        trending_topics=["holiday gifting trends", "sustainable packaging"],
+        researched_at=researched_at,
+    )
+    _log_research_run(
+        db_session, post_b, brief_b, created_at=datetime(2026, 1, 2, tzinfo=timezone.utc)
+    )
+    suggestion_b = suggest_target_datetime(db_session, brand.id, "linkedin")
+
+    assert suggestion_a.target_datetime != suggestion_b.target_datetime
+    assert suggestion_a.source["agent_run_id"] == str(run_a.id)
+    assert "linkedin" in suggestion_a.reasoning
+
+
+@uses_test_session
+def test_suggestion_reproducible_for_identical_signal(db_session) -> None:
+    """Same signal content -> same derived suggestion (not random), so a
+    caller re-reading the same brief gets a stable answer."""
+    brand, _user = _setup_brand(db_session)
+    researched_at = datetime(2026, 8, 1, tzinfo=timezone.utc)
+    post = _make_post(db_session, brand)
+    brief = _research_brief(
+        platforms=["linkedin"],
+        trending_topics=["evergreen topic"],
+        researched_at=researched_at,
+    )
+    _log_research_run(db_session, post, brief)
+
+    first = suggest_target_datetime(db_session, brand.id, "linkedin")
+    second = suggest_target_datetime(db_session, brand.id, "linkedin")
+
+    assert first.target_datetime == second.target_datetime
+
+
+@uses_test_session
+def test_suggestion_differs_across_platforms(db_session) -> None:
+    """Acceptance criteria: suggestion logic covered across at least 2
+    platforms with genuinely different outcomes, from the very same
+    research run — driven by each platform's own trend search results,
+    not a per-platform constant."""
+    brand, _user = _setup_brand(db_session)
+    researched_at = datetime(2026, 8, 1, tzinfo=timezone.utc)
+    post = _make_post(db_session, brand)
+    brief = _research_brief(
+        platforms=["linkedin", "x"],
+        trending_topics=["remote work culture"],
+        researched_at=researched_at,
+        platform_trends={
+            "linkedin": [
+                {"title": "B2B thought leadership on the rise", "url": "u1", "content": "..."}
+            ],
+            "x": [
+                {"title": "Breaking: real-time news cycle trends", "url": "u2", "content": "..."}
+            ],
+        },
+    )
+    _log_research_run(db_session, post, brief)
+
+    linkedin_suggestion = suggest_target_datetime(db_session, brand.id, "linkedin")
+    x_suggestion = suggest_target_datetime(db_session, brand.id, "x")
+
+    assert linkedin_suggestion.target_datetime != x_suggestion.target_datetime
+    assert "linkedin" in linkedin_suggestion.reasoning
+    assert "x" in x_suggestion.reasoning
+    assert linkedin_suggestion.reasoning != x_suggestion.reasoning
+
+
+@uses_test_session
+def test_suggestion_uses_most_recent_research_run(db_session) -> None:
+    brand, _user = _setup_brand(db_session)
+    researched_at = datetime(2026, 8, 1, tzinfo=timezone.utc)
+
+    old_post = _make_post(db_session, brand)
+    _log_research_run(
+        db_session,
+        old_post,
+        _research_brief(
+            platforms=["linkedin"],
+            trending_topics=["old topic"],
+            researched_at=researched_at,
+        ),
+        created_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+    )
+
+    new_post = _make_post(db_session, brand)
+    newest_run = _log_research_run(
+        db_session,
+        new_post,
+        _research_brief(
+            platforms=["linkedin"],
+            trending_topics=["fresh topic"],
+            researched_at=researched_at + timedelta(days=1),
+        ),
+        created_at=datetime(2026, 2, 1, tzinfo=timezone.utc),
+    )
+
+    suggestion = suggest_target_datetime(db_session, brand.id, "linkedin")
+
+    assert suggestion.source["agent_run_id"] == str(newest_run.id)
+
+
+@uses_test_session
+def test_suggestion_never_in_the_past(db_session) -> None:
+    """A research run from far in the past must still yield a future
+    suggestion (not, say, a date years ago)."""
+    brand, _user = _setup_brand(db_session)
+    post = _make_post(db_session, brand)
+    _log_research_run(
+        db_session,
+        post,
+        _research_brief(
+            platforms=["linkedin"],
+            trending_topics=["ancient history"],
+            researched_at=datetime(2020, 1, 1, tzinfo=timezone.utc),
+        ),
+    )
+
+    suggestion = suggest_target_datetime(db_session, brand.id, "linkedin")
+
+    assert suggestion.target_datetime > datetime.now(timezone.utc)
+
+
+# --- API-level (create-event) tests -------------------------------------
+
+
+@uses_test_session
+def test_create_event_without_target_datetime_uses_suggestion(db_session) -> None:
+    brand, user = _setup_brand(db_session)
+    post = _make_post(db_session, brand)
+    _log_research_run(
+        db_session,
+        post,
+        _research_brief(
+            platforms=["linkedin"],
+            trending_topics=["auto-scheduling launch"],
+            researched_at=datetime.now(timezone.utc),
+        ),
+    )
+
+    response = client.post(
+        f"/brands/{brand.id}/calendar-events",
+        json=_payload(target_platforms=["linkedin"]),
+        headers=_auth_headers(user),
+    )
+
+    assert response.status_code == 201
+    body = response.json()
+    assert body["target_datetime"] is not None
+    suggested = datetime.fromisoformat(body["target_datetime"].replace("Z", "+00:00"))
+    assert suggested > datetime.now(timezone.utc)
+
+
+@uses_test_session
+def test_create_event_explicit_target_datetime_not_overridden(db_session) -> None:
+    brand, user = _setup_brand(db_session)
+    post = _make_post(db_session, brand)
+    _log_research_run(
+        db_session,
+        post,
+        _research_brief(
+            platforms=["linkedin"],
+            trending_topics=["some trend"],
+            researched_at=datetime.now(timezone.utc),
+        ),
+    )
+
+    explicit = "2026-09-15T09:30:00Z"
+    response = client.post(
+        f"/brands/{brand.id}/calendar-events",
+        json=_payload(target_platforms=["linkedin"], target_datetime=explicit),
+        headers=_auth_headers(user),
+    )
+
+    assert response.status_code == 201
+    body = response.json()
+    assert datetime.fromisoformat(body["target_datetime"]) == datetime.fromisoformat(explicit.replace("Z", "+00:00"))
+
+
+@uses_test_session
+def test_create_event_without_datetime_and_without_signal_returns_422(db_session) -> None:
+    brand, user = _setup_brand(db_session)
+
+    response = client.post(
+        f"/brands/{brand.id}/calendar-events",
+        json=_payload(target_platforms=["linkedin"]),
+        headers=_auth_headers(user),
+    )
+
+    assert response.status_code == 422
+
+
+@uses_test_session
+def test_update_does_not_reset_target_datetime_when_omitted(db_session) -> None:
+    brand, user = _setup_brand(db_session)
+    headers = _auth_headers(user)
+    created = client.post(
+        f"/brands/{brand.id}/calendar-events",
+        json=_payload(target_platforms=["linkedin"], target_datetime="2026-09-01T12:00:00Z"),
+        headers=headers,
+    ).json()
+
+    response = client.patch(
+        f"/brands/{brand.id}/calendar-events/{created['id']}",
+        json={"status": "approved"},
+        headers=headers,
+    )
+
+    assert response.status_code == 200
+    assert datetime.fromisoformat(response.json()["target_datetime"]) == datetime.fromisoformat(
+        "2026-09-01T12:00:00+00:00"
+    )
+
+
+@uses_test_session
+def test_update_respects_explicit_target_datetime_override(db_session) -> None:
+    brand, user = _setup_brand(db_session)
+    headers = _auth_headers(user)
+    created = client.post(
+        f"/brands/{brand.id}/calendar-events",
+        json=_payload(target_platforms=["linkedin"], target_datetime="2026-09-01T12:00:00Z"),
+        headers=headers,
+    ).json()
+
+    response = client.patch(
+        f"/brands/{brand.id}/calendar-events/{created['id']}",
+        json={"target_datetime": "2026-10-05T08:00:00Z"},
+        headers=headers,
+    )
+
+    assert response.status_code == 200
+    assert datetime.fromisoformat(response.json()["target_datetime"]) == datetime.fromisoformat(
+        "2026-10-05T08:00:00+00:00"
+    )


### PR DESCRIPTION
## What

Adds `apps/api/services/scheduling_suggestion.py`: a suggestion service that reads the Research Engine's (#19) `timing_signal` back from the most recent `AgentRun(agent_type=research)` row for a brand/platform (research briefs aren't persisted standalone — see `packages/agents/pipeline/graph.py`'s `run_pipeline`, which already logs each stage's raw output dict onto `AgentRun.output`), and derives a suggested `target_datetime` for a new `ContentCalendarEvent` (#26).

The suggested day/hour/minute is a hash of the signal's actual content — the run's trending topics plus that platform's own trend search results (`research_brief["platform_trends"][platform]`) — not a hardcoded time-of-day table. Same content always reproduces the same suggestion; different content (different trending topics, different platform search results, or a different platform entirely) produces a different one.

Wired into `POST /brands/{brand_id}/calendar-events`:
- `target_datetime` is now optional on `CalendarEventCreate`.
- Omitted -> the suggestion service is consulted for the event's first `target_platforms` entry. If no research signal is available yet for that brand/platform, the endpoint returns `422` asking for an explicit `target_datetime` rather than fabricating one.
- Provided -> always used as-is; the suggestion service is never consulted, so an explicit choice can't be silently overridden.
- `PATCH` (update) already respected explicit values via `model_dump(exclude_unset=True)`, so no change was needed there — omitting `target_datetime` on update never resets it.

## Why

The Research Engine already computes a `timing_signal` (trending topics, platforms researched, `researched_at`) but nothing consumed it — it just sat unused in the research brief. This closes that loop: real research signal in, real suggested publish time out, which the user can accept or override when creating a calendar event.

## Test plan

`apps/api/tests/test_scheduling_suggestion.py` (12 tests, all passing):
- Service raises `NoResearchSignalError` when no research run exists for the brand, or when the requested platform isn't covered by the most recent signal.
- Suggestion is derived from real signal content, not hardcoded: two research briefs with different trending topics produce different `target_datetime`s (from the same platform).
- Suggestion is reproducible for identical signal content.
- Suggestion differs across at least 2 platforms (`linkedin` and `x`) from the very same research run, driven by each platform's own trend search results.
- Suggestion always uses the most recent research run for the brand.
- Suggestion is never in the past even when the underlying research run is old.
- API-level: create without `target_datetime` uses the suggestion; create with an explicit `target_datetime` is respected and not overridden even when a research signal exists; create without `target_datetime` and without any research signal returns 422; update never resets `target_datetime` when omitted; update respects an explicit override.

Ran locally against a scratch DB (`raindeer_test_issue28`, migrated via `alembic upgrade head`):

```
pytest apps/api/tests packages/agents/tests -v --cov=apps/api --cov=packages --cov-fail-under=70
```

Result: **192 passed**, coverage **98.03%** (>= 70% required). No pre-existing test failures observed in this run (including the sometimes-flaky `test_connect_503_when_linkedin_not_configured`, which passed).

## Note on branch base

This PR targets `feature/issue-24-reviewer-engine`, the same base as #25 (sibling branch, not yet merged). Both branches build on #24 independently and will need reconciliation when merged — expected, not something this PR tries to avoid.

Closes #28