### PR TITLE
feat(web): add onboarding UI + brand report view + PDF export

### DIFF
--- a/apps/web/__tests__/onboarding-page.test.tsx
+++ b/apps/web/__tests__/onboarding-page.test.tsx
@@ -1,0 +1,214 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import OnboardingPage from "@/app/onboarding/page";
+import { AuthProvider } from "@/lib/auth-context";
+import { BrandProvider } from "@/lib/brand-context";
+import { ToastProvider } from "@/components/ui/Toast";
+import type { Brand, OnboardingResponseData } from "@/lib/api";
+
+const fetchBrandsMock = vi.fn();
+const fetchOnboardingMock = vi.fn();
+const upsertOnboardingMock = vi.fn();
+const completeOnboardingMock = vi.fn();
+const runOnboardingAgentMock = vi.fn();
+const exportBrandReportMock = vi.fn();
+
+vi.mock("@/lib/api", () => {
+  class MockApiError extends Error {
+    status: number;
+    constructor(message: string, status: number) {
+      super(message);
+      this.name = "ApiError";
+      this.status = status;
+    }
+  }
+
+  return {
+    ApiError: MockApiError,
+    fetchBrands: (...args: unknown[]) => fetchBrandsMock(...args),
+    fetchOnboarding: (...args: unknown[]) => fetchOnboardingMock(...args),
+    upsertOnboarding: (...args: unknown[]) => upsertOnboardingMock(...args),
+    completeOnboarding: (...args: unknown[]) => completeOnboardingMock(...args),
+    runOnboardingAgent: (...args: unknown[]) => runOnboardingAgentMock(...args),
+    exportBrandReport: (...args: unknown[]) => exportBrandReportMock(...args),
+  };
+});
+
+function makeBrand(overrides: Partial<Brand> = {}): Brand {
+  return {
+    id: "brand-1",
+    organization_id: "org-1",
+    name: "Acme Co",
+    industry: null,
+    logo_url: null,
+    target_audience: null,
+    colors: null,
+    tone_descriptors: null,
+    product_catalog: null,
+    brand_report: null,
+    created_at: "2026-01-01",
+    updated_at: "2026-01-01",
+    ...overrides,
+  };
+}
+
+function makeOnboarding(overrides: Partial<OnboardingResponseData> = {}): OnboardingResponseData {
+  return {
+    id: "onboarding-1",
+    brand_id: "brand-1",
+    voice: "Friendly and confident",
+    audience: "Small business owners",
+    product_catalog: { products: [{ name: "Widget Pro" }] },
+    competitors: ["Widget Inc"],
+    goals: ["Grow LinkedIn following"],
+    is_complete: true,
+    created_at: "2026-01-01",
+    updated_at: "2026-01-01",
+    ...overrides,
+  };
+}
+
+function renderPage() {
+  return render(
+    <ToastProvider>
+      <AuthProvider>
+        <BrandProvider>
+          <OnboardingPage />
+        </BrandProvider>
+      </AuthProvider>
+    </ToastProvider>
+  );
+}
+
+describe("OnboardingPage", () => {
+  beforeEach(() => {
+    fetchBrandsMock.mockReset();
+    fetchOnboardingMock.mockReset();
+    upsertOnboardingMock.mockReset();
+    completeOnboardingMock.mockReset();
+    runOnboardingAgentMock.mockReset();
+    exportBrandReportMock.mockReset();
+
+    window.localStorage.clear();
+    window.localStorage.setItem("raindeer.auth.token", "test-token");
+
+    vi.spyOn(window, "open").mockImplementation(() => null);
+  });
+
+  it("submits the not-started form and saves onboarding answers", async () => {
+    fetchBrandsMock.mockResolvedValue([makeBrand()]);
+    fetchOnboardingMock.mockResolvedValue(null);
+    upsertOnboardingMock.mockResolvedValue(makeOnboarding({ is_complete: false }));
+    const user = userEvent.setup();
+
+    renderPage();
+
+    expect(await screen.findByText("Start onboarding")).toBeInTheDocument();
+
+    await user.type(screen.getByLabelText("Brand voice"), "Friendly and confident");
+    await user.type(screen.getByLabelText("Audience"), "Small business owners");
+    // userEvent.type interprets "{"/"}" as special-key syntax, so set the
+    // raw JSON text directly instead.
+    fireEvent.change(screen.getByLabelText("Product catalog"), {
+      target: { value: '{"products": [{"name": "Widget Pro"}]}' },
+    });
+    await user.type(screen.getByLabelText("Competitors"), "Widget Inc, Acme Rival");
+    await user.type(screen.getByLabelText("Goals"), "Grow LinkedIn following");
+
+    await act(async () => {
+      await user.click(screen.getByRole("button", { name: "Save answers" }));
+    });
+
+    await waitFor(() => {
+      expect(upsertOnboardingMock).toHaveBeenCalledWith(
+        "test-token",
+        "brand-1",
+        expect.objectContaining({
+          voice: "Friendly and confident",
+          audience: "Small business owners",
+          product_catalog: { products: [{ name: "Widget Pro" }] },
+          competitors: ["Widget Inc", "Acme Rival"],
+          goals: ["Grow LinkedIn following"],
+        })
+      );
+    });
+
+    expect(await screen.findByText("Onboarding answers saved.")).toBeInTheDocument();
+  });
+
+  it("shows a pending state while generating the report, then renders it", async () => {
+    fetchOnboardingMock.mockResolvedValue(makeOnboarding({ is_complete: true }));
+
+    const reportedBrand = makeBrand({
+      brand_report: {
+        voice_and_tone: "Warm and direct.",
+        audience: "Owners of small retail shops.",
+        product_catalog_summary: "A line of productivity widgets.",
+        competitive_positioning: "Positioned as the premium, easy-to-use option.",
+      },
+    });
+    fetchBrandsMock.mockResolvedValueOnce([makeBrand()]).mockResolvedValueOnce([reportedBrand]);
+
+    let resolveAgent: (() => void) | undefined;
+    runOnboardingAgentMock.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveAgent = () => resolve();
+        })
+    );
+
+    const user = userEvent.setup();
+    renderPage();
+
+    const generateButton = await screen.findByRole("button", { name: "Generate brand report" });
+    await user.click(generateButton);
+
+    await waitFor(() => expect(runOnboardingAgentMock).toHaveBeenCalledWith("test-token", "brand-1"));
+    expect(completeOnboardingMock).not.toHaveBeenCalled();
+
+    expect(await screen.findByRole("status")).toHaveTextContent(/running research and synthesis/i);
+    expect(screen.getByRole("button", { name: "Generating…" })).toBeDisabled();
+
+    await act(async () => {
+      resolveAgent?.();
+      await Promise.resolve();
+    });
+
+    expect(await screen.findByText("Warm and direct.")).toBeInTheDocument();
+    expect(screen.getByText("Positioned as the premium, easy-to-use option.")).toBeInTheDocument();
+    expect(await screen.findByText("Brand report generated.")).toBeInTheDocument();
+  });
+
+  it("exports and links the PDF report", async () => {
+    const brandWithReport = makeBrand({
+      brand_report: { voice_and_tone: "Warm and direct." },
+    });
+    fetchBrandsMock.mockResolvedValue([brandWithReport]);
+    fetchOnboardingMock.mockResolvedValue(makeOnboarding({ is_complete: true }));
+    exportBrandReportMock.mockResolvedValue({
+      url: "https://cdn.example.com/reports/brand-1.pdf",
+      generated_at: "2026-08-25T12:00:00Z",
+    });
+
+    const user = userEvent.setup();
+    renderPage();
+
+    const exportButton = await screen.findByRole("button", { name: "Download PDF report" });
+    await act(async () => {
+      await user.click(exportButton);
+    });
+
+    await waitFor(() => {
+      expect(exportBrandReportMock).toHaveBeenCalledWith("test-token", "brand-1");
+    });
+
+    const link = await screen.findByRole("link", { name: "Open PDF report" });
+    expect(link).toHaveAttribute("href", "https://cdn.example.com/reports/brand-1.pdf");
+    expect(window.open).toHaveBeenCalledWith(
+      "https://cdn.example.com/reports/brand-1.pdf",
+      "_blank",
+      "noopener,noreferrer"
+    );
+  });
+});

