### PR TITLE
feat(api): add analytics aggregation API

### DIFF
--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -6,6 +6,7 @@ from apps.api.middleware.error_handlers import register_error_handlers
 from apps.api.middleware.logging import RequestLoggingMiddleware, configure_json_logging
 from apps.api.middleware.rate_limit import RateLimitMiddleware
 from apps.api.observability import init_sentry
+from apps.api.routers.analytics import router as analytics_router
 from apps.api.routers.brands import router as brands_router
 from apps.api.routers.calendar import router as calendar_router
 from apps.api.routers.onboarding import router as onboarding_router
@@ -21,6 +22,7 @@ register_error_handlers(app)
 app.add_middleware(RateLimitMiddleware)
 app.add_middleware(RequestLoggingMiddleware)
 app.include_router(auth_router)
+app.include_router(analytics_router)
 app.include_router(brands_router)
 app.include_router(calendar_router)
 app.include_router(onboarding_router)

--- a/apps/api/routers/analytics.py
+++ b/apps/api/routers/analytics.py
@@ -1,0 +1,166 @@
+import uuid
+from datetime import datetime, timedelta, timezone
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy.orm import Session
+
+from apps.api.auth.dependencies import CurrentUser, get_current_user
+from apps.api.config.database import get_db
+from apps.api.models import Brand, Post
+from apps.api.schemas.analytics import (
+    BrandAnalyticsSummary,
+    EngagementSnapshotPoint,
+    PlatformAggregate,
+    PostAnalyticsAggregate,
+    PostAnalyticsTrend,
+)
+from apps.api.services import analytics_aggregation
+
+router = APIRouter(prefix="/brands/{brand_id}/analytics", tags=["analytics"])
+
+# Same default window used across the dashboard/report if a caller doesn't
+# specify one — recent enough to be useful, wide enough to show a trend.
+DEFAULT_WINDOW_DAYS = 30
+
+
+def _get_org_brand(db: Session, brand_id: uuid.UUID, org_id: str) -> Brand:
+    brand = (
+        db.query(Brand)
+        .filter(Brand.id == brand_id, Brand.organization_id == uuid.UUID(org_id))
+        .first()
+    )
+    if brand is None:
+        # 404, not 403 — don't leak whether a brand with this id exists in
+        # another org.
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Brand not found")
+    return brand
+
+
+def _get_brand_post_or_404(db: Session, brand_id: uuid.UUID, post_id: uuid.UUID) -> Post:
+    post = (
+        db.query(Post)
+        .filter(Post.id == post_id, Post.brand_id == brand_id)
+        .first()
+    )
+    if post is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Post not found")
+    return post
+
+
+def _resolve_date_range(
+    start_date: datetime | None, end_date: datetime | None
+) -> tuple[datetime, datetime]:
+    """Defaults to the last DEFAULT_WINDOW_DAYS days ending now (UTC) when
+    either bound is omitted, so callers aren't forced to compute a range
+    just to see recent activity. Naive datetimes (no tzinfo in the query
+    string) are treated as UTC, matching EngagementSnapshot.polled_at's
+    timezone-aware storage."""
+    resolved_end = end_date or datetime.now(timezone.utc)
+    resolved_start = start_date or (resolved_end - timedelta(days=DEFAULT_WINDOW_DAYS))
+
+    if resolved_end.tzinfo is None:
+        resolved_end = resolved_end.replace(tzinfo=timezone.utc)
+    if resolved_start.tzinfo is None:
+        resolved_start = resolved_start.replace(tzinfo=timezone.utc)
+
+    if resolved_start >= resolved_end:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="start_date must be before end_date",
+        )
+    return resolved_start, resolved_end
+
+
+def _to_platform_aggregate(row: analytics_aggregation.PlatformAggregateRow) -> PlatformAggregate:
+    return PlatformAggregate(
+        platform=row.platform,
+        snapshot_count=row.snapshot_count,
+        total_likes=row.total_likes,
+        total_comments=row.total_comments,
+        total_shares=row.total_shares,
+        total_impressions=row.total_impressions,
+        average_likes=row.average_likes,
+        average_comments=row.average_comments,
+        average_shares=row.average_shares,
+        average_impressions=row.average_impressions,
+    )
+
+
+@router.get("/summary", response_model=BrandAnalyticsSummary)
+def get_brand_summary(
+    brand_id: uuid.UUID,
+    start_date: datetime | None = Query(None),
+    end_date: datetime | None = Query(None),
+    db: Session = Depends(get_db),
+    current_user: CurrentUser = Depends(get_current_user),
+) -> BrandAnalyticsSummary:
+    _get_org_brand(db, brand_id, current_user.org_id)
+    resolved_start, resolved_end = _resolve_date_range(start_date, end_date)
+
+    summary = analytics_aggregation.get_brand_summary(db, brand_id, resolved_start, resolved_end)
+    return BrandAnalyticsSummary(
+        brand_id=str(brand_id),
+        start_date=resolved_start,
+        end_date=resolved_end,
+        post_count=summary.post_count,
+        platforms=[_to_platform_aggregate(row) for row in summary.platforms],
+        overall=_to_platform_aggregate(summary.overall),
+    )
+
+
+@router.get("/posts/{post_id}", response_model=PostAnalyticsAggregate)
+def get_post_aggregate(
+    brand_id: uuid.UUID,
+    post_id: uuid.UUID,
+    start_date: datetime | None = Query(None),
+    end_date: datetime | None = Query(None),
+    db: Session = Depends(get_db),
+    current_user: CurrentUser = Depends(get_current_user),
+) -> PostAnalyticsAggregate:
+    _get_org_brand(db, brand_id, current_user.org_id)
+    _get_brand_post_or_404(db, brand_id, post_id)
+    resolved_start, resolved_end = _resolve_date_range(start_date, end_date)
+
+    aggregate = analytics_aggregation.get_post_aggregate(db, post_id, resolved_start, resolved_end)
+    return PostAnalyticsAggregate(
+        post_id=str(post_id),
+        start_date=resolved_start,
+        end_date=resolved_end,
+        platforms=[_to_platform_aggregate(row) for row in aggregate.platforms],
+        overall=_to_platform_aggregate(aggregate.overall),
+    )
+
+
+@router.get("/posts/{post_id}/trend", response_model=PostAnalyticsTrend)
+def get_post_trend(
+    brand_id: uuid.UUID,
+    post_id: uuid.UUID,
+    start_date: datetime | None = Query(None),
+    end_date: datetime | None = Query(None),
+    platform: str | None = Query(None),
+    db: Session = Depends(get_db),
+    current_user: CurrentUser = Depends(get_current_user),
+) -> PostAnalyticsTrend:
+    _get_org_brand(db, brand_id, current_user.org_id)
+    _get_brand_post_or_404(db, brand_id, post_id)
+    resolved_start, resolved_end = _resolve_date_range(start_date, end_date)
+
+    points = analytics_aggregation.get_post_trend(
+        db, post_id, resolved_start, resolved_end, platform=platform
+    )
+    return PostAnalyticsTrend(
+        post_id=str(post_id),
+        start_date=resolved_start,
+        end_date=resolved_end,
+        points=[
+            EngagementSnapshotPoint(
+                platform=p.platform,
+                likes=p.likes,
+                comments=p.comments,
+                shares=p.shares,
+                impressions=p.impressions,
+                polled_at=p.polled_at,
+            )
+            for p in points
+        ],
+    )

