### PR TITLE
feat(web): add brand management UI

### DIFF
--- a/apps/web/__tests__/api.test.ts
+++ b/apps/web/__tests__/api.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
-import { ApiError, fetchBrands, login } from "@/lib/api";
+import { ApiError, createBrand, fetchBrands, login, uploadBrandLogo } from "@/lib/api";
 
 describe("api client", () => {
   const originalFetch = global.fetch;
@@ -63,5 +63,37 @@ describe("api client", () => {
     });
 
     await expect(fetchBrands("test-token")).rejects.toBeInstanceOf(ApiError);
+  });
+
+  it("createBrand posts the payload as JSON with the bearer token", async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: async () => ({ id: "brand-1", name: "Acme Co" }),
+    });
+
+    await createBrand("test-token", { name: "Acme Co", industry: "Retail" });
+
+    const [url, options] = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(url).toContain("/brands");
+    expect(options.method).toBe("POST");
+    expect(options.headers.Authorization).toBe("Bearer test-token");
+    expect(JSON.parse(options.body)).toEqual({ name: "Acme Co", industry: "Retail" });
+  });
+
+  it("uploadBrandLogo PUTs a multipart form with the file under the 'file' field", async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: async () => ({ id: "brand-1", logo_url: "https://cdn.example.com/logo.png" }),
+    });
+    const file = new File(["bytes"], "logo.png", { type: "image/png" });
+
+    await uploadBrandLogo("test-token", "brand-1", file);
+
+    const [url, options] = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(url).toContain("/brands/brand-1/logo");
+    expect(options.method).toBe("PUT");
+    expect(options.headers.Authorization).toBe("Bearer test-token");
+    expect(options.body).toBeInstanceOf(FormData);
+    expect((options.body as FormData).get("file")).toBe(file);
   });
 });