--- a/apps/web/app/onboarding/brand-report-view.tsx
+++ b/apps/web/app/onboarding/brand-report-view.tsx
@@ -1,0 +1,79 @@
+import type { ReactNode } from "react";
+
+// Known keys from packages/agents/onboarding/prompts.py::REQUIRED_REPORT_KEYS
+// get a friendlier label; anything else (the LLM's exact JSON shape per key
+// can vary, and it may add keys beyond these) falls back to a humanized
+// version of its key name so the section still renders sensibly.
+const SECTION_LABELS: Record<string, string> = {
+  voice_and_tone: "Voice & tone",
+  audience: "Audience",
+  product_catalog_summary: "Product catalog summary",
+  competitive_positioning: "Competitive positioning",
+};
+
+function humanizeKey(key: string): string {
+  return key.replace(/_/g, " ").replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
+function renderScalar(value: unknown): string {
+  return typeof value === "string" ? value : JSON.stringify(value);
+}
+
+function renderValue(value: unknown): ReactNode {
+  if (value === null || value === undefined || value === "") {
+    return <p className="text-sm text-slate-400">Not available.</p>;
+  }
+
+  if (typeof value === "string") {
+    return <p className="whitespace-pre-wrap text-sm text-slate-700">{value}</p>;
+  }
+
+  if (Array.isArray(value)) {
+    if (value.length === 0) return <p className="text-sm text-slate-400">Not available.</p>;
+    return (
+      <ul className="list-disc space-y-1 pl-5 text-sm text-slate-700">
+        {value.map((item, index) => (
+          <li key={index}>{renderScalar(item)}</li>
+        ))}
+      </ul>
+    );
+  }
+
+  if (typeof value === "object") {
+    const entries = Object.entries(value as Record<string, unknown>);
+    if (entries.length === 0) return <p className="text-sm text-slate-400">Not available.</p>;
+    return (
+      <dl className="space-y-2">
+        {entries.map(([key, entryValue]) => (
+          <div key={key}>
+            <dt className="text-xs font-semibold uppercase tracking-wide text-slate-400">
+              {humanizeKey(key)}
+            </dt>
+            <dd className="mt-0.5 text-sm text-slate-700">{renderScalar(entryValue)}</dd>
+          </div>
+        ))}
+      </dl>
+    );
+  }
+
+  return <p className="text-sm text-slate-700">{String(value)}</p>;
+}
+
+export function BrandReportView({ report }: { report: Record<string, unknown> }) {
+  const entries = Object.entries(report);
+
+  if (entries.length === 0) {
+    return <p className="text-sm text-slate-500">The brand report is empty.</p>;
+  }
+
+  return (
+    <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+      {entries.map(([key, value]) => (
+        <div key={key} className="rounded-lg border border-slate-200 p-4">
+          <h4 className="text-sm font-semibold text-slate-900">{SECTION_LABELS[key] ?? humanizeKey(key)}</h4>
+          <div className="mt-2">{renderValue(value)}</div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/apps/web/app/onboarding/onboarding-form.tsx
+++ b/apps/web/app/onboarding/onboarding-form.tsx
@@ -1,0 +1,117 @@
+"use client";
+
+import { useState } from "react";
+import type { FormEvent } from "react";
+import { Button } from "@/components/ui/Button";
+import { Field, Input, Textarea } from "@/components/ui/Input";
+import type { OnboardingResponseData, OnboardingUpsertInput } from "@/lib/api";
+
+function toCommaList(value: string): string[] {
+  return value
+    .split(",")
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
+function fromList(value: string[] | null | undefined): string {
+  return (value ?? []).join(", ");
+}
+
+export function OnboardingForm({
+  initialValues,
+  isSubmitting,
+  onSubmit,
+}: {
+  initialValues: OnboardingResponseData | null;
+  isSubmitting: boolean;
+  onSubmit: (payload: OnboardingUpsertInput) => void | Promise<void>;
+}) {
+  const [voice, setVoice] = useState(initialValues?.voice ?? "");
+  const [audience, setAudience] = useState(initialValues?.audience ?? "");
+  const [productCatalogText, setProductCatalogText] = useState(
+    initialValues?.product_catalog ? JSON.stringify(initialValues.product_catalog, null, 2) : ""
+  );
+  const [competitors, setCompetitors] = useState(fromList(initialValues?.competitors));
+  const [goals, setGoals] = useState(fromList(initialValues?.goals));
+  const [jsonError, setJsonError] = useState<string | null>(null);
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setJsonError(null);
+
+    let productCatalog: Record<string, unknown> | null = null;
+    if (productCatalogText.trim()) {
+      try {
+        productCatalog = JSON.parse(productCatalogText);
+      } catch {
+        setJsonError("Product catalog must be valid JSON.");
+        return;
+      }
+    }
+
+    await onSubmit({
+      voice: voice.trim() || null,
+      audience: audience.trim() || null,
+      product_catalog: productCatalog,
+      competitors: toCommaList(competitors),
+      goals: toCommaList(goals),
+    });
+  }
+
+  return (
+    <form onSubmit={handleSubmit} noValidate className="space-y-4">
+      <Field
+        label="Brand voice"
+        htmlFor="onboarding-voice"
+        hint="Describe how your brand sounds — tone, personality, style."
+      >
+        <Textarea id="onboarding-voice" value={voice} onChange={(event) => setVoice(event.target.value)} />
+      </Field>
+
+      <Field label="Audience" htmlFor="onboarding-audience" hint="Who are you trying to reach?">
+        <Textarea
+          id="onboarding-audience"
+          value={audience}
+          onChange={(event) => setAudience(event.target.value)}
+        />
+      </Field>
+
+      <Field
+        label="Product catalog"
+        htmlFor="onboarding-product-catalog"
+        hint="Paste JSON describing your products or services."
+        error={jsonError}
+      >
+        <Textarea
+          id="onboarding-product-catalog"
+          value={productCatalogText}
+          onChange={(event) => setProductCatalogText(event.target.value)}
+          className="min-h-[8rem] font-mono text-xs"
+          placeholder='{"products": [{"name": "Widget Pro", "price": "$49"}]}'
+        />
+      </Field>
+
+      <Field label="Competitors" htmlFor="onboarding-competitors" hint="Comma-separated list.">
+        <Input
+          id="onboarding-competitors"
+          value={competitors}
+          onChange={(event) => setCompetitors(event.target.value)}
+          placeholder="Acme Co, Widget Inc"
+        />
+      </Field>
+
+      <Field label="Goals" htmlFor="onboarding-goals" hint="Comma-separated list.">
+        <Input
+          id="onboarding-goals"
+          value={goals}
+          onChange={(event) => setGoals(event.target.value)}
+          placeholder="Grow LinkedIn following, launch product X"
+        />
+      </Field>
+
+      <Button type="submit" isLoading={isSubmitting} disabled={isSubmitting}>
+        {isSubmitting ? "Saving…" : "Save answers"}
+      </Button>
+    </form>
+  );
+}

--- a/apps/web/app/onboarding/page.tsx
+++ b/apps/web/app/onboarding/page.tsx
@@ -1,18 +1,228 @@
 "use client";
 
+import { useCallback, useEffect, useState } from "react";
+import {
+  ApiError,
+  completeOnboarding,
+  exportBrandReport,
+  fetchOnboarding,
+  runOnboardingAgent,
+  upsertOnboarding,
+  type BrandReportExportResult,
+  type OnboardingResponseData,
+  type OnboardingUpsertInput,
+} from "@/lib/api";
+import { useAuth } from "@/lib/auth-context";
 import { useBrand } from "@/lib/brand-context";
+import { Button } from "@/components/ui/Button";
+import { Card, CardBody, CardHeader } from "@/components/ui/Card";
+import { EmptyState } from "@/components/ui/EmptyState";
+import { PageHeader } from "@/components/ui/PageHeader";
+import { Skeleton } from "@/components/ui/Skeleton";
+import { useToast } from "@/components/ui/Toast";
+import { BrandReportView } from "./brand-report-view";
+import { OnboardingForm } from "./onboarding-form";
 
-// Stub for #13 — replace with the real onboarding flow.
 export default function OnboardingPage() {
-  const { selectedBrand } = useBrand();
+  const { token } = useAuth();
+  const { selectedBrand, selectedBrandId, refresh: refreshBrands } = useBrand();
+  const { push: pushToast } = useToast();
+
+  const [onboarding, setOnboarding] = useState<OnboardingResponseData | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [isSaving, setIsSaving] = useState(false);
+  const [isGenerating, setIsGenerating] = useState(false);
+  const [isExporting, setIsExporting] = useState(false);
+  const [lastExport, setLastExport] = useState<BrandReportExportResult | null>(null);
+
+  const loadOnboarding = useCallback(async () => {
+    if (!token || !selectedBrandId) {
+      setOnboarding(null);
+      return;
+    }
+    setIsLoading(true);
+    setLoadError(null);
+    try {
+      const result = await fetchOnboarding(token, selectedBrandId);
+      setOnboarding(result);
+    } catch (err) {
+      setLoadError(err instanceof ApiError ? err.message : "Failed to load onboarding");
+    } finally {
+      setIsLoading(false);
+    }
+  }, [token, selectedBrandId]);
+
+  useEffect(() => {
+    setOnboarding(null);
+    setLastExport(null);
+    loadOnboarding();
+  }, [loadOnboarding]);
+
+  async function handleSaveAnswers(payload: OnboardingUpsertInput) {
+    if (!token || !selectedBrandId) return;
+    setIsSaving(true);
+    try {
+      const result = await upsertOnboarding(token, selectedBrandId, payload);
+      setOnboarding(result);
+      pushToast("Onboarding answers saved.", "success");
+    } catch (err) {
+      pushToast(err instanceof ApiError ? err.message : "Failed to save onboarding answers", "error");
+    } finally {
+      setIsSaving(false);
+    }
+  }
+
+  async function handleGenerateReport() {
+    if (!token || !selectedBrandId || !onboarding) return;
+    setIsGenerating(true);
+    try {
+      // The agent (apps/api/routers/onboarding.py::run_agent) requires
+      // onboarding to already be marked complete — get that out of the way
+      // first so "Generate brand report" reads as one action to the user.
+      let current = onboarding;
+      if (!current.is_complete) {
+        current = await completeOnboarding(token, selectedBrandId);
+        setOnboarding(current);
+      }
+      await runOnboardingAgent(token, selectedBrandId);
+      // The agent writes brand_report onto the Brand row, not onto anything
+      // BrandProvider already holds — refetch so selectedBrand picks it up.
+      await refreshBrands();
+      pushToast("Brand report generated.", "success");
+    } catch (err) {
+      pushToast(err instanceof ApiError ? err.message : "Failed to generate brand report", "error");
+    } finally {
+      setIsGenerating(false);
+    }
+  }
+
+  async function handleExportPdf() {
+    if (!token || !selectedBrandId) return;
+    setIsExporting(true);
+    try {
+      const result = await exportBrandReport(token, selectedBrandId);
+      setLastExport(result);
+      if (typeof window !== "undefined") {
+        window.open(result.url, "_blank", "noopener,noreferrer");
+      }
+      pushToast("Brand report PDF ready.", "success");
+    } catch (err) {
+      pushToast(err instanceof ApiError ? err.message : "Failed to export PDF report", "error");
+    } finally {
+      setIsExporting(false);
+    }
+  }
+
+  if (!selectedBrand) {
+    return (
+      <div>
+        <PageHeader title="Onboarding" description="Teach the AI your brand's voice, audience, and goals." />
+        <EmptyState
+          title="No brand selected"
+          description="Select a brand from the switcher to start or continue its onboarding."
+        />
+      </div>
+    );
+  }
 
   return (
-    <section className="stub-page">
-      <h1>Onboarding</h1>
-      <p>Coming soon.</p>
-      <p className="scoped-brand">
-        Showing data for: <strong>{selectedBrand ? selectedBrand.name : "no brand selected"}</strong>
-      </p>
-    </section>
+    <div>
+      <PageHeader
+        title="Onboarding"
+        description={`Teach the AI ${selectedBrand.name}'s voice, audience, and goals.`}
+      />
+
+      {isLoading ? (
+        <div className="space-y-4">
+          <Skeleton className="h-64 w-full" />
+          <Skeleton className="h-40 w-full" />
+        </div>
+      ) : loadError ? (
+        <EmptyState title="Couldn't load onboarding" description={loadError} />
+      ) : (
+        <div className="space-y-6" key={`${selectedBrandId}-${onboarding?.id ?? "new"}`}>
+          <Card>
+            <CardHeader
+              title={onboarding ? "Onboarding answers" : "Start onboarding"}
+              description={
+                onboarding
+                  ? "Update your brand's questionnaire answers at any time."
+                  : "Answer these questions so the AI can learn your brand."
+              }
+            />
+            <CardBody>
+              <OnboardingForm initialValues={onboarding} isSubmitting={isSaving} onSubmit={handleSaveAnswers} />
+            </CardBody>
+          </Card>
+
+          {onboarding ? (
+            <Card>
+              <CardHeader
+                title="Brand report"
+                description={
+                  selectedBrand.brand_report
+                    ? "Regenerate the report any time your answers change."
+                    : "Run the onboarding agent to generate your brand report."
+                }
+                action={
+                  <Button onClick={handleGenerateReport} isLoading={isGenerating} disabled={isGenerating}>
+                    {isGenerating
+                      ? "Generating…"
+                      : selectedBrand.brand_report
+                        ? "Regenerate brand report"
+                        : "Generate brand report"}
+                  </Button>
+                }
+              />
+              <CardBody>
+                {isGenerating ? (
+                  <p role="status" className="text-sm text-slate-500">
+                    Running research and synthesis — this can take a minute or two. Feel free to
+                    leave this open; the report will appear here as soon as it&rsquo;s ready.
+                  </p>
+                ) : selectedBrand.brand_report ? (
+                  <div className="space-y-6">
+                    <div className="flex flex-wrap items-center justify-between gap-3 rounded-lg bg-slate-50 p-4">
+                      <p className="text-sm text-slate-600">
+                        {lastExport
+                          ? `Last exported ${new Date(lastExport.generated_at).toLocaleString()}`
+                          : "Export the report as a PDF to share with stakeholders."}
+                      </p>
+                      <div className="flex items-center gap-3">
+                        {lastExport ? (
+                          <a
+                            href={lastExport.url}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="text-sm font-medium text-brand-600 hover:underline"
+                          >
+                            Open PDF report
+                          </a>
+                        ) : null}
+                        <Button
+                          variant="outline"
+                          onClick={handleExportPdf}
+                          isLoading={isExporting}
+                          disabled={isExporting}
+                        >
+                          {isExporting ? "Preparing PDF…" : "Download PDF report"}
+                        </Button>
+                      </div>
+                    </div>
+                    <BrandReportView report={selectedBrand.brand_report} />
+                  </div>
+                ) : (
+                  <EmptyState
+                    title="No report yet"
+                    description="Generate a brand report once you're happy with your onboarding answers."
+                  />
+                )}
+              </CardBody>
+            </Card>
+          ) : null}
+        </div>
+      )}
+    </div>
   );
 }

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -338,3 +338,127 @@ export async function rescheduleReviewPost(
 
   return res.json();
 }
+
+// --- Onboarding + Brand Report (Issue #90) ---
+
+// Mirrors apps/api/schemas/onboarding.py::OnboardingUpsert.
+export interface OnboardingUpsertInput {
+  voice?: string | null;
+  audience?: string | null;
+  product_catalog?: Record<string, unknown> | null;
+  competitors?: string[] | null;
+  goals?: string[] | null;
+}
+
+// Mirrors apps/api/schemas/onboarding.py::OnboardingRead.
+export interface OnboardingResponseData {
+  id: string;
+  brand_id: string;
+  voice: string | null;
+  audience: string | null;
+  product_catalog: Record<string, unknown> | null;
+  competitors: string[] | null;
+  goals: string[] | null;
+  is_complete: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+// Mirrors apps/api/schemas/brand.py::BrandReportExport.
+export interface BrandReportExportResult {
+  url: string;
+  generated_at: string;
+}
+
+// apps/api/routers/onboarding.py mounts these under
+// /brands/{brand_id}/onboarding, so every call is scoped to a brand — same
+// convention as calendarEventsUrl/reviewQueueUrl above.
+function onboardingUrl(brandId: string, suffix = ""): string {
+  return `${API_URL}/brands/${brandId}/onboarding${suffix}`;
+}
+
+// Returns null (rather than throwing) when onboarding hasn't been started
+// yet — apps/api/routers/onboarding.py::get_onboarding 404s in that case,
+// which the onboarding page treats as its "not started" state, not an error.
+export async function fetchOnboarding(
+  token: string,
+  brandId: string
+): Promise<OnboardingResponseData | null> {
+  const res = await fetch(onboardingUrl(brandId), {
+    headers: authHeaders(token),
+  });
+
+  if (res.status === 404) return null;
+  if (!res.ok) {
+    throw new ApiError(await parseErrorDetail(res), res.status);
+  }
+
+  return res.json();
+}
+
+export async function upsertOnboarding(
+  token: string,
+  brandId: string,
+  payload: OnboardingUpsertInput
+): Promise<OnboardingResponseData> {
+  const res = await fetch(onboardingUrl(brandId), {
+    method: "PUT",
+    headers: { "Content-Type": "application/json", ...authHeaders(token) },
+    body: JSON.stringify(payload),
+  });
+
+  if (!res.ok) {
+    throw new ApiError(await parseErrorDetail(res), res.status);
+  }
+
+  return res.json();
+}
+
+export async function completeOnboarding(
+  token: string,
+  brandId: string
+): Promise<OnboardingResponseData> {
+  const res = await fetch(onboardingUrl(brandId, "/complete"), {
+    method: "POST",
+    headers: authHeaders(token),
+  });
+
+  if (!res.ok) {
+    throw new ApiError(await parseErrorDetail(res), res.status);
+  }
+
+  return res.json();
+}
+
+// Triggers the onboarding research + synthesis agent chain (a real LLM call
+// chain — can take tens of seconds) and returns the Brand with brand_report
+// populated. apps/api/routers/onboarding.py::run_agent requires onboarding
+// to already be complete.
+export async function runOnboardingAgent(token: string, brandId: string): Promise<Brand> {
+  const res = await fetch(onboardingUrl(brandId, "/run-agent"), {
+    method: "POST",
+    headers: authHeaders(token),
+  });
+
+  if (!res.ok) {
+    throw new ApiError(await parseErrorDetail(res), res.status);
+  }
+
+  return res.json();
+}
+
+export async function exportBrandReport(
+  token: string,
+  brandId: string
+): Promise<BrandReportExportResult> {
+  const res = await fetch(`${API_URL}/brands/${brandId}/report/export`, {
+    method: "POST",
+    headers: authHeaders(token),
+  });
+
+  if (!res.ok) {
+    throw new ApiError(await parseErrorDetail(res), res.status);
+  }
+
+  return res.json();
+}


### PR DESCRIPTION
## Summary
- Replaces the `/onboarding` stub with a full questionnaire flow (voice, audience, product catalog, competitors, goals), backed by `GET/PUT /brands/{brand_id}/onboarding`.
- Adds a "Generate brand report" action that completes onboarding (if needed) and calls `POST /brands/{brand_id}/onboarding/run-agent`, with a clear disabled/pending state while the LLM chain runs.
- Renders the generated `brand_report` (`voice_and_tone`, `audience`, `product_catalog_summary`, `competitive_positioning`, plus any other keys) generically based on value shape (string/list/dict).
- Adds a "Download PDF report" action wired to `POST /brands/{brand_id}/report/export`, opening/linking the returned PDF URL.
- Extends `apps/web/lib/api.ts` with `fetchOnboarding`, `upsertOnboarding`, `completeOnboarding`, `runOnboardingAgent`, `exportBrandReport` (appended under a clearly bannered section to keep merges with sibling feature branches clean).

## Why
Closes #90. Onboarding was the last stubbed page in the app; this wires it to the already-recovered backend (#14/#15/#16) and reuses the shared design system from #88.

## Test plan
- [x] `npm run lint --prefix apps/web`
- [x] `npm run test --prefix apps/web` (32 tests passing, including new `__tests__/onboarding-page.test.tsx` covering the not-started form submit, the generate-report pending → success flow, and PDF export)
- [x] `npm run build --prefix apps/web`
- [ ] Manual smoke test against a live backend (not run in this environment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012iWB6uxCB3Rsp97RmVgBW6