--- a/apps/api/schemas/analytics.py
+++ b/apps/api/schemas/analytics.py
@@ -1,0 +1,70 @@
+from datetime import datetime
+
+from pydantic import BaseModel
+
+
+class PlatformAggregate(BaseModel):
+    """Totals/averages for one platform within a requested date range —
+    the per-platform breakdown row both the brand summary and the
+    per-post aggregate endpoints return. total_* are real SQL SUM()s and
+    average_* are real SQL AVG()s (apps/api/services/analytics_aggregation.py)
+    computed in Postgres, not accumulated in Python."""
+
+    platform: str
+    snapshot_count: int
+    total_likes: int
+    total_comments: int
+    total_shares: int
+    total_impressions: int
+    average_likes: float
+    average_comments: float
+    average_shares: float
+    average_impressions: float
+
+
+class BrandAnalyticsSummary(BaseModel):
+    """Per-brand aggregate over [start_date, end_date), broken down by
+    platform, plus an overall row summed across every platform."""
+
+    brand_id: str
+    start_date: datetime
+    end_date: datetime
+    post_count: int
+    platforms: list[PlatformAggregate]
+    overall: PlatformAggregate
+
+
+class PostAnalyticsAggregate(BaseModel):
+    """Per-post aggregate over [start_date, end_date), broken down by
+    platform — e.g. "how did this one post perform on LinkedIn vs X over
+    the last 30 days", as opposed to the raw time series the /trend
+    endpoint returns."""
+
+    post_id: str
+    start_date: datetime
+    end_date: datetime
+    platforms: list[PlatformAggregate]
+    overall: PlatformAggregate
+
+
+class EngagementSnapshotPoint(BaseModel):
+    """One raw point in a post's engagement time series."""
+
+    platform: str
+    likes: int
+    comments: int
+    shares: int
+    impressions: int
+    polled_at: datetime
+
+
+class PostAnalyticsTrend(BaseModel):
+    """The time series for one post over [start_date, end_date), ordered
+    by polled_at ascending — every EngagementSnapshot row polled for this
+    post in the window, not aggregated, so a caller (a chart, #35's
+    report) can see actual engagement growth over time."""
+
+    post_id: str
+    start_date: datetime
+    end_date: datetime
+    points: list[EngagementSnapshotPoint]

