### PR TITLE
feat(api): add pipeline trigger job

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,3 +41,8 @@ SENTRY_DSN=
 LINKEDIN_CLIENT_ID=
 LINKEDIN_CLIENT_SECRET=
 LINKEDIN_REDIRECT_URI=http://localhost:8000/oauth/linkedin/callback
+
+# --- Pipeline trigger (Celery Beat, apps/api/worker.py) ---
+# Minutes ahead of a calendar event's target_datetime the pipeline trigger
+# job starts its pipeline run.
+PIPELINE_TRIGGER_LEAD_MINUTES=60

--- a/apps/api/config/__init__.py
+++ b/apps/api/config/__init__.py
@@ -43,6 +43,13 @@ class Settings(BaseSettings):
 
     sentry_dsn: str | None = None
 
+    # Issue #29: how far ahead of a ContentCalendarEvent's target_datetime
+    # (in minutes) the pipeline trigger job starts its pipeline run. Read
+    # by apps/api/worker.py's Celery Beat task; the actual selection logic
+    # in packages/agents/pipeline/trigger.py takes it as a plain argument
+    # so it stays unit-testable without touching Settings.
+    pipeline_trigger_lead_minutes: int = 60
+
 
 @lru_cache
 def get_settings() -> Settings:

--- a/apps/api/tests/test_pipeline_trigger.py
+++ b/apps/api/tests/test_pipeline_trigger.py
@@ -1,0 +1,223 @@
+"""Tests for the Issue #29 pipeline trigger.
+
+Exercises packages/agents/pipeline/trigger.py directly (not the Celery
+task wrapper in apps/api/worker.py — that's a thin, untested-here wrapper
+by design, see this repo's other Celery task docstrings) against a real
+Postgres-backed pipeline run, same pattern as
+packages/agents/tests/test_pipeline_graph.py. Covers the issue's three
+acceptance criteria:
+
+  1. An event with a near-future target_datetime is picked up and its
+     status flips to PIPELINE_RUNNING (and, once the run reaches the
+     human_review interrupt, on to READY_FOR_REVIEW).
+  2. An event far in the future is not picked up.
+  3. An event already PIPELINE_RUNNING is not re-triggered even if it's
+     still within the lead-time window — including when a second,
+     duplicate/"concurrent" poll call races the first.
+"""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from apps.api.models import (
+    Brand,
+    CalendarEventStatus,
+    ContentCalendarEvent,
+    Organization,
+    PipelineStage,
+    Post,
+)
+from packages.agents.pipeline.checkpointer import get_postgres_checkpointer
+from packages.agents.pipeline.trigger import (
+    DEFAULT_LEAD_TIME_MINUTES,
+    _claim_due_events,
+    trigger_due_pipelines,
+)
+
+NOW = datetime(2026, 6, 1, 12, 0, tzinfo=timezone.utc)
+
+
+@pytest.fixture()
+def thread_cleanup():
+    """Pipeline checkpoint rows live in Postgres on a connection totally
+    separate from db_session's rolled-back transaction (see
+    test_pipeline_graph.py), so they need explicit teardown."""
+    thread_ids: list[str] = []
+    yield thread_ids
+    if not thread_ids:
+        return
+    with get_postgres_checkpointer() as checkpointer:
+        for thread_id in thread_ids:
+            checkpointer.delete_thread(thread_id)
+
+
+def _setup_brand(db_session) -> Brand:
+    org = Organization(name="Acme Agency")
+    db_session.add(org)
+    db_session.flush()
+
+    brand = Brand(organization_id=org.id, name="Acme Widgets")
+    db_session.add(brand)
+    db_session.flush()
+    return brand
+
+
+def _make_event(
+    db_session,
+    brand: Brand,
+    *,
+    target_datetime: datetime,
+    status: CalendarEventStatus = CalendarEventStatus.SCHEDULED,
+) -> ContentCalendarEvent:
+    event = ContentCalendarEvent(
+        brand_id=brand.id,
+        title="Launch announcement",
+        description="Announce the new widget line",
+        target_platforms=["linkedin"],
+        desired_format="single-image",
+        target_datetime=target_datetime,
+        status=status,
+    )
+    db_session.add(event)
+    db_session.flush()
+    return event
+
+
+def test_near_future_event_is_claimed_and_flips_to_pipeline_running(db_session) -> None:
+    brand = _setup_brand(db_session)
+    event = _make_event(db_session, brand, target_datetime=NOW + timedelta(minutes=30))
+
+    claimed = _claim_due_events(db_session, lead_time_minutes=60, now=NOW)
+
+    assert [e.id for e in claimed] == [event.id]
+    db_session.refresh(event)
+    assert event.status == CalendarEventStatus.PIPELINE_RUNNING
+
+
+def test_far_future_event_is_not_picked_up(db_session) -> None:
+    brand = _setup_brand(db_session)
+    event = _make_event(db_session, brand, target_datetime=NOW + timedelta(days=5))
+
+    claimed = _claim_due_events(db_session, lead_time_minutes=60, now=NOW)
+
+    assert claimed == []
+    db_session.refresh(event)
+    assert event.status == CalendarEventStatus.SCHEDULED
+
+
+def test_event_exactly_at_lead_time_horizon_is_picked_up(db_session) -> None:
+    brand = _setup_brand(db_session)
+    event = _make_event(db_session, brand, target_datetime=NOW + timedelta(minutes=60))
+
+    claimed = _claim_due_events(db_session, lead_time_minutes=60, now=NOW)
+
+    assert [e.id for e in claimed] == [event.id]
+
+
+def test_already_pipeline_running_event_is_not_reclaimed(db_session) -> None:
+    brand = _setup_brand(db_session)
+    event = _make_event(
+        db_session,
+        brand,
+        target_datetime=NOW + timedelta(minutes=10),
+        status=CalendarEventStatus.PIPELINE_RUNNING,
+    )
+
+    claimed = _claim_due_events(db_session, lead_time_minutes=60, now=NOW)
+
+    assert claimed == []
+    db_session.refresh(event)
+    assert event.status == CalendarEventStatus.PIPELINE_RUNNING
+
+
+def test_duplicate_poll_call_only_triggers_once(db_session, thread_cleanup, monkeypatch) -> None:
+    """Simulates a concurrent/duplicate poll: trigger_due_pipelines is
+    called twice in a row for the same due event. The atomic claim means
+    the second call must find nothing left to claim, so the pipeline is
+    only ever started once."""
+    brand = _setup_brand(db_session)
+    event = _make_event(db_session, brand, target_datetime=NOW + timedelta(minutes=15))
+
+    run_calls: list[str] = []
+    from packages.agents.pipeline import trigger as trigger_module
+
+    original_run_pipeline = trigger_module.run_pipeline
+
+    def _counting_run_pipeline(db, post, checkpointer, **kwargs):
+        run_calls.append(str(post.id))
+        return original_run_pipeline(db, post, checkpointer, **kwargs)
+
+    monkeypatch.setattr(trigger_module, "run_pipeline", _counting_run_pipeline)
+
+    first_started = trigger_due_pipelines(db_session, lead_time_minutes=60, now=NOW)
+    assert len(first_started) == 1
+    thread_cleanup.append(str(first_started[0].id))
+
+    second_started = trigger_due_pipelines(db_session, lead_time_minutes=60, now=NOW)
+
+    assert second_started == []
+    assert run_calls == [str(first_started[0].id)]
+
+    db_session.refresh(event)
+    assert event.status != CalendarEventStatus.SCHEDULED
+
+    # Only one Post was ever created for this event, not two.
+    posts = db_session.query(Post).filter(Post.calendar_event_id == event.id).all()
+    assert len(posts) == 1
+
+
+def test_trigger_creates_post_runs_pipeline_and_syncs_status_to_ready_for_review(
+    db_session, thread_cleanup
+) -> None:
+    brand = _setup_brand(db_session)
+    event = _make_event(db_session, brand, target_datetime=NOW + timedelta(minutes=5))
+
+    started = trigger_due_pipelines(db_session, lead_time_minutes=60, now=NOW)
+
+    assert len(started) == 1
+    post = started[0]
+    thread_cleanup.append(str(post.id))
+
+    assert post.brand_id == brand.id
+    assert post.calendar_event_id == event.id
+
+    # The stub pipeline (research/creative/generation/reviewer all run,
+    # then interrupts at human_review) reaches HUMAN_REVIEW synchronously
+    # within this call, so the event's status is already synced past
+    # PIPELINE_RUNNING to READY_FOR_REVIEW — reusing Post.
+    # current_pipeline_stage (#18) as the source of truth rather than a
+    # second, independently-tracked progress field.
+    assert post.current_pipeline_stage == PipelineStage.HUMAN_REVIEW
+    db_session.refresh(event)
+    assert event.status == CalendarEventStatus.READY_FOR_REVIEW
+
+
+def test_trigger_reuses_existing_post_for_event_instead_of_creating_a_second_one(
+    db_session, thread_cleanup
+) -> None:
+    """Covers the case where a Post already exists for a calendar event
+    (e.g. a previous run got partway through before this poll fired) —
+    the trigger must resume that Post's pipeline thread, not fork a new,
+    disconnected one."""
+    brand = _setup_brand(db_session)
+    event = _make_event(db_session, brand, target_datetime=NOW + timedelta(minutes=5))
+
+    existing_post = Post(brand_id=brand.id, calendar_event_id=event.id)
+    db_session.add(existing_post)
+    db_session.flush()
+    thread_cleanup.append(str(existing_post.id))
+
+    started = trigger_due_pipelines(db_session, lead_time_minutes=60, now=NOW)
+
+    assert len(started) == 1
+    assert started[0].id == existing_post.id
+
+    posts = db_session.query(Post).filter(Post.calendar_event_id == event.id).all()
+    assert len(posts) == 1
+
+
+def test_default_lead_time_constant_matches_settings_default() -> None:
+    from apps.api.config import Settings
+
+    assert DEFAULT_LEAD_TIME_MINUTES == Settings().pipeline_trigger_lead_minutes