--- a/apps/web/__tests__/brands-page.test.tsx
+++ b/apps/web/__tests__/brands-page.test.tsx
@@ -1,0 +1,237 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { act, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import BrandsPage from "@/app/brands/page";
+import { AuthProvider } from "@/lib/auth-context";
+import { BrandProvider } from "@/lib/brand-context";
+import { ToastProvider } from "@/components/ui/Toast";
+import type { Brand } from "@/lib/api";
+
+const fetchBrandsMock = vi.fn();
+const createBrandMock = vi.fn();
+const updateBrandMock = vi.fn();
+const deleteBrandMock = vi.fn();
+const uploadBrandLogoMock = vi.fn();
+const removeBrandLogoMock = vi.fn();
+
+vi.mock("@/lib/api", () => ({
+  fetchBrands: (...args: unknown[]) => fetchBrandsMock(...args),
+  createBrand: (...args: unknown[]) => createBrandMock(...args),
+  updateBrand: (...args: unknown[]) => updateBrandMock(...args),
+  deleteBrand: (...args: unknown[]) => deleteBrandMock(...args),
+  uploadBrandLogo: (...args: unknown[]) => uploadBrandLogoMock(...args),
+  removeBrandLogo: (...args: unknown[]) => removeBrandLogoMock(...args),
+}));
+
+function makeBrand(overrides: Partial<Brand> = {}): Brand {
+  return {
+    id: "brand-1",
+    organization_id: "org-1",
+    name: "Acme Co",
+    industry: "Retail",
+    logo_url: null,
+    target_audience: "Young professionals",
+    colors: ["#FF5733", "#1A1A2E"],
+    tone_descriptors: ["playful", "confident"],
+    product_catalog: null,
+    brand_report: null,
+    created_at: "2026-01-01",
+    updated_at: "2026-01-01",
+    ...overrides,
+  };
+}
+
+function renderPage() {
+  return render(
+    <ToastProvider>
+      <AuthProvider>
+        <BrandProvider>
+          <BrandsPage />
+        </BrandProvider>
+      </AuthProvider>
+    </ToastProvider>
+  );
+}
+
+describe("BrandsPage", () => {
+  beforeEach(() => {
+    fetchBrandsMock.mockReset();
+    createBrandMock.mockReset();
+    updateBrandMock.mockReset();
+    deleteBrandMock.mockReset();
+    uploadBrandLogoMock.mockReset();
+    removeBrandLogoMock.mockReset();
+
+    window.localStorage.clear();
+    window.localStorage.setItem("raindeer.auth.token", "test-token");
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("renders every brand as a card with its industry, audience, and color swatches", async () => {
+    fetchBrandsMock.mockResolvedValue([makeBrand()]);
+
+    renderPage();
+
+    const card = await screen.findByRole("article", { name: "Acme Co" });
+    expect(within(card).getByText("Retail")).toBeInTheDocument();
+    expect(within(card).getByText("Young professionals")).toBeInTheDocument();
+    expect(within(card).getByText("playful")).toBeInTheDocument();
+    expect(within(card).getByTitle("#FF5733")).toBeInTheDocument();
+  });
+
+  it("shows an empty state with a create CTA when the org has no brands", async () => {
+    fetchBrandsMock.mockResolvedValue([]);
+
+    renderPage();
+
+    await screen.findByText("No brands yet");
+    expect(screen.getByRole("button", { name: "Create your first brand" })).toBeInTheDocument();
+  });
+
+  it("creates a new brand through the form and refreshes the list", async () => {
+    fetchBrandsMock.mockResolvedValueOnce([]).mockResolvedValueOnce([makeBrand({ id: "new-1", name: "New Brand" })]);
+    createBrandMock.mockResolvedValue(makeBrand({ id: "new-1", name: "New Brand" }));
+    const user = userEvent.setup();
+
+    renderPage();
+    await screen.findByText("No brands yet");
+
+    await user.click(screen.getByRole("button", { name: "Create your first brand" }));
+    const dialog = await screen.findByRole("dialog");
+    expect(within(dialog).getByRole("heading", { name: "New brand" })).toBeInTheDocument();
+
+    await user.type(within(dialog).getByLabelText("Name", { exact: false }), "New Brand");
+    await user.type(within(dialog).getByLabelText("Industry"), "Tech");
+    await user.type(within(dialog).getByLabelText(/Brand colors/), "#111111, #222222");
+    await act(async () => {
+      await user.click(within(dialog).getByRole("button", { name: "Create brand" }));
+    });
+
+    await waitFor(() => {
+      expect(createBrandMock).toHaveBeenCalledWith(
+        "test-token",
+        expect.objectContaining({
+          name: "New Brand",
+          industry: "Tech",
+          colors: ["#111111", "#222222"],
+        })
+      );
+    });
+
+    expect(fetchBrandsMock).toHaveBeenCalledTimes(2);
+    await screen.findByRole("article", { name: "New Brand" });
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("rejects invalid JSON in the product catalog field without submitting", async () => {
+    fetchBrandsMock.mockResolvedValue([]);
+    const user = userEvent.setup();
+
+    renderPage();
+    await screen.findByText("No brands yet");
+    await user.click(screen.getByRole("button", { name: "Create your first brand" }));
+    const dialog = await screen.findByRole("dialog");
+
+    await user.type(within(dialog).getByLabelText("Name", { exact: false }), "Bad JSON Brand");
+    // fireEvent.change (not user.type) — userEvent.type() treats "{"/"}" as
+    // special-key syntax, so a raw invalid-JSON string can't be typed with it.
+    fireEvent.change(within(dialog).getByLabelText(/Product catalog/), {
+      target: { value: "{not valid json" },
+    });
+    await user.click(within(dialog).getByRole("button", { name: "Create brand" }));
+
+    expect(await within(dialog).findByRole("alert")).toHaveTextContent(/valid JSON/);
+    expect(createBrandMock).not.toHaveBeenCalled();
+  });
+
+  it("edits an existing brand, pre-filling the form, and round-trips it through the API", async () => {
+    fetchBrandsMock
+      .mockResolvedValueOnce([makeBrand()])
+      .mockResolvedValueOnce([makeBrand({ industry: "Fashion" })]);
+    updateBrandMock.mockResolvedValue(makeBrand({ industry: "Fashion" }));
+    const user = userEvent.setup();
+
+    renderPage();
+    const card = await screen.findByRole("article", { name: "Acme Co" });
+
+    await user.click(within(card).getByRole("button", { name: "Edit" }));
+    const dialog = await screen.findByRole("dialog");
+    expect(within(dialog).getByRole("heading", { name: "Edit brand" })).toBeInTheDocument();
+    expect(within(dialog).getByLabelText("Name", { exact: false })).toHaveValue("Acme Co");
+    expect(within(dialog).getByLabelText("Industry")).toHaveValue("Retail");
+
+    await user.clear(within(dialog).getByLabelText("Industry"));
+    await user.type(within(dialog).getByLabelText("Industry"), "Fashion");
+    await act(async () => {
+      await user.click(within(dialog).getByRole("button", { name: "Save changes" }));
+    });
+
+    await waitFor(() => {
+      expect(updateBrandMock).toHaveBeenCalledWith(
+        "test-token",
+        "brand-1",
+        expect.objectContaining({ industry: "Fashion" })
+      );
+    });
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("deletes a brand after confirmation and removes it from the list", async () => {
+    fetchBrandsMock.mockResolvedValueOnce([makeBrand()]).mockResolvedValueOnce([]);
+    deleteBrandMock.mockResolvedValue(undefined);
+    vi.spyOn(window, "confirm").mockReturnValue(true);
+    const user = userEvent.setup();
+
+    renderPage();
+    const card = await screen.findByRole("article", { name: "Acme Co" });
+
+    await act(async () => {
+      await user.click(within(card).getByRole("button", { name: "Delete" }));
+    });
+
+    expect(window.confirm).toHaveBeenCalledWith(expect.stringContaining("Acme Co"));
+    await waitFor(() => expect(deleteBrandMock).toHaveBeenCalledWith("test-token", "brand-1"));
+    await waitFor(() => expect(screen.queryByRole("article", { name: "Acme Co" })).not.toBeInTheDocument());
+  });
+
+  it("does not delete a brand when the confirmation is dismissed", async () => {
+    fetchBrandsMock.mockResolvedValue([makeBrand()]);
+    vi.spyOn(window, "confirm").mockReturnValue(false);
+    const user = userEvent.setup();
+
+    renderPage();
+    const card = await screen.findByRole("article", { name: "Acme Co" });
+    await user.click(within(card).getByRole("button", { name: "Delete" }));
+
+    expect(deleteBrandMock).not.toHaveBeenCalled();
+    expect(screen.getByRole("article", { name: "Acme Co" })).toBeInTheDocument();
+  });
+
+  it("uploads a logo from the edit modal and refreshes the brand list", async () => {
+    fetchBrandsMock
+      .mockResolvedValueOnce([makeBrand()])
+      .mockResolvedValueOnce([makeBrand({ logo_url: "https://cdn.example.com/logo.png" })]);
+    uploadBrandLogoMock.mockResolvedValue(makeBrand({ logo_url: "https://cdn.example.com/logo.png" }));
+    const user = userEvent.setup();
+
+    renderPage();
+    const card = await screen.findByRole("article", { name: "Acme Co" });
+    await user.click(within(card).getByRole("button", { name: "Edit" }));
+
+    const dialog = await screen.findByRole("dialog");
+    const file = new File(["logo-bytes"], "logo.png", { type: "image/png" });
+    const fileInput = within(dialog).getByLabelText("Upload logo");
+
+    await act(async () => {
+      await user.upload(fileInput, file);
+    });
+
+    await waitFor(() => {
+      expect(uploadBrandLogoMock).toHaveBeenCalledWith("test-token", "brand-1", file);
+    });
+    expect(fetchBrandsMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/web/app/brands/brand-card.tsx
+++ b/apps/web/app/brands/brand-card.tsx
@@ -1,0 +1,67 @@
+import type { Brand } from "@/lib/api";
+import { Avatar } from "@/components/ui/Avatar";
+import { Badge } from "@/components/ui/Badge";
+import { Button } from "@/components/ui/Button";
+import { Card } from "@/components/ui/Card";
+
+export function BrandCard({
+  brand,
+  onEdit,
+  onDelete,
+}: {
+  brand: Brand;
+  onEdit: () => void;
+  onDelete: () => void;
+}) {
+  return (
+    <Card role="article" aria-label={brand.name} className="flex h-full flex-col p-5">
+      <div className="flex items-center gap-3">
+        <Avatar name={brand.name} src={brand.logo_url} size="lg" />
+        <div className="min-w-0">
+          <h3 className="truncate text-sm font-semibold text-slate-900">{brand.name}</h3>
+          {brand.industry ? (
+            <Badge tone="brand" className="mt-1">
+              {brand.industry}
+            </Badge>
+          ) : null}
+        </div>
+      </div>
+
+      {brand.target_audience ? (
+        <p className="mt-3 line-clamp-2 text-sm text-slate-500">{brand.target_audience}</p>
+      ) : null}
+
+      {brand.colors && brand.colors.length > 0 ? (
+        <div className="mt-3 flex flex-wrap items-center gap-1.5">
+          {brand.colors.map((color, index) => (
+            <span
+              key={`${color}-${index}`}
+              title={color}
+              className="h-5 w-5 rounded-full border border-slate-200"
+              style={{ backgroundColor: color }}
+            />
+          ))}
+        </div>
+      ) : null}
+
+      {brand.tone_descriptors && brand.tone_descriptors.length > 0 ? (
+        <div className="mt-3 flex flex-wrap gap-1.5">
+          {brand.tone_descriptors.map((tone) => (
+            <Badge key={tone} tone="slate">
+              {tone}
+            </Badge>
+          ))}
+        </div>
+      ) : null}
+
+      <div className="mt-4 flex justify-end gap-2 border-t border-slate-100 pt-3">
+        <Button variant="outline" size="sm" onClick={onEdit}>
+          Edit
+        </Button>
+        <Button variant="danger" size="sm" onClick={onDelete}>
+          Delete
+        </Button>
+      </div>
+    </Card>
+  );
+}

--- a/apps/web/app/brands/brand-form.tsx
+++ b/apps/web/app/brands/brand-form.tsx
@@ -1,0 +1,242 @@
+"use client";
+
+import { useRef, useState } from "react";
+import type { ChangeEvent, FormEvent } from "react";
+import type { Brand, BrandInput, BrandUpdateInput } from "@/lib/api";
+import { Button } from "@/components/ui/Button";
+import { Field, Input, Textarea } from "@/components/ui/Input";
+
+interface BrandFormProps {
+  /** null when creating a new brand, the existing brand when editing one. */
+  brand: Brand | null;
+  onCancel: () => void;
+  onSubmit: (payload: BrandInput | BrandUpdateInput) => Promise<void>;
+  /** Only available when editing — a brand must exist before it can have a logo. */
+  onUploadLogo?: (file: File) => Promise<void>;
+  onRemoveLogo?: () => Promise<void>;
+}
+
+function joinList(values: string[] | null | undefined): string {
+  return values?.join(", ") ?? "";
+}
+
+// Comma-separated free text -> a trimmed, non-empty string array, or null
+// when the field was left blank (so PATCH payloads can clear a field by
+// submitting an empty input rather than omitting it).
+function parseList(value: string): string[] | null {
+  const items = value
+    .split(",")
+    .map((item) => item.trim())
+    .filter(Boolean);
+  return items.length > 0 ? items : null;
+}
+
+export function BrandForm({ brand, onCancel, onSubmit, onUploadLogo, onRemoveLogo }: BrandFormProps) {
+  const isEdit = brand !== null;
+
+  const [name, setName] = useState(brand?.name ?? "");
+  const [industry, setIndustry] = useState(brand?.industry ?? "");
+  const [targetAudience, setTargetAudience] = useState(brand?.target_audience ?? "");
+  const [colors, setColors] = useState(joinList(brand?.colors));
+  const [toneDescriptors, setToneDescriptors] = useState(joinList(brand?.tone_descriptors));
+  const [productCatalog, setProductCatalog] = useState(
+    brand?.product_catalog ? JSON.stringify(brand.product_catalog, null, 2) : ""
+  );
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [isUploadingLogo, setIsUploadingLogo] = useState(false);
+  const [isRemovingLogo, setIsRemovingLogo] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const colorSwatches = parseList(colors) ?? [];
+
+  async function handleSubmit(event: FormEvent) {
+    event.preventDefault();
+
+    if (!name.trim()) {
+      setError("Name is required.");
+      return;
+    }
+
+    let parsedCatalog: Record<string, unknown> | null = null;
+    if (productCatalog.trim()) {
+      try {
+        parsedCatalog = JSON.parse(productCatalog);
+      } catch {
+        setError("Product catalog must be valid JSON.");
+        return;
+      }
+    }
+
+    setError(null);
+    setIsSubmitting(true);
+    try {
+      await onSubmit({
+        name: name.trim(),
+        industry: industry.trim() || null,
+        target_audience: targetAudience.trim() || null,
+        colors: parseList(colors),
+        tone_descriptors: parseList(toneDescriptors),
+        product_catalog: parsedCatalog,
+      });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to save brand.");
+      setIsSubmitting(false);
+    }
+  }
+
+  async function handleLogoFileChange(event: ChangeEvent<HTMLInputElement>) {
+    const file = event.target.files?.[0];
+    event.target.value = "";
+    if (!file || !onUploadLogo) return;
+
+    setIsUploadingLogo(true);
+    try {
+      await onUploadLogo(file);
+    } finally {
+      setIsUploadingLogo(false);
+    }
+  }
+
+  async function handleRemoveLogoClick() {
+    if (!onRemoveLogo) return;
+    setIsRemovingLogo(true);
+    try {
+      await onRemoveLogo();
+    } finally {
+      setIsRemovingLogo(false);
+    }
+  }
+
+  return (
+    <form id="brand-form" onSubmit={handleSubmit} noValidate className="space-y-4">
+      {isEdit && brand ? (
+        <div className="space-y-1.5">
+          <span className="block text-sm font-medium text-slate-700">Logo</span>
+          <div className="flex items-center gap-3">
+            {brand.logo_url ? (
+              // eslint-disable-next-line @next/next/no-img-element
+              <img
+                src={brand.logo_url}
+                alt={`${brand.name} logo`}
+                className="h-12 w-12 rounded-full object-cover"
+              />
+            ) : (
+              <div className="flex h-12 w-12 items-center justify-center rounded-full bg-slate-100 text-xs font-medium text-slate-400">
+                No logo
+              </div>
+            )}
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept="image/*"
+              aria-label="Upload logo"
+              className="hidden"
+              onChange={handleLogoFileChange}
+            />
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              isLoading={isUploadingLogo}
+              onClick={() => fileInputRef.current?.click()}
+            >
+              {brand.logo_url ? "Replace logo" : "Upload logo"}
+            </Button>
+            {brand.logo_url ? (
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                isLoading={isRemovingLogo}
+                disabled={isUploadingLogo}
+                onClick={handleRemoveLogoClick}
+              >
+                Remove logo
+              </Button>
+            ) : null}
+          </div>
+        </div>
+      ) : null}
+
+      <Field label="Name" htmlFor="brand-name" required>
+        <Input id="brand-name" value={name} onChange={(e) => setName(e.target.value)} required />
+      </Field>
+
+      <Field label="Industry" htmlFor="brand-industry">
+        <Input id="brand-industry" value={industry ?? ""} onChange={(e) => setIndustry(e.target.value)} />
+      </Field>
+
+      <Field label="Target audience" htmlFor="brand-target-audience">
+        <Textarea
+          id="brand-target-audience"
+          rows={2}
+          value={targetAudience ?? ""}
+          onChange={(e) => setTargetAudience(e.target.value)}
+        />
+      </Field>
+
+      <Field
+        label="Brand colors"
+        htmlFor="brand-colors"
+        hint="Comma-separated hex colors, e.g. #FF5733, #1A1A2E"
+      >
+        <Input id="brand-colors" value={colors} onChange={(e) => setColors(e.target.value)} />
+        {colorSwatches.length > 0 ? (
+          <div className="mt-2 flex flex-wrap items-center gap-1.5">
+            {colorSwatches.map((color, index) => (
+              <span
+                key={`${color}-${index}`}
+                title={color}
+                className="h-5 w-5 rounded-full border border-slate-200"
+                style={{ backgroundColor: color }}
+              />
+            ))}
+          </div>
+        ) : null}
+      </Field>
+
+      <Field
+        label="Tone descriptors"
+        htmlFor="brand-tone-descriptors"
+        hint="Comma-separated, e.g. playful, confident, concise"
+      >
+        <Input
+          id="brand-tone-descriptors"
+          value={toneDescriptors}
+          onChange={(e) => setToneDescriptors(e.target.value)}
+        />
+      </Field>
+
+      <Field
+        label="Product catalog"
+        htmlFor="brand-product-catalog"
+        hint="Raw JSON — leave blank for none."
+      >
+        <Textarea
+          id="brand-product-catalog"
+          rows={5}
+          className="font-mono text-xs"
+          value={productCatalog}
+          onChange={(e) => setProductCatalog(e.target.value)}
+          placeholder={'{\n  "products": []\n}'}
+        />
+      </Field>
+
+      {error ? (
+        <p role="alert" className="rounded-lg bg-red-50 px-3 py-2 text-sm font-medium text-red-700">
+          {error}
+        </p>
+      ) : null}
+
+      <div className="flex justify-end gap-2 pt-2">
+        <Button type="button" variant="outline" onClick={onCancel} disabled={isSubmitting}>
+          Cancel
+        </Button>
+        <Button type="submit" isLoading={isSubmitting}>
+          {isEdit ? "Save changes" : "Create brand"}
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/apps/web/app/brands/page.tsx
+++ b/apps/web/app/brands/page.tsx
@@ -1,0 +1,185 @@
+"use client";
+
+import { useState } from "react";
+import {
+  type Brand,
+  type BrandInput,
+  type BrandUpdateInput,
+  createBrand,
+  deleteBrand,
+  removeBrandLogo,
+  updateBrand,
+  uploadBrandLogo,
+} from "@/lib/api";
+import { useAuth } from "@/lib/auth-context";
+import { useBrand } from "@/lib/brand-context";
+import { Button } from "@/components/ui/Button";
+import { Card } from "@/components/ui/Card";
+import { EmptyState } from "@/components/ui/EmptyState";
+import { Modal } from "@/components/ui/Modal";
+import { PageHeader } from "@/components/ui/PageHeader";
+import { Skeleton } from "@/components/ui/Skeleton";
+import { useToast } from "@/components/ui/Toast";
+import { BrandCard } from "./brand-card";
+import { BrandForm } from "./brand-form";
+
+type ModalState = { mode: "create" } | { mode: "edit"; brandId: string } | null;
+
+function IconBrand() {
+  return (
+    <svg width="22" height="22" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+      <path
+        d="M4 20V6a2 2 0 012-2h8l6 6v10a2 2 0 01-2 2H6a2 2 0 01-2-2Z"
+        stroke="currentColor"
+        strokeWidth="1.8"
+        strokeLinejoin="round"
+      />
+      <path d="M14 4v5a1 1 0 001 1h5" stroke="currentColor" strokeWidth="1.8" strokeLinejoin="round" />
+    </svg>
+  );
+}
+
+function BrandCardSkeleton() {
+  return (
+    <Card className="p-5">
+      <div className="flex items-center gap-3">
+        <Skeleton className="h-12 w-12 rounded-full" />
+        <div className="flex-1 space-y-2">
+          <Skeleton className="h-4 w-2/3" />
+          <Skeleton className="h-4 w-1/3" />
+        </div>
+      </div>
+      <Skeleton className="mt-4 h-3 w-full" />
+      <Skeleton className="mt-2 h-3 w-4/5" />
+    </Card>
+  );
+}
+
+export default function BrandsPage() {
+  const { token } = useAuth();
+  const { brands, isLoading, error, refresh } = useBrand();
+  const { push } = useToast();
+  const [modalState, setModalState] = useState<ModalState>(null);
+
+  const editingBrand =
+    modalState?.mode === "edit" ? brands.find((brand) => brand.id === modalState.brandId) ?? null : null;
+
+  function openCreateModal() {
+    setModalState({ mode: "create" });
+  }
+
+  function openEditModal(brand: Brand) {
+    setModalState({ mode: "edit", brandId: brand.id });
+  }
+
+  function closeModal() {
+    setModalState(null);
+  }
+
+  async function handleSubmit(payload: BrandInput | BrandUpdateInput) {
+    if (!token || !modalState) return;
+    if (modalState.mode === "edit") {
+      await updateBrand(token, modalState.brandId, payload);
+    } else {
+      await createBrand(token, payload as BrandInput);
+    }
+    await refresh();
+    push(modalState.mode === "edit" ? "Brand updated." : "Brand created.", "success");
+    closeModal();
+  }
+
+  async function handleDelete(brand: Brand) {
+    if (!token) return;
+    const confirmed = window.confirm(`Delete "${brand.name}"? This cannot be undone.`);
+    if (!confirmed) return;
+
+    try {
+      await deleteBrand(token, brand.id);
+      await refresh();
+      push("Brand deleted.", "success");
+    } catch (err) {
+      push(err instanceof Error ? err.message : "Failed to delete brand.", "error");
+    }
+  }
+
+  async function handleUploadLogo(brandId: string, file: File) {
+    if (!token) return;
+    try {
+      await uploadBrandLogo(token, brandId, file);
+      await refresh();
+      push("Logo uploaded.", "success");
+    } catch (err) {
+      push(err instanceof Error ? err.message : "Failed to upload logo.", "error");
+    }
+  }
+
+  async function handleRemoveLogo(brandId: string) {
+    if (!token) return;
+    try {
+      await removeBrandLogo(token, brandId);
+      await refresh();
+      push("Logo removed.", "success");
+    } catch (err) {
+      push(err instanceof Error ? err.message : "Failed to remove logo.", "error");
+    }
+  }
+
+  return (
+    <div>
+      <PageHeader
+        title="Brands"
+        description="Manage the brands your organization runs content for."
+        action={<Button onClick={openCreateModal}>+ New brand</Button>}
+      />
+
+      {error ? (
+        <p role="alert" className="mb-4 rounded-lg bg-red-50 px-3 py-2 text-sm font-medium text-red-700">
+          {error}
+        </p>
+      ) : null}
+
+      {isLoading && brands.length === 0 ? (
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          <BrandCardSkeleton />
+          <BrandCardSkeleton />
+          <BrandCardSkeleton />
+        </div>
+      ) : brands.length === 0 ? (
+        <EmptyState
+          icon={<IconBrand />}
+          title="No brands yet"
+          description="Create your first brand to start planning and publishing content for it."
+          action={<Button onClick={openCreateModal}>Create your first brand</Button>}
+        />
+      ) : (
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {brands.map((brand) => (
+            <BrandCard
+              key={brand.id}
+              brand={brand}
+              onEdit={() => openEditModal(brand)}
+              onDelete={() => handleDelete(brand)}
+            />
+          ))}
+        </div>
+      )}
+
+      <Modal
+        open={modalState !== null}
+        onClose={closeModal}
+        title={modalState?.mode === "edit" ? "Edit brand" : "New brand"}
+        size="lg"
+      >
+        {modalState !== null ? (
+          <BrandForm
+            brand={editingBrand}
+            onCancel={closeModal}
+            onSubmit={handleSubmit}
+            onUploadLogo={editingBrand ? (file) => handleUploadLogo(editingBrand.id, file) : undefined}
+            onRemoveLogo={editingBrand ? () => handleRemoveLogo(editingBrand.id) : undefined}
+          />
+        ) : null}
+      </Modal>
+    </div>
+  );
+}

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -32,9 +32,26 @@ export interface Brand {
   tone_descriptors: string[] | null;
   product_catalog: Record<string, unknown> | null;
   brand_report: Record<string, unknown> | null;
+  report_pdf_url?: string | null;
+  report_pdf_generated_at?: string | null;
   created_at: string;
   updated_at: string;
 }
+
+// Mirrors apps/api/schemas/brand.py::BrandCreate.
+export interface BrandInput {
+  name: string;
+  industry?: string | null;
+  logo_url?: string | null;
+  target_audience?: string | null;
+  colors?: string[] | null;
+  tone_descriptors?: string[] | null;
+  product_catalog?: Record<string, unknown> | null;
+}
+
+// Mirrors apps/api/schemas/brand.py::BrandUpdate — every field optional,
+// PATCH-style (only fields present are changed server-side).
+export type BrandUpdateInput = Partial<BrandInput>;
 
 // Mirrors apps/api/models/content_calendar_event.py::CalendarEventStatus.
 export type CalendarEventStatus =
@@ -330,6 +347,88 @@ export async function rescheduleReviewPost(
     method: "POST",
     headers: { "Content-Type": "application/json", ...authHeaders(token) },
     body: JSON.stringify(payload),
+  });
+
+  if (!res.ok) {
+    throw new ApiError(await parseErrorDetail(res), res.status);
+  }
+
+  return res.json();
+}
+
+// --- Brand CRUD (Issue #89) ---
+
+function brandUrl(brandId: string, suffix = ""): string {
+  return `${API_URL}/brands/${brandId}${suffix}`;
+}
+
+export async function createBrand(token: string, payload: BrandInput): Promise<Brand> {
+  const res = await fetch(`${API_URL}/brands`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", ...authHeaders(token) },
+    body: JSON.stringify(payload),
+  });
+
+  if (!res.ok) {
+    throw new ApiError(await parseErrorDetail(res), res.status);
+  }
+
+  return res.json();
+}
+
+export async function updateBrand(
+  token: string,
+  brandId: string,
+  payload: BrandUpdateInput
+): Promise<Brand> {
+  const res = await fetch(brandUrl(brandId), {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json", ...authHeaders(token) },
+    body: JSON.stringify(payload),
+  });
+
+  if (!res.ok) {
+    throw new ApiError(await parseErrorDetail(res), res.status);
+  }
+
+  return res.json();
+}
+
+export async function deleteBrand(token: string, brandId: string): Promise<void> {
+  const res = await fetch(brandUrl(brandId), {
+    method: "DELETE",
+    headers: authHeaders(token),
+  });
+
+  if (!res.ok) {
+    throw new ApiError(await parseErrorDetail(res), res.status);
+  }
+}
+
+// apps/api/routers/brands.py::upload_brand_logo takes a single multipart
+// field named "file" (fastapi.UploadFile) — the field name matters, the
+// backend reads request.form()["file"].
+export async function uploadBrandLogo(token: string, brandId: string, file: File): Promise<Brand> {
+  const formData = new FormData();
+  formData.append("file", file);
+
+  const res = await fetch(brandUrl(brandId, "/logo"), {
+    method: "PUT",
+    headers: authHeaders(token),
+    body: formData,
+  });
+
+  if (!res.ok) {
+    throw new ApiError(await parseErrorDetail(res), res.status);
+  }
+
+  return res.json();
+}
+
+export async function removeBrandLogo(token: string, brandId: string): Promise<Brand> {
+  const res = await fetch(brandUrl(brandId, "/logo"), {
+    method: "DELETE",
+    headers: authHeaders(token),
   });
 
   if (!res.ok) {


### PR DESCRIPTION
## Summary
- Adds the `/brands` page: lists every brand in the org as cards (name, industry, logo/avatar, color swatch row), with an empty state and skeleton loading state built from the shared design system.
- Create and edit brand via a shared `Modal` + form (name required; industry, target audience, colors, tone descriptors as comma-separated inputs; product catalog as a validated raw-JSON textarea).
- Delete brand with a `window.confirm` guard.
- Logo upload/remove wired to `PUT/DELETE /brands/{brand_id}/logo` (multipart field name `file`, matching `apps/api/routers/brands.py::upload_brand_logo`), shown from the edit modal.
- `useToast()` for success/error feedback on every mutation; `useBrand().refresh()` called after each mutation so the sidebar brand switcher stays in sync without a full reload.
- Extends `apps/web/lib/api.ts` with `createBrand`, `updateBrand`, `deleteBrand`, `uploadBrandLogo`, `removeBrandLogo` (plus `BrandInput`/`BrandUpdateInput` types), added in a clearly-bannered append block (`// --- Brand CRUD (Issue #89) ---`) to keep merges with sibling feature branches clean.

## Why
Closes #89 — the org needs a UI to manage brands (create/edit/delete, logo, brand voice fields) now that the design system (#88) and the backend brands router are both in place.

## Test plan
Run from `apps/web`, Node 18, matching CI (`.github/workflows/frontend-ci.yml`):
- [x] `npm run lint` — clean (one pre-existing warning in `components/ui/Avatar.tsx`, unrelated to this change)
- [x] `npm run test` — 7 test files, 39 tests passing, including the new `__tests__/brands-page.test.tsx` (list rendering, create, invalid-JSON-catalog rejection, edit/pre-fill, delete with/without confirmation, logo upload) and new `createBrand`/`uploadBrandLogo` cases in `__tests__/api.test.ts`
- [x] `npm run build` — compiles and typechecks cleanly, `/brands` route included in the output

Claude-Session: https://claude.ai/code/session_012iWB6uxCB3Rsp97RmVgBW6