--- a/apps/api/services/analytics_aggregation.py
+++ b/apps/api/services/analytics_aggregation.py
@@ -1,0 +1,209 @@
+"""Analytics aggregation queries over EngagementSnapshot — Issue #34.
+
+Raw EngagementSnapshot rows (one per poll, #33) aren't directly useful to
+a dashboard or to #35's weekly AI report — both want per-brand and
+per-post *aggregates* (totals/averages broken down by platform) and
+per-post *trends* (the raw time series) over a caller-chosen date range.
+
+Performance is an explicit acceptance criterion for this issue: a brand
+can accumulate many thousands of snapshot rows (frequent polling x many
+posts x many platforms x a long-lived brand), so every aggregate here is
+computed as a single SQL GROUP BY (SUM/AVG/COUNT) executed in Postgres —
+never "fetch all matching rows and reduce them in Python". The only query
+that returns row-per-snapshot is get_post_trend, which is inherently a
+list (a trend *is* the raw series) rather than an aggregate, and is
+already scoped to one post so its result set is bounded by that post's
+poll history, not the whole brand's.
+
+engagement_snapshots_post_id_platform_idx (migrations/versions/eee13f771456)
+and posts_brand_id_idx (migrations/versions/63bac4f4c66f) let Postgres
+satisfy both the per-post and per-brand queries via index scans instead of
+sequential scans over engagement_snapshots/posts.
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass
+from datetime import datetime
+
+from sqlalchemy import func
+from sqlalchemy.orm import Session
+
+from apps.api.models.engagement_snapshot import EngagementSnapshot
+from apps.api.models.post import Post
+
+
+@dataclass
+class PlatformAggregateRow:
+    platform: str
+    snapshot_count: int
+    total_likes: int
+    total_comments: int
+    total_shares: int
+    total_impressions: int
+    average_likes: float
+    average_comments: float
+    average_shares: float
+    average_impressions: float
+
+
+@dataclass
+class BrandSummary:
+    post_count: int
+    platforms: list[PlatformAggregateRow]
+    overall: PlatformAggregateRow
+
+
+@dataclass
+class PostAggregate:
+    platforms: list[PlatformAggregateRow]
+    overall: PlatformAggregateRow
+
+
+@dataclass
+class TrendPoint:
+    platform: str
+    likes: int
+    comments: int
+    shares: int
+    impressions: int
+    polled_at: datetime
+
+
+# Aggregate columns shared by every "totals + averages, grouped by
+# platform" query below. COALESCE(..., 0) matters here: SUM/AVG over zero
+# matching rows returns SQL NULL, not 0, and this module's callers (and
+# their Pydantic response models) expect real numbers even for a
+# platform/date-range with no snapshots.
+def _aggregate_columns() -> list:
+    return [
+        func.count(EngagementSnapshot.id).label("snapshot_count"),
+        func.coalesce(func.sum(EngagementSnapshot.likes), 0).label("total_likes"),
+        func.coalesce(func.sum(EngagementSnapshot.comments), 0).label("total_comments"),
+        func.coalesce(func.sum(EngagementSnapshot.shares), 0).label("total_shares"),
+        func.coalesce(func.sum(EngagementSnapshot.impressions), 0).label("total_impressions"),
+        func.coalesce(func.avg(EngagementSnapshot.likes), 0).label("average_likes"),
+        func.coalesce(func.avg(EngagementSnapshot.comments), 0).label("average_comments"),
+        func.coalesce(func.avg(EngagementSnapshot.shares), 0).label("average_shares"),
+        func.coalesce(func.avg(EngagementSnapshot.impressions), 0).label("average_impressions"),
+    ]
+
+
+def _row_to_platform_aggregate(platform: str, row) -> PlatformAggregateRow:
+    return PlatformAggregateRow(
+        platform=platform,
+        snapshot_count=int(row.snapshot_count),
+        total_likes=int(row.total_likes),
+        total_comments=int(row.total_comments),
+        total_shares=int(row.total_shares),
+        total_impressions=int(row.total_impressions),
+        average_likes=float(row.average_likes),
+        average_comments=float(row.average_comments),
+        average_shares=float(row.average_shares),
+        average_impressions=float(row.average_impressions),
+    )
+
+
+def get_brand_summary(
+    db: Session, brand_id: uuid.UUID, start_date: datetime, end_date: datetime
+) -> BrandSummary:
+    """Per-brand aggregate over [start_date, end_date), broken down by
+    platform, plus an "overall" row summed across every platform. Two
+    GROUP BY queries total (one grouped by platform, one not) plus a
+    COUNT(DISTINCT) for post_count — all executed in Postgres."""
+    base_filters = [
+        Post.brand_id == brand_id,
+        EngagementSnapshot.polled_at >= start_date,
+        EngagementSnapshot.polled_at < end_date,
+    ]
+
+    per_platform = (
+        db.query(EngagementSnapshot.platform, *_aggregate_columns())
+        .join(Post, Post.id == EngagementSnapshot.post_id)
+        .filter(*base_filters)
+        .group_by(EngagementSnapshot.platform)
+        .order_by(EngagementSnapshot.platform)
+        .all()
+    )
+    platforms = [_row_to_platform_aggregate(row.platform, row) for row in per_platform]
+
+    overall_row = (
+        db.query(*_aggregate_columns())
+        .join(Post, Post.id == EngagementSnapshot.post_id)
+        .filter(*base_filters)
+        .one()
+    )
+    overall = _row_to_platform_aggregate("all", overall_row)
+
+    post_count = (
+        db.query(func.count(func.distinct(EngagementSnapshot.post_id)))
+        .join(Post, Post.id == EngagementSnapshot.post_id)
+        .filter(*base_filters)
+        .scalar()
+    ) or 0
+
+    return BrandSummary(post_count=int(post_count), platforms=platforms, overall=overall)
+
+
+def get_post_aggregate(
+    db: Session, post_id: uuid.UUID, start_date: datetime, end_date: datetime
+) -> PostAggregate:
+    """Per-post aggregate over [start_date, end_date), broken down by
+    platform — e.g. how one post performed on LinkedIn vs X. Callers are
+    responsible for confirming the post belongs to the requesting brand
+    before calling this (see apps/api/routers/analytics.py)."""
+    base_filters = [
+        EngagementSnapshot.post_id == post_id,
+        EngagementSnapshot.polled_at >= start_date,
+        EngagementSnapshot.polled_at < end_date,
+    ]
+
+    per_platform = (
+        db.query(EngagementSnapshot.platform, *_aggregate_columns())
+        .filter(*base_filters)
+        .group_by(EngagementSnapshot.platform)
+        .order_by(EngagementSnapshot.platform)
+        .all()
+    )
+    platforms = [_row_to_platform_aggregate(row.platform, row) for row in per_platform]
+
+    overall_row = db.query(*_aggregate_columns()).filter(*base_filters).one()
+    overall = _row_to_platform_aggregate("all", overall_row)
+
+    return PostAggregate(platforms=platforms, overall=overall)
+
+
+def get_post_trend(
+    db: Session,
+    post_id: uuid.UUID,
+    start_date: datetime,
+    end_date: datetime,
+    platform: str | None = None,
+) -> list[TrendPoint]:
+    """The raw time series for one post over [start_date, end_date),
+    ordered by polled_at ascending — every EngagementSnapshot row polled
+    in the window (optionally narrowed to one platform), unaggregated, so
+    a caller can chart real engagement growth over time. Bounded by one
+    post's poll history via engagement_snapshots_post_id_platform_idx, not
+    a brand-wide scan."""
+    query = db.query(EngagementSnapshot).filter(
+        EngagementSnapshot.post_id == post_id,
+        EngagementSnapshot.polled_at >= start_date,
+        EngagementSnapshot.polled_at < end_date,
+    )
+    if platform is not None:
+        query = query.filter(EngagementSnapshot.platform == platform)
+
+    rows = query.order_by(EngagementSnapshot.polled_at.asc()).all()
+    return [
+        TrendPoint(
+            platform=row.platform,
+            likes=row.likes,
+            comments=row.comments,
+            shares=row.shares,
+            impressions=row.impressions,
+            polled_at=row.polled_at,
+        )
+        for row in rows
+    ]

--- a/apps/api/tests/test_analytics.py
+++ b/apps/api/tests/test_analytics.py
@@ -1,0 +1,455 @@
+import time
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from fastapi.testclient import TestClient
+
+from apps.api.auth.jwt import create_access_token, hash_password
+from apps.api.main import app
+from apps.api.models import Brand, EngagementSnapshot, Organization, Post, User, UserRole
+
+client = TestClient(app)
+uses_test_session = pytest.mark.usefixtures("override_get_db")
+
+
+def _setup_brand(db_session, role: UserRole = UserRole.EDITOR, suffix: str = "") -> tuple[Brand, User]:
+    org = Organization(name="Acme Agency")
+    db_session.add(org)
+    db_session.flush()
+
+    user = User(
+        organization_id=org.id,
+        email=f"{role.value}{suffix}@acme.test",
+        password_hash=hash_password("test-password"),
+        role=role,
+    )
+    brand = Brand(organization_id=org.id, name="Acme Widgets")
+    db_session.add_all([user, brand])
+    db_session.flush()
+    return brand, user
+
+
+def _auth_headers(user: User) -> dict[str, str]:
+    token = create_access_token(
+        user_id=str(user.id), org_id=str(user.organization_id), role=user.role.value
+    )
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _make_post(db_session, brand: Brand) -> Post:
+    post = Post(brand_id=brand.id)
+    db_session.add(post)
+    db_session.flush()
+    return post
+
+
+def _snapshot(
+    post: Post,
+    platform: str,
+    polled_at: datetime,
+    likes: int = 0,
+    comments: int = 0,
+    shares: int = 0,
+    impressions: int = 0,
+) -> EngagementSnapshot:
+    return EngagementSnapshot(
+        post_id=post.id,
+        platform=platform,
+        likes=likes,
+        comments=comments,
+        shares=shares,
+        impressions=impressions,
+        polled_at=polled_at,
+    )
+
+
+BASE_TIME = datetime(2026, 1, 1, tzinfo=timezone.utc)
+
+
+def _iso_range(start: datetime, end: datetime) -> dict[str, str]:
+    return {"start_date": start.isoformat(), "end_date": end.isoformat()}
+
+
+# ---------------------------------------------------------------------------
+# Brand summary: correctness
+# ---------------------------------------------------------------------------
+
+
+@uses_test_session
+def test_brand_summary_returns_correct_per_platform_aggregates(db_session) -> None:
+    brand, user = _setup_brand(db_session)
+    post_a = _make_post(db_session, brand)
+    post_b = _make_post(db_session, brand)
+
+    db_session.add_all(
+        [
+            _snapshot(post_a, "linkedin", BASE_TIME, likes=10, comments=1, shares=2, impressions=100),
+            _snapshot(
+                post_a,
+                "linkedin",
+                BASE_TIME + timedelta(hours=1),
+                likes=20,
+                comments=3,
+                shares=4,
+                impressions=200,
+            ),
+            _snapshot(post_b, "x", BASE_TIME, likes=5, comments=0, shares=1, impressions=50),
+        ]
+    )
+    db_session.flush()
+
+    response = client.get(
+        f"/brands/{brand.id}/analytics/summary",
+        params=_iso_range(BASE_TIME - timedelta(hours=1), BASE_TIME + timedelta(hours=2)),
+        headers=_auth_headers(user),
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["post_count"] == 2
+
+    platforms = {row["platform"]: row for row in body["platforms"]}
+    assert set(platforms) == {"linkedin", "x"}
+
+    linkedin = platforms["linkedin"]
+    assert linkedin["snapshot_count"] == 2
+    assert linkedin["total_likes"] == 30
+    assert linkedin["total_comments"] == 4
+    assert linkedin["total_shares"] == 6
+    assert linkedin["total_impressions"] == 300
+    assert linkedin["average_likes"] == pytest.approx(15.0)
+
+    x = platforms["x"]
+    assert x["snapshot_count"] == 1
+    assert x["total_likes"] == 5
+
+    overall = body["overall"]
+    assert overall["snapshot_count"] == 3
+    assert overall["total_likes"] == 35
+    assert overall["total_comments"] == 4
+    assert overall["total_shares"] == 7
+    assert overall["total_impressions"] == 350
+
+
+@uses_test_session
+def test_brand_summary_excludes_snapshots_outside_date_range(db_session) -> None:
+    brand, user = _setup_brand(db_session)
+    post = _make_post(db_session, brand)
+
+    db_session.add_all(
+        [
+            _snapshot(post, "linkedin", BASE_TIME, likes=100),
+            _snapshot(post, "linkedin", BASE_TIME - timedelta(days=30), likes=999),
+            _snapshot(post, "linkedin", BASE_TIME + timedelta(days=30), likes=999),
+        ]
+    )
+    db_session.flush()
+
+    response = client.get(
+        f"/brands/{brand.id}/analytics/summary",
+        params=_iso_range(BASE_TIME - timedelta(hours=1), BASE_TIME + timedelta(hours=1)),
+        headers=_auth_headers(user),
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["overall"]["snapshot_count"] == 1
+    assert body["overall"]["total_likes"] == 100
+
+
+@uses_test_session
+def test_brand_summary_excludes_other_brands_posts(db_session) -> None:
+    brand, user = _setup_brand(db_session)
+    other_brand = Brand(organization_id=user.organization_id, name="Other Brand")
+    db_session.add(other_brand)
+    db_session.flush()
+
+    own_post = _make_post(db_session, brand)
+    other_post = _make_post(db_session, other_brand)
+    db_session.add_all(
+        [
+            _snapshot(own_post, "linkedin", BASE_TIME, likes=10),
+            _snapshot(other_post, "linkedin", BASE_TIME, likes=999),
+        ]
+    )
+    db_session.flush()
+
+    response = client.get(
+        f"/brands/{brand.id}/analytics/summary",
+        params=_iso_range(BASE_TIME - timedelta(hours=1), BASE_TIME + timedelta(hours=1)),
+        headers=_auth_headers(user),
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["overall"]["total_likes"] == 10
+    assert body["post_count"] == 1
+
+
+@uses_test_session
+def test_brand_summary_defaults_to_last_30_days_when_no_range_given(db_session) -> None:
+    brand, user = _setup_brand(db_session)
+    post = _make_post(db_session, brand)
+    now = datetime.now(timezone.utc)
+    db_session.add_all(
+        [
+            _snapshot(post, "linkedin", now - timedelta(days=1), likes=7),
+            _snapshot(post, "linkedin", now - timedelta(days=90), likes=999),
+        ]
+    )
+    db_session.flush()
+
+    response = client.get(f"/brands/{brand.id}/analytics/summary", headers=_auth_headers(user))
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["overall"]["total_likes"] == 7
+
+
+# ---------------------------------------------------------------------------
+# Per-post aggregate + trend: correctness
+# ---------------------------------------------------------------------------
+
+
+@uses_test_session
+def test_post_aggregate_returns_correct_numbers(db_session) -> None:
+    brand, user = _setup_brand(db_session)
+    post = _make_post(db_session, brand)
+    other_post = _make_post(db_session, brand)
+
+    db_session.add_all(
+        [
+            _snapshot(post, "linkedin", BASE_TIME, likes=10, impressions=100),
+            _snapshot(post, "x", BASE_TIME, likes=3, impressions=30),
+            _snapshot(other_post, "linkedin", BASE_TIME, likes=500, impressions=5000),
+        ]
+    )
+    db_session.flush()
+
+    response = client.get(
+        f"/brands/{brand.id}/analytics/posts/{post.id}",
+        params=_iso_range(BASE_TIME - timedelta(hours=1), BASE_TIME + timedelta(hours=1)),
+        headers=_auth_headers(user),
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    platforms = {row["platform"]: row for row in body["platforms"]}
+    assert platforms["linkedin"]["total_likes"] == 10
+    assert platforms["x"]["total_likes"] == 3
+    assert body["overall"]["total_likes"] == 13
+    assert body["overall"]["total_impressions"] == 130
+
+
+@uses_test_session
+def test_post_trend_returns_points_ordered_by_polled_at(db_session) -> None:
+    brand, user = _setup_brand(db_session)
+    post = _make_post(db_session, brand)
+
+    db_session.add_all(
+        [
+            _snapshot(post, "linkedin", BASE_TIME + timedelta(hours=2), likes=30),
+            _snapshot(post, "linkedin", BASE_TIME, likes=10),
+            _snapshot(post, "linkedin", BASE_TIME + timedelta(hours=1), likes=20),
+        ]
+    )
+    db_session.flush()
+
+    response = client.get(
+        f"/brands/{brand.id}/analytics/posts/{post.id}/trend",
+        params=_iso_range(BASE_TIME - timedelta(hours=1), BASE_TIME + timedelta(hours=3)),
+        headers=_auth_headers(user),
+    )
+
+    assert response.status_code == 200
+    points = response.json()["points"]
+    assert [p["likes"] for p in points] == [10, 20, 30]
+
+
+@uses_test_session
+def test_post_trend_filters_by_platform(db_session) -> None:
+    brand, user = _setup_brand(db_session)
+    post = _make_post(db_session, brand)
+
+    db_session.add_all(
+        [
+            _snapshot(post, "linkedin", BASE_TIME, likes=10),
+            _snapshot(post, "x", BASE_TIME, likes=99),
+        ]
+    )
+    db_session.flush()
+
+    response = client.get(
+        f"/brands/{brand.id}/analytics/posts/{post.id}/trend",
+        params={
+            **_iso_range(BASE_TIME - timedelta(hours=1), BASE_TIME + timedelta(hours=1)),
+            "platform": "linkedin",
+        },
+        headers=_auth_headers(user),
+    )
+
+    assert response.status_code == 200
+    points = response.json()["points"]
+    assert len(points) == 1
+    assert points[0]["platform"] == "linkedin"
+    assert points[0]["likes"] == 10
+
+
+# ---------------------------------------------------------------------------
+# Org/brand scoping — 404, not 403, matching this repo's convention
+# ---------------------------------------------------------------------------
+
+
+@uses_test_session
+def test_cross_org_brand_summary_returns_404(db_session) -> None:
+    brand, _owner = _setup_brand(db_session, UserRole.EDITOR, suffix="-1")
+    _other_brand, other_user = _setup_brand(db_session, UserRole.EDITOR, suffix="-2")
+
+    response = client.get(
+        f"/brands/{brand.id}/analytics/summary", headers=_auth_headers(other_user)
+    )
+
+    assert response.status_code == 404
+
+
+@uses_test_session
+def test_cross_org_post_aggregate_returns_404(db_session) -> None:
+    brand, owner = _setup_brand(db_session, UserRole.EDITOR, suffix="-1")
+    _other_brand, other_user = _setup_brand(db_session, UserRole.EDITOR, suffix="-2")
+    post = _make_post(db_session, brand)
+    db_session.add(_snapshot(post, "linkedin", BASE_TIME, likes=10))
+    db_session.flush()
+
+    response = client.get(
+        f"/brands/{brand.id}/analytics/posts/{post.id}", headers=_auth_headers(other_user)
+    )
+
+    assert response.status_code == 404
+
+
+@uses_test_session
+def test_post_from_different_brand_returns_404(db_session) -> None:
+    brand, user = _setup_brand(db_session)
+    other_brand = Brand(organization_id=user.organization_id, name="Other Brand")
+    db_session.add(other_brand)
+    db_session.flush()
+    other_post = _make_post(db_session, other_brand)
+
+    response = client.get(
+        f"/brands/{brand.id}/analytics/posts/{other_post.id}", headers=_auth_headers(user)
+    )
+
+    assert response.status_code == 404
+
+
+@uses_test_session
+def test_unknown_brand_returns_404(db_session) -> None:
+    _brand, user = _setup_brand(db_session)
+
+    response = client.get(
+        f"/brands/{uuid.uuid4()}/analytics/summary", headers=_auth_headers(user)
+    )
+
+    assert response.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Performance: aggregation must be real DB-side SQL, not Python-side
+# reduction over every row — proven by seeding a realistic volume and
+# asserting both correctness and wall-clock time.
+# ---------------------------------------------------------------------------
+
+NUM_POSTS = 5
+PLATFORMS = ["linkedin", "x"]
+SNAPSHOTS_PER_POST_PLATFORM = 300  # 5 * 2 * 300 = 3,000 rows total
+LIKES_PER_SNAPSHOT = 4
+COMMENTS_PER_SNAPSHOT = 1
+SHARES_PER_SNAPSHOT = 2
+IMPRESSIONS_PER_SNAPSHOT = 50
+
+
+def _seed_volume(db_session, brand: Brand) -> list[Post]:
+    posts = [_make_post(db_session, brand) for _ in range(NUM_POSTS)]
+
+    snapshots = []
+    for post in posts:
+        for platform in PLATFORMS:
+            for i in range(SNAPSHOTS_PER_POST_PLATFORM):
+                snapshots.append(
+                    _snapshot(
+                        post,
+                        platform,
+                        BASE_TIME + timedelta(minutes=i),
+                        likes=LIKES_PER_SNAPSHOT,
+                        comments=COMMENTS_PER_SNAPSHOT,
+                        shares=SHARES_PER_SNAPSHOT,
+                        impressions=IMPRESSIONS_PER_SNAPSHOT,
+                    )
+                )
+    db_session.bulk_save_objects(snapshots)
+    db_session.flush()
+    return posts
+
+
+@uses_test_session
+def test_brand_summary_aggregation_is_correct_and_fast_at_seeded_volume(db_session) -> None:
+    brand, user = _setup_brand(db_session)
+    _seed_volume(db_session, brand)
+
+    started = time.perf_counter()
+    response = client.get(
+        f"/brands/{brand.id}/analytics/summary",
+        params=_iso_range(BASE_TIME - timedelta(hours=1), BASE_TIME + timedelta(days=1)),
+        headers=_auth_headers(user),
+    )
+    elapsed = time.perf_counter() - started
+
+    assert response.status_code == 200
+    # This is a generous ceiling meant to catch "fetching every row and
+    # summing in Python" (which degrades with row count), not to chase a
+    # specific benchmark number — a real GROUP BY SUM/AVG/COUNT in
+    # Postgres over a few thousand rows should be nowhere near this.
+    assert elapsed < 2.0, f"brand summary aggregate over {NUM_POSTS * len(PLATFORMS) * SNAPSHOTS_PER_POST_PLATFORM} rows took {elapsed:.3f}s"
+
+    body = response.json()
+    assert body["post_count"] == NUM_POSTS
+
+    per_platform_count = NUM_POSTS * SNAPSHOTS_PER_POST_PLATFORM
+    for row in body["platforms"]:
+        assert row["snapshot_count"] == per_platform_count
+        assert row["total_likes"] == per_platform_count * LIKES_PER_SNAPSHOT
+        assert row["total_comments"] == per_platform_count * COMMENTS_PER_SNAPSHOT
+        assert row["total_shares"] == per_platform_count * SHARES_PER_SNAPSHOT
+        assert row["total_impressions"] == per_platform_count * IMPRESSIONS_PER_SNAPSHOT
+        assert row["average_likes"] == pytest.approx(float(LIKES_PER_SNAPSHOT))
+
+    total_rows = NUM_POSTS * len(PLATFORMS) * SNAPSHOTS_PER_POST_PLATFORM
+    overall = body["overall"]
+    assert overall["snapshot_count"] == total_rows
+    assert overall["total_likes"] == total_rows * LIKES_PER_SNAPSHOT
+    assert overall["total_impressions"] == total_rows * IMPRESSIONS_PER_SNAPSHOT
+
+
+@uses_test_session
+def test_post_aggregate_is_correct_at_seeded_volume(db_session) -> None:
+    brand, user = _setup_brand(db_session)
+    posts = _seed_volume(db_session, brand)
+    target_post = posts[0]
+
+    started = time.perf_counter()
+    response = client.get(
+        f"/brands/{brand.id}/analytics/posts/{target_post.id}",
+        params=_iso_range(BASE_TIME - timedelta(hours=1), BASE_TIME + timedelta(days=1)),
+        headers=_auth_headers(user),
+    )
+    elapsed = time.perf_counter() - started
+
+    assert response.status_code == 200
+    assert elapsed < 2.0
+
+    body = response.json()
+    platforms = {row["platform"]: row for row in body["platforms"]}
+    for platform in PLATFORMS:
+        assert platforms[platform]["snapshot_count"] == SNAPSHOTS_PER_POST_PLATFORM
+        assert platforms[platform]["total_likes"] == SNAPSHOTS_PER_POST_PLATFORM * LIKES_PER_SNAPSHOT

--- a/migrations/versions/63bac4f4c66f_posts_brand_id_index.py
+++ b/migrations/versions/63bac4f4c66f_posts_brand_id_index.py
@@ -1,0 +1,37 @@
+"""posts brand_id index
+
+Revision ID: 63bac4f4c66f
+Revises: eee13f771456
+Create Date: 2026-08-25 02:53:13.750394
+
+Issue #34's analytics aggregation (apps/api/services/analytics_aggregation.py)
+computes brand-level engagement aggregates by joining posts to
+engagement_snapshots and filtering on posts.brand_id — every one of those
+queries starts from "find this brand's posts". posts had no index on
+brand_id at all before this (75d69ba778a0_posts_and_pipeline_checkpoints.py
+only gave it a primary key + a plain FK constraint on brand_id, which
+Postgres does not automatically index), so that join was a sequential scan
+of the whole posts table on every analytics request. Paired with
+engagement_snapshots_post_id_platform_idx (eee13f771456), this lets
+Postgres do brand -> posts -> snapshots entirely through indexes instead of
+scanning either table.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '63bac4f4c66f'
+down_revision: Union[str, None] = 'eee13f771456'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_index('posts_brand_id_idx', 'posts', ['brand_id'])
+
+
+def downgrade() -> None:
+    op.drop_index('posts_brand_id_idx', table_name='posts')