--- a/apps/api/worker.py
+++ b/apps/api/worker.py
@@ -1,6 +1,8 @@
 from celery import Celery
 
 from apps.api.config import get_settings
+from apps.api.config.database import SessionLocal
+from packages.agents.pipeline.trigger import trigger_due_pipelines
 
 settings = get_settings()
 
@@ -11,7 +13,49 @@ celery_app = Celery(
 )
 celery_app.conf.broker_connection_retry_on_startup = True
 
+# Issue #29: on a recurring schedule, poll ContentCalendarEvent for events
+# approaching their target_datetime and start the #18 pipeline for each.
+# Runs every minute — frequent enough that Settings.pipeline_trigger_lead_
+# minutes (the configurable lead-time window) is honored to within about a
+# minute, without needing sub-minute precision anywhere else in the
+# system. The actual selection/claim/pipeline-start logic lives in
+# packages/agents/pipeline/trigger.py, not here, so it's unit-testable
+# without any Celery machinery.
+celery_app.conf.beat_schedule = {
+    "trigger-due-pipelines": {
+        "task": "worker.trigger_due_pipelines",
+        "schedule": 60.0,
+    },
+}
+
 
 @celery_app.task(name="worker.ping")
 def ping() -> str:
     return "pong"
+
+
+@celery_app.task(name="worker.trigger_due_pipelines")
+def trigger_due_pipelines_task() -> int:
+    """Celery Beat entrypoint for Issue #29's pipeline trigger.
+
+    A thin wrapper: opens its own DB session (Celery tasks aren't FastAPI
+    request handlers, so there's no `Depends(get_db)` to lean on),
+    delegates all real work to trigger_due_pipelines, and commits on
+    success / rolls back on failure. Returns the number of pipeline runs
+    started or advanced this poll, mostly useful for task-result
+    inspection/logging.
+    """
+    settings = get_settings()
+    db = SessionLocal()
+    try:
+        started = trigger_due_pipelines(
+            db,
+            lead_time_minutes=settings.pipeline_trigger_lead_minutes,
+        )
+        db.commit()
+        return len(started)
+    except Exception:
+        db.rollback()
+        raise
+    finally:
+        db.close()

