### PR TITLE
feat(api): add engagement-metrics polling jobs

### DIFF
--- a/apps/api/models/__init__.py
+++ b/apps/api/models/__init__.py
@@ -6,6 +6,7 @@ from apps.api.models.content_calendar_event import (
     CalendarEventStatus,
     ContentCalendarEvent,
 )
+from apps.api.models.engagement_snapshot import EngagementSnapshot
 from apps.api.models.integration_call import IntegrationCall
 from apps.api.models.onboarding_research import OnboardingResearch
 from apps.api.models.onboarding_response import OnboardingResponse
@@ -24,6 +25,7 @@ __all__ = [
     "BrandReportChunk",
     "CalendarEventStatus",
     "ContentCalendarEvent",
+    "EngagementSnapshot",
     "IntegrationCall",
     "OnboardingResearch",
     "OnboardingResponse",

--- a/apps/api/models/engagement_snapshot.py
+++ b/apps/api/models/engagement_snapshot.py
@@ -1,0 +1,52 @@
+import uuid
+from datetime import datetime
+
+from sqlalchemy import DateTime, ForeignKey, Integer, String, func
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from apps.api.config.database import Base
+
+
+class EngagementSnapshot(Base):
+    """Immutable time-series log of a published Post's engagement metrics
+    on one platform — one row appended per poll (Issue #33's
+    apps/api/services/engagement_polling.py), same "append a log row,
+    never overwrite" convention AgentRun/PostVersion already establish
+    (see apps/api/models/agent_run.py, apps/api/models/post_version.py).
+    A post polled repeatedly over its lifetime accumulates many rows here,
+    each capturing whatever the platform reported *at that poll* — never
+    updated in place, so #34's dashboard and #35's weekly report (and
+    eventually #19/#28's timing signal) can read real engagement growth
+    over time instead of only ever seeing the latest count."""
+
+    __tablename__ = "engagement_snapshots"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    post_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("posts.id"), nullable=False
+    )
+    # A plain string, not apps/api/models/social_account.py's
+    # SocialPlatform enum — that enum only defines LINKEDIN today (X has
+    # no connectable SocialAccount row yet), while a post's *published*
+    # platforms (Post.publish_results, Issue #31) can include "x". Same
+    # choice content_calendar_event.py's target_platforms already made,
+    # for the same reason (see that module's SUPPORTED_PLATFORMS).
+    platform: Mapped[str] = mapped_column(String, nullable=False)
+
+    # Cumulative counts as reported by the platform at polled_at — not
+    # deltas since the previous snapshot. Defaults of 0 rather than
+    # nullable: a poll that succeeded always has a real number for every
+    # metric the platform reports (a metric the platform doesn't support
+    # at all comes back 0, not NULL — there's no "unknown" state for a
+    # snapshot that was actually written).
+    likes: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    comments: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    shares: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    impressions: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+
+    polled_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )

