### PR TITLE
feat(web): add social account connections UI

### DIFF
--- a/apps/web/__tests__/social-accounts-page.test.tsx
+++ b/apps/web/__tests__/social-accounts-page.test.tsx
@@ -1,0 +1,189 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { act, render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import SocialAccountsPage from "@/app/social-accounts/page";
+import { AuthProvider } from "@/lib/auth-context";
+import { BrandProvider } from "@/lib/brand-context";
+import { ToastProvider } from "@/components/ui/Toast";
+import { ApiError } from "@/lib/api";
+import type { SocialAccount } from "@/lib/api";
+
+const fetchBrandsMock = vi.fn();
+const fetchSocialAccountsMock = vi.fn();
+const connectLinkedInMock = vi.fn();
+const disconnectSocialAccountMock = vi.fn();
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return {
+    ...actual,
+    fetchBrands: (...args: unknown[]) => fetchBrandsMock(...args),
+    fetchSocialAccounts: (...args: unknown[]) => fetchSocialAccountsMock(...args),
+    connectLinkedIn: (...args: unknown[]) => connectLinkedInMock(...args),
+    disconnectSocialAccount: (...args: unknown[]) => disconnectSocialAccountMock(...args),
+  };
+});
+
+const redirectToAuthorizeUrlMock = vi.fn();
+vi.mock("@/app/social-accounts/redirect", () => ({
+  redirectToAuthorizeUrl: (...args: unknown[]) => redirectToAuthorizeUrlMock(...args),
+}));
+
+const BRANDS = [
+  {
+    id: "brand-1",
+    organization_id: "org-1",
+    name: "Acme Co",
+    industry: null,
+    logo_url: null,
+    target_audience: null,
+    colors: null,
+    tone_descriptors: null,
+    product_catalog: null,
+    brand_report: null,
+    created_at: "2026-01-01",
+    updated_at: "2026-01-01",
+  },
+];
+
+function makeAccount(overrides: Partial<SocialAccount> = {}): SocialAccount {
+  return {
+    id: "account-1",
+    brand_id: "brand-1",
+    platform: "linkedin",
+    external_account_id: "urn:li:person:123",
+    token_expires_at: "2026-09-01T00:00:00Z",
+    scopes: ["w_member_social"],
+    status: "active",
+    created_at: "2026-08-01T00:00:00Z",
+    updated_at: "2026-08-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function renderPage() {
+  return render(
+    <ToastProvider>
+      <AuthProvider>
+        <BrandProvider>
+          <SocialAccountsPage />
+        </BrandProvider>
+      </AuthProvider>
+    </ToastProvider>
+  );
+}
+
+describe("SocialAccountsPage", () => {
+  beforeEach(() => {
+    fetchBrandsMock.mockReset();
+    fetchSocialAccountsMock.mockReset();
+    connectLinkedInMock.mockReset();
+    disconnectSocialAccountMock.mockReset();
+    redirectToAuthorizeUrlMock.mockReset();
+
+    window.localStorage.clear();
+    window.localStorage.setItem("raindeer.auth.token", "test-token");
+
+    fetchBrandsMock.mockResolvedValue(BRANDS);
+    fetchSocialAccountsMock.mockResolvedValue([]);
+  });
+
+  it("renders connected accounts with a status badge per account", async () => {
+    fetchSocialAccountsMock.mockResolvedValue([
+      makeAccount({ id: "a1", status: "active" }),
+      makeAccount({ id: "a2", status: "expired", external_account_id: "urn:li:person:456" }),
+      makeAccount({ id: "a3", status: "revoked", external_account_id: null, token_expires_at: null }),
+    ]);
+
+    renderPage();
+
+    await waitFor(() => expect(fetchSocialAccountsMock).toHaveBeenCalledWith("test-token", "brand-1"));
+
+    expect(await screen.findByText("Active")).toBeInTheDocument();
+    expect(screen.getByText("Expired")).toBeInTheDocument();
+    expect(screen.getByText("Revoked")).toBeInTheDocument();
+    expect(screen.getByText("Account ID: urn:li:person:123")).toBeInTheDocument();
+    expect(screen.getByText("No account ID on file")).toBeInTheDocument();
+  });
+
+  it("shows an empty state when nothing is connected for the brand", async () => {
+    renderPage();
+
+    expect(await screen.findByText("No accounts connected")).toBeInTheDocument();
+  });
+
+  it("starts the LinkedIn OAuth flow and redirects to the authorize URL on success", async () => {
+    connectLinkedInMock.mockResolvedValue({
+      authorize_url: "https://www.linkedin.com/oauth/v2/authorization?foo=bar",
+    });
+    const user = userEvent.setup();
+
+    renderPage();
+    await waitFor(() => expect(fetchSocialAccountsMock).toHaveBeenCalled());
+
+    await user.click(screen.getByRole("button", { name: "Connect LinkedIn" }));
+
+    await waitFor(() => {
+      expect(connectLinkedInMock).toHaveBeenCalledWith("test-token", "brand-1");
+      expect(redirectToAuthorizeUrlMock).toHaveBeenCalledWith(
+        "https://www.linkedin.com/oauth/v2/authorization?foo=bar"
+      );
+    });
+  });
+
+  it("shows a friendly message instead of a generic error when LinkedIn isn't configured", async () => {
+    connectLinkedInMock.mockRejectedValue(new ApiError("LinkedIn OAuth is not configured", 503));
+    const user = userEvent.setup();
+
+    renderPage();
+    await waitFor(() => expect(fetchSocialAccountsMock).toHaveBeenCalled());
+
+    await user.click(screen.getByRole("button", { name: "Connect LinkedIn" }));
+
+    expect(await screen.findByText("LinkedIn isn't configured on this server yet.")).toBeInTheDocument();
+    expect(redirectToAuthorizeUrlMock).not.toHaveBeenCalled();
+    // Not a raw/generic backend error message anywhere on the page.
+    expect(screen.queryByText("LinkedIn OAuth is not configured")).not.toBeInTheDocument();
+  });
+
+  it("disconnects an account only after the confirmation step is completed", async () => {
+    fetchSocialAccountsMock.mockResolvedValue([makeAccount({ id: "a1", status: "active" })]);
+    disconnectSocialAccountMock.mockResolvedValue(makeAccount({ id: "a1", status: "revoked" }));
+    const user = userEvent.setup();
+
+    renderPage();
+    await screen.findByText("Active");
+
+    await user.click(screen.getByRole("button", { name: "Disconnect" }));
+
+    // Confirmation dialog is open; the API call hasn't fired yet.
+    const dialog = await screen.findByRole("dialog");
+    expect(disconnectSocialAccountMock).not.toHaveBeenCalled();
+
+    await act(async () => {
+      await user.click(within(dialog).getByRole("button", { name: "Disconnect" }));
+    });
+
+    await waitFor(() => {
+      expect(disconnectSocialAccountMock).toHaveBeenCalledWith("test-token", "brand-1", "a1");
+    });
+    await waitFor(() => expect(screen.queryByRole("dialog")).not.toBeInTheDocument());
+    expect(await screen.findByText("Revoked")).toBeInTheDocument();
+  });
+
+  it("cancels the disconnect confirmation without calling the API", async () => {
+    fetchSocialAccountsMock.mockResolvedValue([makeAccount({ id: "a1", status: "active" })]);
+    const user = userEvent.setup();
+
+    renderPage();
+    await screen.findByText("Active");
+
+    await user.click(screen.getByRole("button", { name: "Disconnect" }));
+    const dialog = await screen.findByRole("dialog");
+    await user.click(within(dialog).getByRole("button", { name: "Cancel" }));
+
+    await waitFor(() => expect(screen.queryByRole("dialog")).not.toBeInTheDocument());
+    expect(disconnectSocialAccountMock).not.toHaveBeenCalled();
+    expect(screen.getByText("Active")).toBeInTheDocument();
+  });
+});

--- a/apps/web/app/social-accounts/page.tsx
+++ b/apps/web/app/social-accounts/page.tsx
@@ -1,0 +1,277 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import {
+  ApiError,
+  connectLinkedIn,
+  disconnectSocialAccount,
+  fetchSocialAccounts,
+  type AuthorizeUrlResponse,
+  type SocialAccount,
+  type SocialAccountStatus,
+  type SocialPlatform,
+} from "@/lib/api";
+import { useAuth } from "@/lib/auth-context";
+import { useBrand } from "@/lib/brand-context";
+import { useToast } from "@/components/ui/Toast";
+import { PageHeader } from "@/components/ui/PageHeader";
+import { Card, CardBody, CardHeader } from "@/components/ui/Card";
+import { Badge, type BadgeTone } from "@/components/ui/Badge";
+import { Button } from "@/components/ui/Button";
+import { EmptyState } from "@/components/ui/EmptyState";
+import { Skeleton } from "@/components/ui/Skeleton";
+import { Modal } from "@/components/ui/Modal";
+import { redirectToAuthorizeUrl } from "./redirect";
+
+// Human-readable labels per apps/api/models/social_account.py::SocialPlatform.
+// Falls back to the raw value for anything not listed, so an unrecognized
+// platform still renders instead of breaking.
+const PLATFORM_LABELS: Partial<Record<SocialPlatform, string>> = {
+  linkedin: "LinkedIn",
+};
+
+function platformLabel(platform: SocialPlatform): string {
+  return PLATFORM_LABELS[platform] ?? platform;
+}
+
+// Platforms the UI can start a connect flow for. LinkedIn is genuinely the
+// only connectable platform today, but this is a list plus a lookup table
+// (not a single hardcoded button/handler) so a second provider is a data
+// change here rather than a rewrite of this page.
+const CONNECTABLE_PLATFORMS: SocialPlatform[] = ["linkedin"];
+
+const CONNECT_HANDLERS: Partial<
+  Record<SocialPlatform, (token: string, brandId: string) => Promise<AuthorizeUrlResponse>>
+> = {
+  linkedin: connectLinkedIn,
+};
+
+const STATUS_TONE: Record<SocialAccountStatus, BadgeTone> = {
+  active: "green",
+  expired: "amber",
+  revoked: "slate",
+};
+
+const STATUS_LABEL: Record<SocialAccountStatus, string> = {
+  active: "Active",
+  expired: "Expired",
+  revoked: "Revoked",
+};
+
+function formatExpiry(iso: string | null): string | null {
+  if (!iso) return null;
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return null;
+  return date.toLocaleString(undefined, { dateStyle: "medium", timeStyle: "short" });
+}
+
+export default function SocialAccountsPage() {
+  const { token } = useAuth();
+  const { selectedBrand, selectedBrandId } = useBrand();
+  const { push } = useToast();
+
+  const [accounts, setAccounts] = useState<SocialAccount[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [connectingPlatform, setConnectingPlatform] = useState<SocialPlatform | null>(null);
+  const [notConfiguredPlatform, setNotConfiguredPlatform] = useState<SocialPlatform | null>(null);
+  const [pendingDisconnect, setPendingDisconnect] = useState<SocialAccount | null>(null);
+  const [isDisconnecting, setIsDisconnecting] = useState(false);
+
+  const loadAccounts = useCallback(
+    async (showSpinner: boolean) => {
+      if (!token || !selectedBrandId) {
+        setAccounts([]);
+        return;
+      }
+      if (showSpinner) setIsLoading(true);
+      setLoadError(null);
+      try {
+        const result = await fetchSocialAccounts(token, selectedBrandId);
+        setAccounts(result);
+      } catch (err) {
+        setLoadError(err instanceof Error ? err.message : "Failed to load social accounts");
+      } finally {
+        if (showSpinner) setIsLoading(false);
+      }
+    },
+    [token, selectedBrandId]
+  );
+
+  // Re-run whenever the token or selected brand changes, and refresh on
+  // window focus — the OAuth flow this page kicks off navigates away from
+  // the app entirely, so a background refresh on return is the only way a
+  // newly connected account shows up without a manual reload.
+  useEffect(() => {
+    setAccounts([]);
+    loadAccounts(true);
+
+    const onFocus = () => loadAccounts(false);
+    window.addEventListener("focus", onFocus);
+    return () => window.removeEventListener("focus", onFocus);
+  }, [loadAccounts]);
+
+  async function handleConnect(platform: SocialPlatform) {
+    if (!token || !selectedBrandId) return;
+    const connect = CONNECT_HANDLERS[platform];
+    if (!connect) return;
+
+    setNotConfiguredPlatform(null);
+    setConnectingPlatform(platform);
+    try {
+      const { authorize_url } = await connect(token, selectedBrandId);
+      redirectToAuthorizeUrl(authorize_url);
+    } catch (err) {
+      // The backend 503s with a specific, well-known detail message when
+      // it has no LINKEDIN_REDIRECT_URI configured (see
+      // apps/api/routers/social_accounts.py::connect_linkedin) — that's an
+      // expected, common dev-environment state, not a generic failure, so
+      // it gets its own friendly message instead of an error toast.
+      if (err instanceof ApiError && err.status === 503) {
+        setNotConfiguredPlatform(platform);
+      } else {
+        push(err instanceof ApiError ? err.message : "Failed to start the connection", "error");
+      }
+    } finally {
+      setConnectingPlatform(null);
+    }
+  }
+
+  async function handleDisconnect() {
+    if (!token || !selectedBrandId || !pendingDisconnect) return;
+    setIsDisconnecting(true);
+    try {
+      const updated = await disconnectSocialAccount(token, selectedBrandId, pendingDisconnect.id);
+      setAccounts((current) => current.map((account) => (account.id === updated.id ? updated : account)));
+      push(`Disconnected ${platformLabel(updated.platform)}`, "success");
+      setPendingDisconnect(null);
+    } catch (err) {
+      push(err instanceof ApiError ? err.message : "Failed to disconnect account", "error");
+    } finally {
+      setIsDisconnecting(false);
+    }
+  }
+
+  return (
+    <div>
+      <PageHeader
+        title="Connections"
+        description={
+          selectedBrand
+            ? `Social accounts connected for ${selectedBrand.name}.`
+            : "Select a brand to manage its social account connections."
+        }
+      />
+
+      {!selectedBrand ? (
+        <EmptyState title="No brand selected" description="Choose a brand to see its connections." />
+      ) : (
+        <div className="space-y-6">
+          <Card>
+            <CardHeader
+              title="Connect a platform"
+              description="Starts the OAuth flow in this tab and brings you back here once it's authorized."
+            />
+            <CardBody className="flex flex-wrap gap-4">
+              {CONNECTABLE_PLATFORMS.map((platform) => (
+                <div key={platform} className="flex flex-col gap-1.5">
+                  <Button
+                    variant="primary"
+                    isLoading={connectingPlatform === platform}
+                    onClick={() => handleConnect(platform)}
+                  >
+                    Connect {platformLabel(platform)}
+                  </Button>
+                  {notConfiguredPlatform === platform ? (
+                    <p role="alert" className="max-w-xs text-sm text-amber-700">
+                      {platformLabel(platform)} isn&apos;t configured on this server yet.
+                    </p>
+                  ) : null}
+                </div>
+              ))}
+            </CardBody>
+          </Card>
+
+          {loadError ? (
+            <p role="alert" className="rounded-lg bg-red-50 px-3 py-2 text-sm font-medium text-red-700">
+              {loadError}
+            </p>
+          ) : null}
+
+          {isLoading && accounts.length === 0 ? (
+            <Card>
+              <CardBody className="space-y-3">
+                <Skeleton className="h-5 w-1/3" />
+                <Skeleton className="h-5 w-1/2" />
+                <Skeleton className="h-5 w-1/4" />
+              </CardBody>
+            </Card>
+          ) : accounts.length === 0 ? (
+            <EmptyState
+              title="No accounts connected"
+              description="Connect a platform above to start publishing from this brand."
+            />
+          ) : (
+            <ul className="space-y-3">
+              {accounts.map((account) => {
+                const expiry = formatExpiry(account.token_expires_at);
+                return (
+                  <li key={account.id}>
+                    <Card>
+                      <CardBody className="flex flex-wrap items-center justify-between gap-4">
+                        <div>
+                          <div className="flex items-center gap-2">
+                            <h3 className="text-sm font-semibold text-slate-900">
+                              {platformLabel(account.platform)}
+                            </h3>
+                            <Badge tone={STATUS_TONE[account.status]}>{STATUS_LABEL[account.status]}</Badge>
+                          </div>
+                          <p className="mt-1 text-sm text-slate-500">
+                            {account.external_account_id
+                              ? `Account ID: ${account.external_account_id}`
+                              : "No account ID on file"}
+                          </p>
+                          {expiry ? (
+                            <p className="mt-0.5 text-sm text-slate-500">
+                              {account.status === "expired" ? "Expired" : "Expires"} {expiry}
+                            </p>
+                          ) : null}
+                        </div>
+                        <Button variant="danger" size="sm" onClick={() => setPendingDisconnect(account)}>
+                          Disconnect
+                        </Button>
+                      </CardBody>
+                    </Card>
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+        </div>
+      )}
+
+      <Modal
+        open={pendingDisconnect !== null}
+        onClose={() => setPendingDisconnect(null)}
+        title="Disconnect account"
+        footer={
+          <>
+            <Button variant="outline" onClick={() => setPendingDisconnect(null)} disabled={isDisconnecting}>
+              Cancel
+            </Button>
+            <Button variant="danger" isLoading={isDisconnecting} onClick={handleDisconnect}>
+              Disconnect
+            </Button>
+          </>
+        }
+      >
+        {pendingDisconnect ? (
+          <p className="text-sm text-slate-600">
+            Disconnect {platformLabel(pendingDisconnect.platform)}? Raindeer will no longer be able to
+            publish to this account until it&apos;s reconnected.
+          </p>
+        ) : null}
+      </Modal>
+    </div>
+  );
+}

--- a/apps/web/app/social-accounts/redirect.ts
+++ b/apps/web/app/social-accounts/redirect.ts
@@ -1,0 +1,7 @@
+// Isolated from page.tsx so tests can mock the actual browser navigation
+// (jsdom doesn't perform real page loads, and asserting on a real
+// `window.location.href` mutation is awkward) while still exercising the
+// real connect-then-redirect flow.
+export function redirectToAuthorizeUrl(url: string): void {
+  window.location.href = url;
+}

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -338,3 +338,86 @@ export async function rescheduleReviewPost(
 
   return res.json();
 }
+
+// --- Social accounts (Issue #91) ---
+
+// Mirrors apps/api/models/social_account.py::SocialPlatform. "linkedin" is
+// the only value today, but this is kept as a string union (not a literal)
+// so the UI layer can stay written generically as more providers land.
+export type SocialPlatform = "linkedin";
+
+// Mirrors apps/api/models/social_account.py::SocialAccountStatus.
+export type SocialAccountStatus = "active" | "expired" | "revoked";
+
+// Mirrors apps/api/schemas/social_account.py::SocialAccountRead.
+export interface SocialAccount {
+  id: string;
+  brand_id: string;
+  platform: SocialPlatform;
+  external_account_id: string | null;
+  token_expires_at: string | null;
+  scopes: string[] | null;
+  status: SocialAccountStatus;
+  created_at: string;
+  updated_at: string;
+}
+
+// Mirrors apps/api/schemas/social_account.py::AuthorizeUrlRead.
+export interface AuthorizeUrlResponse {
+  authorize_url: string;
+}
+
+// apps/api/routers/social_accounts.py mounts these under
+// /brands/{brand_id}/social-accounts — same brand-scoping convention as
+// calendarEventsUrl/reviewQueueUrl above.
+function socialAccountsUrl(brandId: string, suffix = ""): string {
+  return `${API_URL}/brands/${brandId}/social-accounts${suffix}`;
+}
+
+export async function fetchSocialAccounts(token: string, brandId: string): Promise<SocialAccount[]> {
+  const res = await fetch(socialAccountsUrl(brandId), {
+    headers: authHeaders(token),
+  });
+
+  if (!res.ok) {
+    throw new ApiError(await parseErrorDetail(res), res.status);
+  }
+
+  return res.json();
+}
+
+// Starts the LinkedIn OAuth flow and returns the authorize URL to send the
+// browser to. Deliberately does not navigate itself (no `window.location`
+// here) — that's UI-layer behavior the caller performs, which keeps this
+// function trivially testable and matches how apps/api/routers/social_accounts.py
+// separates "give me a URL" (POST .../linkedin/connect) from the redirect
+// the browser does with it.
+export async function connectLinkedIn(token: string, brandId: string): Promise<AuthorizeUrlResponse> {
+  const res = await fetch(socialAccountsUrl(brandId, "/linkedin/connect"), {
+    method: "POST",
+    headers: authHeaders(token),
+  });
+
+  if (!res.ok) {
+    throw new ApiError(await parseErrorDetail(res), res.status);
+  }
+
+  return res.json();
+}
+
+export async function disconnectSocialAccount(
+  token: string,
+  brandId: string,
+  accountId: string
+): Promise<SocialAccount> {
+  const res = await fetch(socialAccountsUrl(brandId, `/${accountId}`), {
+    method: "DELETE",
+    headers: authHeaders(token),
+  });
+
+  if (!res.ok) {
+    throw new ApiError(await parseErrorDetail(res), res.status);
+  }
+
+  return res.json();
+}


### PR DESCRIPTION
## Summary
- Adds `/social-accounts`, a brand-scoped page listing connected social accounts (`GET /brands/{brand_id}/social-accounts`) as cards with a status badge (green/active, amber/expired, slate/revoked), platform label, external account id, and expiry info when present.
- "Connect LinkedIn" button calls `POST /brands/{brand_id}/social-accounts/linkedin/connect` and redirects the browser to the returned `authorize_url`. Written generically over a `CONNECTABLE_PLATFORMS` list + handler map (not a single hardcoded button) so a second provider is a data change, even though LinkedIn is the only connectable platform today.
- The connect endpoint's 503 (`{"detail": "LinkedIn OAuth is not configured"}`, thrown when `LINKEDIN_REDIRECT_UI` isn't set) is caught specifically and rendered as a friendly "LinkedIn isn't configured on this server yet." message instead of a generic error toast.
- Disconnect action per account (`DELETE /brands/{brand_id}/social-accounts/{account_id}`) behind a confirm-step modal.
- Empty states for "no brand selected" and "no accounts connected" via `components/ui/EmptyState.tsx`.
- Built entirely on the #88 design system: `PageHeader`, `Card`/`CardHeader`/`CardBody`, `Badge`, `Button`, `Modal`, `EmptyState`, `Skeleton`, `useToast`.
- `lib/api.ts`: added `fetchSocialAccounts`, `connectLinkedIn`, `disconnectSocialAccount` in a new `// --- Social accounts (Issue #91) ---` banner section at the end of the file, following the existing brand-scoped-URL-helper pattern. `connectLinkedIn` only returns the authorize URL — it does not call `window.location` itself; the redirect is a UI-layer call to a small `redirectToAuthorizeUrl` wrapper in `app/social-accounts/redirect.ts`, kept separate so it's mockable in tests.

### Note on the OAuth callback
`GET /oauth/linkedin/callback` is hit directly by LinkedIn, not by this frontend. It currently returns the `SocialAccountRead` JSON body directly rather than redirecting back to the frontend app — so after a successful LinkedIn authorization, the user is left looking at a raw JSON response instead of landing back on `/social-accounts`. Out of scope for this issue, but worth a follow-up.

## Test plan
- `apps/web/__tests__/social-accounts-page.test.tsx` (new): list rendering across active/expired/revoked statuses, empty state, connect flow asserting the redirect target, the 503 "not configured" friendly-message path (and that the raw backend detail string is never shown), disconnect with confirm/cancel.
- Ran locally with Node 18 (`node -v` confirmed v18.20.8) from `apps/web`:
  - [x] `npm ci` 
  - [x] `npm run lint` (clean; only a pre-existing `next/image` warning in `components/ui/Avatar.tsx`, unrelated to this change)
  - [x] `npm run test` (7 files, 35 tests passing, including the 6 new social-accounts tests)
  - [x] `npm run build` (`/social-accounts` route compiles and prerenders)

Closes #91