### PR DESCRIPTION
## Summary
- Adds a `/brands/{brand_id}/analytics` router with three endpoints, each accepting a configurable `start_date`/`end_date` query-param range (defaults to the last 30 days when omitted):
  - `GET /brands/{brand_id}/analytics/summary` — per-brand aggregate (totals + averages, snapshot/post counts), broken down by platform, plus an `overall` row.
  - `GET /brands/{brand_id}/analytics/posts/{post_id}` — the same aggregate shape scoped to one post.
  - `GET /brands/{brand_id}/analytics/posts/{post_id}/trend` — the raw per-post time series (optionally filtered by `platform`), ordered by `polled_at`.
- Adds `apps/api/services/analytics_aggregation.py`: every aggregate is a single SQLAlchemy `func.sum`/`func.avg`/`func.count` + `group_by` query executed by Postgres — never "fetch all rows and reduce in Python". `get_post_trend` is the one query that legitimately returns row-per-snapshot, since a trend *is* the raw series, and it's bounded to one post's poll history.
- Adds a `posts.brand_id` index (`migrations/versions/63bac4f4c66f_posts_brand_id_index.py`) — posts had no index on `brand_id` before this, so the brand-scoped analytics join would otherwise sequentially scan the whole `posts` table on every request. Paired with the existing `engagement_snapshots_post_id_platform_idx` (#33), brand → posts → snapshots resolves entirely through indexes.
- Org/brand scoping follows the same 404-not-403 convention as `apps/api/routers/calendar.py`/`brands.py`: unknown/cross-org brand → 404, a post that exists but belongs to a different brand → 404.

## Why
Raw `EngagementSnapshot` rows aren't directly useful to a dashboard or to #35's weekly AI report — both need per-brand and per-post aggregates/trends. Closes #34; #35 will read its report data from this API rather than querying raw snapshots directly.

## Test plan
- `apps/api/tests/test_analytics.py` (13 tests): per-brand and per-post aggregate correctness against known seeded numbers, date-range filtering (in/out of window, default 30-day window), platform-filtered trend ordering, and org/brand scoping (404 on cross-org brand, cross-brand post, and unknown brand).
- Performance acceptance criterion: seeds 3,000 `EngagementSnapshot` rows (5 posts × 2 platforms × 300 polls each) and asserts both correct aggregate numbers *and* that the summary/post-aggregate requests complete in well under a 2s ceiling — meant to catch an accidental Python-side reduction, not to chase a specific benchmark.
- Full local suite: `DATABASE_URL=postgresql://localhost:5432/raindeer_test_issue34 pytest apps/api/tests packages/agents/tests -v --cov=apps/api --cov=packages --cov-fail-under=70` → **283 passed**, coverage **98%**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RWDQJeMLcdZ8JGwbKtpr1c