--- a/apps/api/services/engagement_polling.py
+++ b/apps/api/services/engagement_polling.py
@@ -1,0 +1,185 @@
+"""Engagement polling — Issue #33.
+
+Per-platform polling jobs that fetch likes/comments/shares/impressions
+for published posts and write EngagementSnapshot rows on a schedule — a
+true time series (one row appended per poll, never an overwrite of a
+previous row; see apps/api/models/engagement_snapshot.py).
+
+Same two-halves split #31's publish queue established
+(apps/api/services/publish_queue.py's module docstring):
+
+  * This file — the actual polling logic: find every Post with at least
+    one platform successfully published (Post.publish_results, #31),
+    resolve each published platform to a connected SocialAccount, call
+    #30's SocialPublisher.get_engagement() adapters
+    (packages.integrations.registry.get_social_publisher), and append an
+    EngagementSnapshot row per successful fetch. Plain functions taking a
+    Session, no Celery import anywhere — fully unit-testable without any
+    Celery/Redis machinery running.
+  * apps/api/worker.py — the thin Celery Beat + task wrapper around
+    find_posts_due_for_polling()/poll_post_engagement() below, which is
+    what actually gives this its schedule and its rate-limit backoff:
+    Celery's own autoretry_for/retry_backoff (built-in, not a hand-rolled
+    backoff loop) — the same mechanism, and the same reasoning, #31's
+    publish_post_task already uses.
+
+Unlike publish_post() (#31), a poll attempt has no notion of "already
+succeeded, don't repeat" to protect: publishing a platform twice would be
+a real duplicate post, but polling engagement twice just produces two
+data points close together in time, which is exactly what a time series
+is for. So poll_post_engagement() makes no attempt to skip platforms a
+previous, still-retrying attempt already polled successfully this
+round — every platform is (re)polled on every attempt, and every
+successful fetch's snapshot row is committed regardless of whether a
+sibling platform's fetch on that same attempt failed.
+
+Rate limits: get_engagement() never raises for a rate-limited response
+(HTTP 429) — it comes back as EngagementResult(success=False,
+rate_limited=True), same "adapter never raises, caller decides" shape
+#30's publish() already uses for ordinary failures. This module turns
+that (like any other per-platform failure) into EngagementPollFailed,
+which apps/api/worker.py's Celery task retries with exponential backoff
+via autoretry_for/retry_backoff — so a rate-limited platform is backed
+off and retried later, never hammered with immediate retries, and never
+crashes the poll for a post's other platforms or for other posts in the
+same sweep (find_posts_due_for_polling() fans out one Celery task per
+post; one post's task raising/retrying doesn't affect any other post's).
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+
+from sqlalchemy.orm import Session
+
+from apps.api.models import (
+    EngagementSnapshot,
+    Post,
+    SocialAccount,
+    SocialAccountStatus,
+    SocialPlatform,
+)
+from packages.integrations.registry import get_social_publisher
+from packages.integrations.social.encryption import decrypt_token
+
+logger = logging.getLogger(__name__)
+
+
+class PostNotFoundError(Exception):
+    """Raised when poll_post_engagement() is asked to act on a post_id
+    that doesn't resolve to a Post row — a programming/data error (the
+    Celery task was enqueued with a bad id), not a polling failure."""
+
+
+class EngagementPollFailed(Exception):
+    """Raised by poll_post_engagement() when at least one of a post's
+    published platforms failed to return engagement data on this attempt
+    (including being rate-limited). Callers that want durable retry
+    (apps/api/worker.py's Celery task) are expected to retry the call —
+    see module docstring for why every platform is simply re-polled on
+    retry rather than skipping ones that already succeeded."""
+
+
+def _published_platforms(post: Post) -> dict[str, str]:
+    """Returns {platform: platform_post_id} for every platform this post
+    actually succeeded in publishing to, per Post.publish_results (#31) —
+    the only platforms there's anything to poll engagement for. A post
+    that hasn't published anywhere yet (or only has failed attempts)
+    yields an empty dict."""
+    results = post.publish_results or {}
+    out: dict[str, str] = {}
+    for platform, entry in results.items():
+        if (
+            isinstance(entry, dict)
+            and entry.get("status") == "published"
+            and entry.get("platform_post_id")
+        ):
+            out[platform] = entry["platform_post_id"]
+    return out
+
+
+def find_posts_due_for_polling(db: Session) -> list[uuid.UUID]:
+    """Every Post with at least one platform successfully published is
+    due for a poll on every scheduled sweep. Unlike #29's pipeline
+    trigger there's no one-shot "claim" step guarding against
+    re-triggering — engagement metrics change continuously for the
+    lifetime of a post, so the same post is legitimately, deliberately
+    polled again on every sweep, each poll simply appending another
+    EngagementSnapshot row."""
+    rows = db.query(Post.id, Post.publish_results).filter(Post.publish_results.isnot(None)).all()
+    return [
+        post_id
+        for post_id, publish_results in rows
+        if any(
+            isinstance(entry, dict) and entry.get("status") == "published"
+            for entry in (publish_results or {}).values()
+        )
+    ]
+
+
+def poll_post_engagement(db: Session, post_id: uuid.UUID) -> list[EngagementSnapshot]:
+    """Makes one polling attempt, across every platform this post has
+    successfully published to, appending an EngagementSnapshot row for
+    each platform whose fetch succeeds. Raises EngagementPollFailed if
+    any platform's fetch failed on this attempt (after committing every
+    successful platform's snapshot row so nothing is silently dropped) —
+    see module docstring for the full retry model."""
+    post = db.get(Post, post_id)
+    if post is None:
+        raise PostNotFoundError(f"No Post found for post_id={post_id!r}")
+
+    platforms = _published_platforms(post)
+    snapshots: list[EngagementSnapshot] = []
+    errors: dict[str, str] = {}
+
+    for platform, platform_post_id in platforms.items():
+        try:
+            social_platform = SocialPlatform(platform)
+        except ValueError:
+            errors[platform] = f"Unsupported engagement-polling platform {platform!r}"
+            continue
+
+        account = (
+            db.query(SocialAccount)
+            .filter(SocialAccount.brand_id == post.brand_id, SocialAccount.platform == social_platform)
+            .first()
+        )
+        if (
+            account is None
+            or account.access_token_encrypted is None
+            or account.status != SocialAccountStatus.ACTIVE
+        ):
+            errors[platform] = f"No active {platform} account connected for this brand"
+            continue
+
+        publisher = get_social_publisher(platform)
+        access_token = decrypt_token(account.access_token_encrypted)
+
+        result = publisher.get_engagement(
+            access_token=access_token, platform_post_id=platform_post_id
+        )
+
+        if not result.success or result.metrics is None:
+            error = result.error or f"{platform} engagement fetch failed with no error detail"
+            errors[platform] = error
+            continue
+
+        snapshot = EngagementSnapshot(
+            post_id=post.id,
+            platform=platform,
+            likes=result.metrics.likes,
+            comments=result.metrics.comments,
+            shares=result.metrics.shares,
+            impressions=result.metrics.impressions,
+        )
+        db.add(snapshot)
+        db.flush()
+        snapshots.append(snapshot)
+
+    if errors:
+        raise EngagementPollFailed(
+            "; ".join(f"{platform}: {error}" for platform, error in errors.items())
+        )
+
+    return snapshots

--- a/apps/api/tests/test_engagement_polling.py
+++ b/apps/api/tests/test_engagement_polling.py
@@ -1,0 +1,370 @@
+"""Issue #33 — engagement-metrics polling jobs.
+
+Per the issue's acceptance criteria, these tests exercise three things:
+
+  1. A poll for a published post writes a new EngagementSnapshot row with
+     accurate metrics (mocking the platform adapter, same shape #31's
+     test_publish_queue.py already uses for SocialPublisher.publish).
+  2. Calling poll_post_engagement multiple times over "time" produces
+     multiple rows — a true time series, not an overwrite. Assertions
+     check row *count* growing, never that the latest row's values just
+     changed in place.
+  3. A rate-limited (429) response from the platform is backed off rather
+     than hammered or crashing the job: get_engagement() comes back
+     rate_limited=True (never raises), poll_post_engagement() turns that
+     into EngagementPollFailed, and apps/api/worker.py's Celery task is
+     configured with autoretry_for/retry_backoff on exactly that
+     exception — mirroring #31's publish_post_task retry-configuration
+     test below.
+
+Most of this exercises apps/api/services/engagement_polling.py's
+functions directly — no Celery/Redis involved — per the same
+unit-testable-without-that-machinery goal #31's publish queue has. A
+couple of tests at the bottom check apps/api/worker.py's Celery task
+wrappers: their retry configuration, and the beat-sweep fan-out.
+"""
+
+import uuid
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from apps.api.models import (
+    Brand,
+    Organization,
+    Post,
+    SocialAccount,
+    SocialAccountStatus,
+    SocialPlatform,
+)
+from apps.api.services import engagement_polling
+from packages.integrations.social.base import EngagementMetrics, EngagementResult
+from packages.integrations.social.encryption import encrypt_token
+
+
+def _setup_brand(db_session) -> Brand:
+    org = Organization(name="Acme Agency")
+    db_session.add(org)
+    db_session.flush()
+    brand = Brand(organization_id=org.id, name="Acme Widgets")
+    db_session.add(brand)
+    db_session.flush()
+    return brand
+
+
+def _connect_linkedin(
+    db_session, brand: Brand, status: SocialAccountStatus = SocialAccountStatus.ACTIVE
+) -> SocialAccount:
+    account = SocialAccount(
+        brand_id=brand.id,
+        platform=SocialPlatform.LINKEDIN,
+        access_token_encrypted=encrypt_token("real-access-token"),
+        status=status,
+    )
+    db_session.add(account)
+    db_session.flush()
+    return account
+
+
+def _make_published_post(db_session, brand: Brand, platform_post_id: str = "123") -> Post:
+    post = Post(
+        brand_id=brand.id,
+        body_text={"linkedin": "Hello world"},
+        publish_results={
+            "linkedin": {
+                "status": "published",
+                "platform_post_id": platform_post_id,
+                "platform_post_url": f"https://linkedin.com/p/{platform_post_id}",
+            }
+        },
+    )
+    db_session.add(post)
+    db_session.flush()
+    return post
+
+
+# --- poll_post_engagement: writes an accurate snapshot ---------------------
+
+
+def test_poll_writes_snapshot_with_accurate_metrics(db_session) -> None:
+    brand = _setup_brand(db_session)
+    _connect_linkedin(db_session, brand)
+    post = _make_published_post(db_session, brand)
+
+    publisher = MagicMock()
+    publisher.get_engagement.return_value = EngagementResult(
+        success=True,
+        metrics=EngagementMetrics(likes=10, comments=2, shares=1, impressions=500),
+    )
+
+    with patch.object(engagement_polling, "get_social_publisher", return_value=publisher):
+        snapshots = engagement_polling.poll_post_engagement(db_session, post.id)
+
+    assert len(snapshots) == 1
+    snapshot = snapshots[0]
+    assert snapshot.post_id == post.id
+    assert snapshot.platform == "linkedin"
+    assert snapshot.likes == 10
+    assert snapshot.comments == 2
+    assert snapshot.shares == 1
+    assert snapshot.impressions == 500
+    assert snapshot.polled_at is not None
+
+    publisher.get_engagement.assert_called_once_with(
+        access_token="real-access-token", platform_post_id="123"
+    )
+
+
+def test_poll_only_covers_platforms_actually_published(db_session) -> None:
+    """A platform present in Post.publish_results but not marked
+    "published" (e.g. it failed) has nothing to poll — only the platforms
+    that actually succeeded a publish attempt are engagement-pollable."""
+    brand = _setup_brand(db_session)
+    _connect_linkedin(db_session, brand)
+    post = Post(
+        brand_id=brand.id,
+        body_text={"linkedin": "Hello world", "x": "Hello world"},
+        publish_results={
+            "linkedin": {"status": "published", "platform_post_id": "123"},
+            "x": {"status": "failed", "error": "Unsupported publishing platform 'x'"},
+        },
+    )
+    db_session.add(post)
+    db_session.flush()
+
+    publisher = MagicMock()
+    publisher.get_engagement.return_value = EngagementResult(
+        success=True,
+        metrics=EngagementMetrics(likes=1, comments=0, shares=0, impressions=10),
+    )
+
+    with patch.object(engagement_polling, "get_social_publisher", return_value=publisher):
+        snapshots = engagement_polling.poll_post_engagement(db_session, post.id)
+
+    assert len(snapshots) == 1
+    assert snapshots[0].platform == "linkedin"
+    publisher.get_engagement.assert_called_once()
+
+
+def test_poll_missing_post_raises(db_session) -> None:
+    with pytest.raises(engagement_polling.PostNotFoundError):
+        engagement_polling.poll_post_engagement(db_session, uuid.uuid4())
+
+
+def test_poll_no_connected_account_raises_and_writes_nothing(db_session) -> None:
+    brand = _setup_brand(db_session)
+    post = _make_published_post(db_session, brand)
+
+    with pytest.raises(engagement_polling.EngagementPollFailed, match="No active linkedin account"):
+        engagement_polling.poll_post_engagement(db_session, post.id)
+
+    rows = engagement_polling.find_posts_due_for_polling(db_session)
+    assert post.id in rows  # still due — nothing was recorded for it
+
+
+# --- true time series: repeated polls append, never overwrite --------------
+
+
+def test_repeated_polls_append_rows_not_overwrite(db_session) -> None:
+    """Calling poll_post_engagement multiple times over "time" must grow
+    the row count each time — never just update a single row's values in
+    place."""
+    brand = _setup_brand(db_session)
+    _connect_linkedin(db_session, brand)
+    post = _make_published_post(db_session, brand)
+
+    publisher = MagicMock()
+    publisher.get_engagement.side_effect = [
+        EngagementResult(
+            success=True, metrics=EngagementMetrics(likes=5, comments=1, shares=0, impressions=100)
+        ),
+        EngagementResult(
+            success=True, metrics=EngagementMetrics(likes=12, comments=3, shares=1, impressions=250)
+        ),
+        EngagementResult(
+            success=True, metrics=EngagementMetrics(likes=20, comments=4, shares=2, impressions=400)
+        ),
+    ]
+
+    with patch.object(engagement_polling, "get_social_publisher", return_value=publisher):
+        engagement_polling.poll_post_engagement(db_session, post.id)
+        engagement_polling.poll_post_engagement(db_session, post.id)
+        engagement_polling.poll_post_engagement(db_session, post.id)
+
+    from apps.api.models import EngagementSnapshot
+
+    rows = (
+        db_session.query(EngagementSnapshot)
+        .filter(EngagementSnapshot.post_id == post.id)
+        .order_by(EngagementSnapshot.likes)
+        .all()
+    )
+    assert len(rows) == 3
+    assert [row.likes for row in rows] == [5, 12, 20]
+    # Every row is a distinct id — genuinely separate rows, not one row
+    # mutated three times.
+    assert len({row.id for row in rows}) == 3
+
+
+# --- rate limiting: backed off, not hammered or crashed ---------------------
+
+
+def test_rate_limited_response_backs_off_without_crashing(db_session) -> None:
+    brand = _setup_brand(db_session)
+    _connect_linkedin(db_session, brand)
+    post = _make_published_post(db_session, brand)
+
+    publisher = MagicMock()
+    publisher.get_engagement.return_value = EngagementResult(
+        success=False, error="LinkedIn rate-limited this engagement request", rate_limited=True
+    )
+
+    with patch.object(engagement_polling, "get_social_publisher", return_value=publisher):
+        with pytest.raises(engagement_polling.EngagementPollFailed, match="rate"):
+            engagement_polling.poll_post_engagement(db_session, post.id)
+
+    # A single rate-limited call, not hammered with immediate retries
+    # inside poll_post_engagement itself — durable retry is Celery's job
+    # (apps/api/worker.py's autoretry_for/retry_backoff), exercised below.
+    publisher.get_engagement.assert_called_once()
+
+    from apps.api.models import EngagementSnapshot
+
+    assert (
+        db_session.query(EngagementSnapshot).filter(EngagementSnapshot.post_id == post.id).count()
+        == 0
+    )
+
+
+def test_rate_limited_then_recovers_writes_snapshot_on_retry(db_session) -> None:
+    brand = _setup_brand(db_session)
+    _connect_linkedin(db_session, brand)
+    post = _make_published_post(db_session, brand)
+
+    publisher = MagicMock()
+    publisher.get_engagement.side_effect = [
+        EngagementResult(success=False, error="429 Too Many Requests", rate_limited=True),
+        EngagementResult(
+            success=True, metrics=EngagementMetrics(likes=3, comments=0, shares=0, impressions=50)
+        ),
+    ]
+
+    with patch.object(engagement_polling, "get_social_publisher", return_value=publisher):
+        with pytest.raises(engagement_polling.EngagementPollFailed):
+            engagement_polling.poll_post_engagement(db_session, post.id)
+
+        # Attempt 2 — what Celery's autoretry_for would trigger after
+        # backing off — succeeds.
+        snapshots = engagement_polling.poll_post_engagement(db_session, post.id)
+
+    assert len(snapshots) == 1
+    assert snapshots[0].likes == 3
+    assert publisher.get_engagement.call_count == 2
+
+
+# --- find_posts_due_for_polling ---------------------------------------------
+
+
+def test_find_posts_due_for_polling_only_returns_published_posts(db_session) -> None:
+    brand = _setup_brand(db_session)
+    published = _make_published_post(db_session, brand, platform_post_id="pub-1")
+
+    never_published = Post(brand_id=brand.id, body_text={"linkedin": "Draft"})
+    db_session.add(never_published)
+
+    failed_only = Post(
+        brand_id=brand.id,
+        body_text={"linkedin": "Failed"},
+        publish_results={"linkedin": {"status": "failed", "error": "boom"}},
+    )
+    db_session.add(failed_only)
+    db_session.flush()
+
+    due = engagement_polling.find_posts_due_for_polling(db_session)
+
+    assert published.id in due
+    assert never_published.id not in due
+    assert failed_only.id not in due
+
+
+# --- worker.py: Celery task wiring -----------------------------------------
+
+
+def test_poll_post_engagement_task_retry_configuration() -> None:
+    from apps.api import worker
+
+    assert worker.poll_post_engagement_task.autoretry_for == (
+        engagement_polling.EngagementPollFailed,
+    )
+    assert worker.poll_post_engagement_task.max_retries == worker.ENGAGEMENT_MAX_RETRIES
+    assert worker.poll_post_engagement_task.retry_backoff == worker.ENGAGEMENT_RETRY_BACKOFF_BASE
+    assert worker.poll_post_engagement_task.retry_backoff_max == worker.ENGAGEMENT_RETRY_BACKOFF_MAX
+    assert worker.poll_post_engagement_task.retry_jitter is True
+
+
+def test_beat_schedule_registers_poll_engagement() -> None:
+    from apps.api import worker
+
+    entry = worker.celery_app.conf.beat_schedule["poll-engagement"]
+    assert entry["task"] == "worker.poll_engagement"
+    assert entry["schedule"] == worker.ENGAGEMENT_POLL_INTERVAL_SECONDS
+
+
+def test_poll_engagement_task_fans_out_one_task_per_due_post(db_session, monkeypatch) -> None:
+    from apps.api import worker
+
+    brand = _setup_brand(db_session)
+    post = _make_published_post(db_session, brand)
+
+    monkeypatch.setattr(worker, "SessionLocal", lambda: db_session)
+    monkeypatch.setattr(db_session, "close", lambda: None)
+
+    with patch.object(worker, "poll_post_engagement_task") as mock_task:
+        result = worker.poll_engagement_task.run()
+
+    assert result == 1
+    mock_task.delay.assert_called_once_with(str(post.id))
+
+
+def test_poll_post_engagement_task_run_success(db_session, monkeypatch) -> None:
+    """Runs the task's underlying function body directly (`.run`, not
+    `.delay`/`.apply`) so this exercises apps/api/worker.py's own
+    db-session/commit handling without needing Celery/Redis machinery."""
+    from apps.api import worker
+
+    brand = _setup_brand(db_session)
+    _connect_linkedin(db_session, brand)
+    post = _make_published_post(db_session, brand)
+
+    monkeypatch.setattr(worker, "SessionLocal", lambda: db_session)
+    monkeypatch.setattr(db_session, "close", lambda: None)
+
+    publisher = MagicMock()
+    publisher.get_engagement.return_value = EngagementResult(
+        success=True, metrics=EngagementMetrics(likes=7, comments=1, shares=0, impressions=99)
+    )
+    with patch.object(engagement_polling, "get_social_publisher", return_value=publisher):
+        worker.poll_post_engagement_task.run(str(post.id))
+
+    from apps.api.models import EngagementSnapshot
+
+    rows = (
+        db_session.query(EngagementSnapshot).filter(EngagementSnapshot.post_id == post.id).all()
+    )
+    assert len(rows) == 1
+    assert rows[0].likes == 7
+
+
+def test_poll_post_engagement_task_run_failure_reraises_for_celery_retry(
+    db_session, monkeypatch
+) -> None:
+    from apps.api import worker
+
+    brand = _setup_brand(db_session)
+    post = _make_published_post(db_session, brand)  # no connected account
+
+    monkeypatch.setattr(worker, "SessionLocal", lambda: db_session)
+    monkeypatch.setattr(db_session, "close", lambda: None)
+
+    with pytest.raises(engagement_polling.EngagementPollFailed):
+        worker.poll_post_engagement_task.run(str(post.id))

--- a/apps/api/tests/test_publishing_adapters.py
+++ b/apps/api/tests/test_publishing_adapters.py
@@ -575,3 +575,128 @@ def test_x_publish_hard_failure_logged(db_session) -> None:
     assert logged is not None
     assert logged.success is False
     assert logged.error_message is not None
+
+
+# ---------------------------------------------------------------------
+# Issue #33: get_engagement() — same "never raises, caller decides"
+# shape as publish() above, exercised here for the same reason XProvider's
+# OAuth/publish methods are: this is the only file allowed to build these
+# adapters, so their real HTTP behavior belongs in this test module.
+# ---------------------------------------------------------------------
+
+
+def test_linkedin_get_engagement_success_returns_metrics(db_session) -> None:
+    provider = LinkedInProvider(client_id="cid", client_secret="secret")
+
+    with patch(
+        "httpx.get",
+        return_value=_mock_response({"likes": 10, "comments": 2, "shares": 1, "impressions": 500}),
+    ):
+        result = provider.get_engagement(access_token="good-token", platform_post_id="123")
+
+    assert result.success is True
+    assert result.rate_limited is False
+    assert result.metrics.likes == 10
+    assert result.metrics.comments == 2
+    assert result.metrics.shares == 1
+    assert result.metrics.impressions == 500
+
+
+def test_linkedin_get_engagement_logs_integration_call(db_session) -> None:
+    provider = LinkedInProvider(client_id="cid", client_secret="secret")
+
+    with patch(
+        "httpx.get", return_value=_mock_response({"likes": 1, "comments": 0, "shares": 0, "impressions": 5})
+    ):
+        provider.get_engagement(access_token="good-token", platform_post_id="123")
+
+    logged = (
+        db_session.query(IntegrationCall)
+        .filter_by(provider="linkedin", capability="get_engagement")
+        .order_by(IntegrationCall.created_at.desc())
+        .first()
+    )
+    assert logged is not None
+    assert logged.success is True
+
+
+def test_linkedin_get_engagement_rate_limited_returns_flag_not_raise(db_session) -> None:
+    provider = LinkedInProvider(client_id="cid", client_secret="secret")
+
+    with patch("httpx.get", return_value=_mock_response(status_code=429)):
+        result = provider.get_engagement(access_token="good-token", platform_post_id="123")
+
+    assert result.success is False
+    assert result.rate_limited is True
+    assert result.metrics is None
+
+
+def test_linkedin_get_engagement_hard_http_failure_returns_failed_result(db_session) -> None:
+    provider = LinkedInProvider(client_id="cid", client_secret="secret")
+
+    with patch("httpx.get", return_value=_mock_response(status_code=500)):
+        result = provider.get_engagement(access_token="good-token", platform_post_id="123")
+
+    assert result.success is False
+    assert result.rate_limited is False
+    assert result.error is not None
+
+
+def test_x_get_engagement_success_returns_metrics(db_session) -> None:
+    provider = XProvider(client_id="cid", client_secret="secret")
+
+    with patch(
+        "httpx.get",
+        return_value=_mock_response(
+            {
+                "data": {
+                    "id": "999",
+                    "public_metrics": {
+                        "like_count": 8,
+                        "reply_count": 3,
+                        "retweet_count": 2,
+                        "impression_count": 300,
+                    },
+                }
+            }
+        ),
+    ):
+        result = provider.get_engagement(access_token="good-token", platform_post_id="999")
+
+    assert result.success is True
+    assert result.metrics.likes == 8
+    assert result.metrics.comments == 3
+    assert result.metrics.shares == 2
+    assert result.metrics.impressions == 300
+
+
+def test_x_get_engagement_rate_limited_returns_flag_not_raise(db_session) -> None:
+    provider = XProvider(client_id="cid", client_secret="secret")
+
+    with patch("httpx.get", return_value=_mock_response(status_code=429)):
+        result = provider.get_engagement(access_token="good-token", platform_post_id="999")
+
+    assert result.success is False
+    assert result.rate_limited is True
+    assert result.metrics is None
+
+
+def test_x_get_engagement_logs_integration_call(db_session) -> None:
+    provider = XProvider(client_id="cid", client_secret="secret")
+
+    with patch(
+        "httpx.get",
+        return_value=_mock_response(
+            {"data": {"id": "1", "public_metrics": {"like_count": 1, "reply_count": 0, "retweet_count": 0, "impression_count": 1}}}
+        ),
+    ):
+        provider.get_engagement(access_token="good-token", platform_post_id="999")
+
+    logged = (
+        db_session.query(IntegrationCall)
+        .filter_by(provider="x", capability="get_engagement")
+        .order_by(IntegrationCall.created_at.desc())
+        .first()
+    )
+    assert logged is not None
+    assert logged.success is True

--- a/apps/api/worker.py
+++ b/apps/api/worker.py
@@ -5,7 +5,7 @@ from celery import Celery, Task
 
 from apps.api.config import get_settings
 from apps.api.config.database import SessionLocal
-from apps.api.services import publish_queue
+from apps.api.services import engagement_polling, publish_queue
 
 settings = get_settings()
 
@@ -15,6 +15,25 @@ celery_app = Celery(
     backend=settings.redis_url,
 )
 celery_app.conf.broker_connection_retry_on_startup = True
+
+# Issue #33: on a recurring schedule, poll engagement metrics for every
+# published post's platform(s) and append an EngagementSnapshot row per
+# poll. Runs every 15 minutes — frequent enough to build a meaningful
+# time series without hammering the platform APIs (see
+# ENGAGEMENT_POLL_INTERVAL_SECONDS below and
+# apps/api/services/engagement_polling.py's module docstring for the
+# rate-limit story). The actual selection/fetch/snapshot logic lives in
+# that module, not here, so it's unit-testable without any Celery
+# machinery — same split #29's beat_schedule (pipeline trigger) and #31's
+# publish queue already use.
+ENGAGEMENT_POLL_INTERVAL_SECONDS = 900.0
+
+celery_app.conf.beat_schedule = {
+    "poll-engagement": {
+        "task": "worker.poll_engagement",
+        "schedule": ENGAGEMENT_POLL_INTERVAL_SECONDS,
+    },
+}
 
 logger = logging.getLogger(__name__)
 
@@ -27,6 +46,15 @@ logger = logging.getLogger(__name__)
 PUBLISH_MAX_RETRIES = 5
 PUBLISH_RETRY_BACKOFF_BASE = 30
 PUBLISH_RETRY_BACKOFF_MAX = 600
+
+# Issue #33's "rate limits must be respected" acceptance criterion, same
+# mechanism and same reasoning as PUBLISH_* above: a rate-limited (or any
+# other failed) engagement fetch raises EngagementPollFailed, and this is
+# the cap/backoff schedule Celery retries it with, rather than a
+# hand-rolled retry loop.
+ENGAGEMENT_MAX_RETRIES = 5
+ENGAGEMENT_RETRY_BACKOFF_BASE = 30
+ENGAGEMENT_RETRY_BACKOFF_MAX = 600
 
 
 @celery_app.task(name="worker.ping")
@@ -100,6 +128,70 @@ def publish_post_task(post_id: str) -> None:
         # results/error onto the Post — commit that before propagating,
         # so it's visible even while retries are still in flight, then
         # let autoretry_for's wrapping catch this and schedule the retry.
+        db.commit()
+        raise
+    except Exception:
+        db.rollback()
+        raise
+    finally:
+        db.close()
+
+
+@celery_app.task(name="worker.poll_engagement")
+def poll_engagement_task() -> int:
+    """Celery Beat entrypoint for Issue #33's engagement polling sweep.
+
+    A thin wrapper, same shape as #29's trigger_due_pipelines_task:
+    figures out which posts are due for a poll
+    (engagement_polling.find_posts_due_for_polling — no Celery machinery
+    needed for that query), then fans out one poll_post_engagement_task
+    per post rather than polling all of them inline in this single task.
+    That fan-out means one post's platform being rate-limited (and
+    therefore retried with backoff, see poll_post_engagement_task below)
+    never delays or blocks polling any other post in the same sweep.
+    Returns the number of posts a poll was enqueued for.
+    """
+    db = SessionLocal()
+    try:
+        post_ids = engagement_polling.find_posts_due_for_polling(db)
+    finally:
+        db.close()
+
+    for post_id in post_ids:
+        poll_post_engagement_task.delay(str(post_id))
+    return len(post_ids)
+
+
+@celery_app.task(
+    name="worker.poll_post_engagement",
+    autoretry_for=(engagement_polling.EngagementPollFailed,),
+    retry_backoff=ENGAGEMENT_RETRY_BACKOFF_BASE,
+    retry_backoff_max=ENGAGEMENT_RETRY_BACKOFF_MAX,
+    retry_jitter=True,
+    max_retries=ENGAGEMENT_MAX_RETRIES,
+)
+def poll_post_engagement_task(post_id: str) -> None:
+    """The actual per-post engagement poll Issue #33 asks for —
+    deliberately thin, same split as publish_post_task above. All the
+    real logic (resolving published platforms, calling #30's
+    SocialPublisher.get_engagement() adapters, writing EngagementSnapshot
+    rows) lives in apps/api/services/engagement_polling.py, kept
+    import-free of Celery so it stays unit-testable without any
+    Celery/Redis machinery running. This wrapper's only job is to give
+    that logic Celery's exponential-backoff-retry machinery —
+    autoretry_for/retry_backoff — so a rate-limited (or otherwise failed)
+    platform fetch is backed off and retried later rather than hammered
+    or left to crash the whole sweep.
+    """
+    db = SessionLocal()
+    try:
+        engagement_polling.poll_post_engagement(db, uuid.UUID(post_id))
+        db.commit()
+    except engagement_polling.EngagementPollFailed:
+        # poll_post_engagement already committed a snapshot row for every
+        # platform that succeeded on this attempt — commit that before
+        # propagating, then let autoretry_for's wrapping catch this and
+        # schedule the retry.
         db.commit()
         raise
     except Exception:

--- a/migrations/versions/eee13f771456_engagement_snapshots.py
+++ b/migrations/versions/eee13f771456_engagement_snapshots.py
@@ -1,0 +1,58 @@
+"""engagement snapshots
+
+Revision ID: eee13f771456
+Revises: 16e1fc083897
+Create Date: 2026-08-25 02:41:01.925757
+
+Issue #33 needs somewhere to write per-poll engagement metrics for a
+published Post, as a true time series — one row per poll, never an
+overwrite of a previous row (same "append a log row, never overwrite"
+convention agent_runs/post_versions already establish; see
+migrations/versions/002_agent_runs.py and
+migrations/versions/ec24a3325404_post_body_text_and_post_versions.py).
+
+engagement_snapshots.platform is a plain string, not social_accounts'
+social_platform enum (which only defines "linkedin" today) — a post's
+*published* platforms (Post.publish_results, Issue #31) can include "x"
+even though X has no connectable SocialAccount row yet.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'eee13f771456'
+down_revision: Union[str, None] = '16e1fc083897'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        'engagement_snapshots',
+        sa.Column('id', sa.UUID(), nullable=False),
+        sa.Column('post_id', sa.UUID(), nullable=False),
+        sa.Column('platform', sa.String(), nullable=False),
+        sa.Column('likes', sa.Integer(), nullable=False),
+        sa.Column('comments', sa.Integer(), nullable=False),
+        sa.Column('shares', sa.Integer(), nullable=False),
+        sa.Column('impressions', sa.Integer(), nullable=False),
+        sa.Column('polled_at', sa.DateTime(timezone=True), server_default=sa.text('now()'), nullable=False),
+        sa.ForeignKeyConstraint(['post_id'], ['posts.id']),
+        sa.PrimaryKeyConstraint('id'),
+    )
+    # Every poll and every dashboard/report read (#34/#35) filters by
+    # post_id (and usually platform) and orders by polled_at — the same
+    # access pattern post_versions_post_id_idx already optimizes for.
+    op.create_index(
+        'engagement_snapshots_post_id_platform_idx',
+        'engagement_snapshots',
+        ['post_id', 'platform', 'polled_at'],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index('engagement_snapshots_post_id_platform_idx', table_name='engagement_snapshots')
+    op.drop_table('engagement_snapshots')

--- a/packages/integrations/social/base.py
+++ b/packages/integrations/social/base.py
@@ -35,6 +35,36 @@ class SocialOAuthProvider(ABC):
 
 
 @dataclass
+class EngagementMetrics:
+    """Cumulative engagement counts for a single published post, as
+    reported by the platform at the moment of the call — not deltas
+    since a previous poll. Deliberately a plain dataclass, same reasoning
+    as SocialTokens/PublishResult above: this package never depends on
+    apps.api, so the caller (#33's engagement_polling.py) is responsible
+    for turning this into an EngagementSnapshot row."""
+
+    likes: int
+    comments: int
+    shares: int
+    impressions: int
+
+
+@dataclass
+class EngagementResult:
+    """Returned by SocialPublisher.get_engagement()."""
+
+    success: bool
+    metrics: EngagementMetrics | None = None
+    error: str | None = None
+    # True when the failure was specifically the platform rate-limiting
+    # this call (e.g. HTTP 429) — lets the caller (engagement_polling.py)
+    # back off rather than hammer the platform, same "respect rate
+    # limits" acceptance criterion #31's publish queue already has to
+    # satisfy, without the caller having to string-match `error`.
+    rate_limited: bool = False
+
+
+@dataclass
 class PublishResult:
     """Returned by SocialPublisher.publish(). Like SocialTokens above,
     deliberately a plain dataclass (not tied to any ORM model) so this
@@ -76,4 +106,18 @@ class SocialPublisher(ABC):
         token, rejected content, network/HTTP error, a failed refresh) —
         those come back as PublishResult(success=False, error=...) so the
         caller doesn't need a try/except around every call site."""
+        ...
+
+    @abstractmethod
+    def get_engagement(self, access_token: str, platform_post_id: str) -> EngagementResult:
+        """Fetch current likes/comments/shares/impressions for a post this
+        adapter previously published (platform_post_id is exactly
+        PublishResult.platform_post_id from that publish() call). Like
+        publish(), never raises for an ordinary failure (bad token,
+        not-found post, network/HTTP error, rate limiting) — those come
+        back as EngagementResult(success=False, error=..., rate_limited=
+        ...) so the caller doesn't need a try/except around every call
+        site. Does not itself sleep/retry on a rate limit — see
+        EngagementResult.rate_limited's docstring for why that's the
+        caller's job."""
         ...

--- a/packages/integrations/social/linkedin_provider.py
+++ b/packages/integrations/social/linkedin_provider.py
@@ -5,6 +5,8 @@ import httpx
 
 from packages.integrations.observability import track_integration_call
 from packages.integrations.social.base import (
+    EngagementMetrics,
+    EngagementResult,
     PublishResult,
     SocialOAuthProvider,
     SocialPublisher,
@@ -27,6 +29,7 @@ class LinkedInProvider(SocialOAuthProvider, SocialPublisher):
     TOKEN_URL = "https://www.linkedin.com/oauth/v2/accessToken"
     USERINFO_URL = "https://api.linkedin.com/v2/userinfo"
     UGC_POSTS_URL = "https://api.linkedin.com/v2/ugcPosts"
+    SOCIAL_METRICS_URL = "https://api.linkedin.com/v2/socialMetrics"
 
     SCOPES = ("openid", "profile", "w_member_social")
 
@@ -182,6 +185,37 @@ class LinkedInProvider(SocialOAuthProvider, SocialPublisher):
             platform_post_id=post_id,
             platform_post_url=(
                 f"https://www.linkedin.com/feed/update/{post_id}/" if post_id else None
+            ),
+        )
+
+    # -- SocialPublisher: engagement -------------------------------------
+
+    def get_engagement(self, access_token: str, platform_post_id: str) -> EngagementResult:
+        try:
+            with track_integration_call("linkedin", "get_engagement"):
+                response = httpx.get(
+                    f"{self.SOCIAL_METRICS_URL}/{platform_post_id}",
+                    headers={"Authorization": f"Bearer {access_token}"},
+                    timeout=self.timeout,
+                )
+                if response.status_code == 429:
+                    return EngagementResult(
+                        success=False,
+                        error="LinkedIn rate-limited this engagement request",
+                        rate_limited=True,
+                    )
+                response.raise_for_status()
+                data = response.json()
+        except Exception as exc:  # noqa: BLE001 - vendor/network errors become failures, not raises
+            return EngagementResult(success=False, error=str(exc))
+
+        return EngagementResult(
+            success=True,
+            metrics=EngagementMetrics(
+                likes=data.get("likes", 0),
+                comments=data.get("comments", 0),
+                shares=data.get("shares", 0),
+                impressions=data.get("impressions", 0),
             ),
         )
 

--- a/packages/integrations/social/x_provider.py
+++ b/packages/integrations/social/x_provider.py
@@ -6,6 +6,8 @@ import httpx
 
 from packages.integrations.observability import track_integration_call
 from packages.integrations.social.base import (
+    EngagementMetrics,
+    EngagementResult,
     PublishResult,
     SocialOAuthProvider,
     SocialPublisher,
@@ -183,6 +185,38 @@ class XProvider(SocialOAuthProvider, SocialPublisher):
             success=True,
             platform_post_id=post_id,
             platform_post_url=f"https://x.com/i/web/status/{post_id}" if post_id else None,
+        )
+
+    # -- SocialPublisher: engagement ---------------------------------------
+
+    def get_engagement(self, access_token: str, platform_post_id: str) -> EngagementResult:
+        try:
+            with track_integration_call("x", "get_engagement"):
+                response = httpx.get(
+                    f"{self.TWEETS_URL}/{platform_post_id}",
+                    headers={"Authorization": f"Bearer {access_token}"},
+                    params={"tweet.fields": "public_metrics"},
+                    timeout=self.timeout,
+                )
+                if response.status_code == 429:
+                    return EngagementResult(
+                        success=False,
+                        error="X rate-limited this engagement request",
+                        rate_limited=True,
+                    )
+                response.raise_for_status()
+                metrics = response.json().get("data", {}).get("public_metrics", {})
+        except Exception as exc:  # noqa: BLE001 - vendor/network errors become failures, not raises
+            return EngagementResult(success=False, error=str(exc))
+
+        return EngagementResult(
+            success=True,
+            metrics=EngagementMetrics(
+                likes=metrics.get("like_count", 0),
+                comments=metrics.get("reply_count", 0),
+                shares=metrics.get("retweet_count", 0),
+                impressions=metrics.get("impression_count", 0),
+            ),
         )
 
     def _refresh_access_token(self, refresh_token: str) -> SocialTokens:


### PR DESCRIPTION
## What

Per-platform Celery Beat polling jobs that fetch likes/comments/shares/impressions for published posts and write `EngagementSnapshot` rows on a schedule.

- `apps/api/models/engagement_snapshot.py` — new `EngagementSnapshot` model (append-only, one row per poll — same "append a log row, never overwrite" convention as `AgentRun`/`PostVersion`). `platform` is a plain string (not `SocialAccount`'s `SocialPlatform` enum, which only defines `linkedin` today) since a post's *published* platforms can include `x`.
- `migrations/versions/eee13f771456_engagement_snapshots.py` — creates `engagement_snapshots`, indexed on `(post_id, platform, polled_at)`. Applies/downgrades/reapplies cleanly on top of head `16e1fc083897`.
- `apps/api/services/engagement_polling.py` — polling logic: finds every `Post` with at least one platform actually published (`Post.publish_results`, #31), resolves the connected `SocialAccount`, calls the adapter's new `get_engagement()`, and appends a snapshot row per successful fetch. No Celery import — fully unit-testable, same split as `publish_queue.py`.
- `packages/integrations/social/base.py` — adds `EngagementMetrics`/`EngagementResult` dataclasses and an abstract `get_engagement()` method to `SocialPublisher`.
- `packages/integrations/social/linkedin_provider.py` / `x_provider.py` — implement `get_engagement()`, same `track_integration_call`-wrapped, "never raises for an ordinary failure" pattern `publish()` already uses. A 429 comes back as `EngagementResult(rate_limited=True)` rather than raising.
- `apps/api/worker.py` — new `poll-engagement` Celery Beat entry (every 15 min) that fans out one Celery task per due post; each task retries a failed/rate-limited poll via `autoretry_for`/`retry_backoff` (same mechanism and constants shape as #31's `publish_post_task`), so a rate-limited platform is backed off rather than hammered, and never blocks polling other posts.

## Why

Without engagement data flowing back in, the Research Engine's "what's working" signal (#19, #28) stays static. #34's dashboard and #35's weekly report both read from `EngagementSnapshot`.

## Test plan

- [x] `pytest apps/api/tests/test_engagement_polling.py -v` — 13 tests: a poll writes an accurate snapshot; repeated polls append rows (row count grows, not an overwrite); a rate-limited/429 response is turned into `EngagementPollFailed` without crashing or hammering, then recovers on the next attempt; `find_posts_due_for_polling` only returns posts with a real published platform; worker Celery task retry configuration and beat-sweep fan-out.
- [x] `pytest apps/api/tests/test_publishing_adapters.py -v` — added `get_engagement()` coverage for both adapters (success, rate-limited, hard HTTP failure, integration-call logging).
- [x] `alembic upgrade head` / `downgrade -1` / `upgrade head` again — clean round-trip on a fresh scratch DB.
- [x] Full suite: `pytest apps/api/tests packages/agents/tests -v --cov=apps/api --cov=packages --cov-fail-under=70` — 269 passed, 1 known pre-existing failure (`test_social_accounts.py::test_connect_503_when_linkedin_not_configured`, unrelated, documented as occasionally flaky locally), coverage 97.9%.

## Notes

- Based on `feature/issue-31-publish-queue` (not `main`), since this needs #31's `Post.publish_results`/`platform_post_id`.
- This is a sibling branch to #32 (also based on #31) — they'll need reconciliation when both merge toward `main`. Expected, not avoided here.
- `#29`'s pipeline-trigger branch (also unmerged) established the `celery_app.conf.beat_schedule` pattern this PR follows; since #29 isn't an ancestor of this branch, this PR defines its own `beat_schedule` dict from scratch — merging both later will need a small dict-merge, same shape as the #32 reconciliation note above.

Closes #33