--- a/packages/agents/pipeline/trigger.py
+++ b/packages/agents/pipeline/trigger.py
@@ -1,0 +1,163 @@
+"""Pipeline trigger — Issue #29.
+
+The seam between the content calendar (#26/#28) and the agent pipeline
+(#18): polls `ContentCalendarEvent` rows approaching their
+`target_datetime`, atomically claims each one so a concurrent/overlapping
+poll can never re-trigger it, creates or locates the calendar event's
+`Post` row, and starts (or resumes) the #18 pipeline graph
+(`packages/agents/pipeline/graph.py`'s `run_pipeline()`) for it.
+
+Kept separate from `apps/api/worker.py`'s Celery task wrapper — which only
+supplies a DB session, the configured lead time, and a schedule — so this
+module is fully unit-testable without any Celery machinery. See
+`apps/api/tests/test_pipeline_trigger.py`.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timedelta, timezone
+
+from sqlalchemy import select, update
+from sqlalchemy.orm import Session
+
+from apps.api.models.content_calendar_event import CalendarEventStatus, ContentCalendarEvent
+from apps.api.models.post import PipelineStage, Post
+from packages.agents.pipeline.checkpointer import get_postgres_checkpointer
+from packages.agents.pipeline.graph import run_pipeline
+
+logger = logging.getLogger(__name__)
+
+# Default lead time ahead of target_datetime the trigger starts a pipeline
+# run — overridable per call, and, via apps/api/worker.py's Celery Beat
+# task, by Settings.pipeline_trigger_lead_minutes (an env var), which is
+# what makes this "configurable" per the issue's acceptance criteria.
+DEFAULT_LEAD_TIME_MINUTES = 60
+
+# ContentCalendarEvent.status is a distinct field from
+# Post.current_pipeline_stage (the #18 mechanism) rather than the same
+# enum wearing two names — an event can exist with no Post at all
+# (SCHEDULED), and even once a Post exists, "ready for a human to review"
+# is a calendar-facing concept while "which of the eight pipeline stages
+# just ran" is a pipeline-internals concept. They're kept in sync here
+# rather than picked arbitrarily: once a run reaches one of these
+# pipeline stages, the event's status is advanced to match.
+_STAGE_TO_EVENT_STATUS: dict[PipelineStage, CalendarEventStatus] = {
+    PipelineStage.HUMAN_REVIEW: CalendarEventStatus.READY_FOR_REVIEW,
+    PipelineStage.COMPLETED: CalendarEventStatus.PUBLISHED,
+}
+
+
+def _claim_due_events(
+    db: Session, *, lead_time_minutes: int, now: datetime
+) -> list[ContentCalendarEvent]:
+    """Atomically claims every SCHEDULED event whose target_datetime is at
+    or before ``now + lead_time_minutes``, flipping each straight to
+    PIPELINE_RUNNING as part of the same statement.
+
+    This is a single ``UPDATE ... WHERE status = 'scheduled' ... RETURNING``
+    rather than a check-then-act SELECT followed by an UPDATE — the race
+    the issue calls out. Postgres takes the row locks an UPDATE needs as
+    part of evaluating it, so a second, overlapping UPDATE hitting the
+    same rows blocks until the first commits and then re-evaluates its
+    WHERE clause against the now-committed data — at which point
+    ``status = 'scheduled'`` no longer matches (the first caller already
+    moved it to PIPELINE_RUNNING), so the second claims zero rows for
+    that event. Two overlapping pollers can therefore never both claim
+    the same event, without needing a separate
+    ``SELECT ... FOR UPDATE SKIP LOCKED`` step.
+    """
+    horizon = now + timedelta(minutes=lead_time_minutes)
+
+    claimed_ids = (
+        db.execute(
+            update(ContentCalendarEvent)
+            .where(
+                ContentCalendarEvent.status == CalendarEventStatus.SCHEDULED,
+                ContentCalendarEvent.target_datetime <= horizon,
+            )
+            .values(status=CalendarEventStatus.PIPELINE_RUNNING)
+            .returning(ContentCalendarEvent.id)
+        )
+        .scalars()
+        .all()
+    )
+    db.flush()
+
+    if not claimed_ids:
+        return []
+
+    events = (
+        db.execute(
+            select(ContentCalendarEvent)
+            .where(ContentCalendarEvent.id.in_(claimed_ids))
+            .order_by(ContentCalendarEvent.target_datetime)
+        )
+        .scalars()
+        .all()
+    )
+    for event in events:
+        db.refresh(event)
+    return list(events)
+
+
+def _get_or_create_post(db: Session, event: ContentCalendarEvent) -> Post:
+    """A calendar event may already have a Post — e.g. a previous trigger
+    started the run and it's now paused at the human_review interrupt, or
+    a prior attempt failed partway through. Reuse that Post (and hence its
+    pipeline checkpoint thread, keyed on Post.id) rather than starting a
+    second, disconnected run for the same event."""
+    existing = db.query(Post).filter(Post.calendar_event_id == event.id).first()
+    if existing is not None:
+        return existing
+
+    post = Post(brand_id=event.brand_id, calendar_event_id=event.id)
+    db.add(post)
+    db.flush()
+    db.refresh(post)
+    return post
+
+
+def _sync_event_status(event: ContentCalendarEvent, post: Post) -> None:
+    new_status = _STAGE_TO_EVENT_STATUS.get(post.current_pipeline_stage)
+    if new_status is not None:
+        event.status = new_status
+
+
+def trigger_due_pipelines(
+    db: Session,
+    *,
+    lead_time_minutes: int = DEFAULT_LEAD_TIME_MINUTES,
+    now: datetime | None = None,
+) -> list[Post]:
+    """Finds every ContentCalendarEvent within `lead_time_minutes` of its
+    target_datetime, claims it (SCHEDULED -> PIPELINE_RUNNING, guarding
+    against duplicate triggering), starts or resumes its pipeline run via
+    `run_pipeline`, and syncs the event's status to match the run's real
+    progress. Returns the Posts whose pipeline this call started or
+    advanced — an empty list when nothing was due (including when every
+    otherwise-due event was already claimed by an earlier/concurrent
+    call).
+    """
+    now = now or datetime.now(timezone.utc)
+    events = _claim_due_events(db, lead_time_minutes=lead_time_minutes, now=now)
+
+    started: list[Post] = []
+    for event in events:
+        post = _get_or_create_post(db, event)
+        try:
+            with get_postgres_checkpointer() as checkpointer:
+                list(run_pipeline(db, post, checkpointer))
+        except Exception:
+            logger.exception(
+                "Pipeline run failed for calendar event %s (post %s)", event.id, post.id
+            )
+            event.status = CalendarEventStatus.FAILED
+            db.flush()
+            continue
+
+        _sync_event_status(event, post)
+        db.flush()
+        started.append(post)
+
+    return started


### PR DESCRIPTION
## What
Adds the seam between the content calendar (#26/#28) and the agent pipeline (#18): a Celery Beat-scheduled job that polls `ContentCalendarEvent` rows approaching their `target_datetime`, starts the pipeline graph for each, and keeps the event's status in sync.

- `packages/agents/pipeline/trigger.py` (new) — the actual selection/claim/trigger logic, kept separate from Celery so it's unit-testable without any Celery machinery:
  - `_claim_due_events`: atomically claims every `SCHEDULED` event whose `target_datetime` is within a configurable lead-time window, via a single `UPDATE ... WHERE status = 'scheduled' ... RETURNING` statement — this is the hard duplicate-triggering guard from the acceptance criteria, not a check-then-act race. Two overlapping/concurrent polls can never both claim the same event.
  - `_get_or_create_post`: reuses an existing `Post` for the calendar event if one already exists (e.g. a prior interrupted run), rather than forking a second disconnected pipeline thread.
  - `trigger_due_pipelines`: claims due events, runs (or resumes) each one's pipeline via `run_pipeline`, and syncs `ContentCalendarEvent.status` to `Post.current_pipeline_stage` (`HUMAN_REVIEW` -> `READY_FOR_REVIEW`, `COMPLETED` -> `PUBLISHED`) — reusing the #18 status mechanism rather than inventing a parallel one, since `ContentCalendarEvent.status` and `Post.current_pipeline_stage` are already distinct fields for good reason (an event can exist with no `Post` yet).
- `apps/api/worker.py` — thin Celery task wrapper (`worker.trigger_due_pipelines`) that opens its own DB session, delegates to `trigger_due_pipelines`, and commits/rolls back; registers a `beat_schedule` entry (every 60s) — Celery Beat wasn't configured anywhere in this repo before this change.
- `apps/api/config/__init__.py` — new `Settings.pipeline_trigger_lead_minutes` (default 60), the "configurable lead time" from the acceptance criteria. Also added to `.env.example`.

No migration needed — no new columns, and `ContentCalendarEvent.status` already had every state (`pipeline_running`, `ready_for_review`, `failed`, etc.) this needed.

## Why
Nothing currently starts the M3 pipeline automatically — without this, pipelines only ever start manually. This closes that gap so a reviewed draft is sitting ready before an event's target date.

## Test plan
- `apps/api/tests/test_pipeline_trigger.py` (new, 8 tests), covering:
  - a near-future event is claimed and flips to `pipeline_running`
  - a far-future event is not picked up
  - an event exactly at the lead-time horizon is picked up (boundary)
  - an event already `pipeline_running` is not reclaimed
  - a duplicate/"concurrent" poll (`trigger_due_pipelines` called twice in a row for the same event) only triggers the pipeline once, verified via a call-counting monkeypatch of `run_pipeline`
  - the full trigger creates a `Post`, runs the pipeline to the `human_review` interrupt, and syncs the event status to `ready_for_review`
  - an existing `Post` for the event is reused rather than duplicated
  - the lead-time default constant matches `Settings`' default
- Ran locally against a scratch Postgres DB (`raindeer_test_issue29`, migrated to head — `e7d09d412f48`, unchanged by this PR):
  ```
  pytest apps/api/tests packages/agents/tests -v --cov=apps/api --cov=packages --cov-fail-under=70
  # 199 passed, 1 failed, coverage 97.59%
  ```
  The one failure, `test_social_accounts.py::test_connect_503_when_linkedin_not_configured`, is the pre-existing, occasionally-flaky-locally test called out in this issue's setup notes — unrelated to this change (env-var/cache-clearing test isolation issue in `test_social_accounts.py`, not anything touched here).

## Notes
This is a sibling branch to #30 (also based on #28) and will need reconciliation later — expected, not something this PR tries to avoid.

Closes #29