### PR TITLE
feat(web): add weekly AI report UI

### DIFF
--- a/apps/web/__tests__/reports-page.test.tsx
+++ b/apps/web/__tests__/reports-page.test.tsx
@@ -1,0 +1,182 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { act, render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import ReportsPage from "@/app/reports/page";
+import { AuthProvider } from "@/lib/auth-context";
+import { BrandProvider } from "@/lib/brand-context";
+import type { Report } from "@/lib/api";
+
+const fetchBrandsMock = vi.fn();
+const fetchReportsMock = vi.fn();
+const fetchReportMock = vi.fn();
+
+vi.mock("@/lib/api", () => ({
+  fetchBrands: (...args: unknown[]) => fetchBrandsMock(...args),
+  fetchReports: (...args: unknown[]) => fetchReportsMock(...args),
+  fetchReport: (...args: unknown[]) => fetchReportMock(...args),
+}));
+
+const BRANDS = [
+  {
+    id: "brand-1",
+    organization_id: "org-1",
+    name: "Acme Co",
+    industry: null,
+    logo_url: null,
+    target_audience: null,
+    colors: null,
+    tone_descriptors: null,
+    product_catalog: null,
+    brand_report: null,
+    created_at: "2026-01-01",
+    updated_at: "2026-01-01",
+  },
+];
+
+function makeReport(overrides: Partial<Report> = {}): Report {
+  return {
+    id: "report-1",
+    brand_id: "brand-1",
+    period_start: "2026-08-10T00:00:00Z",
+    period_end: "2026-08-17T00:00:00Z",
+    summary: "342 likes across 5 posts this week, up from the prior period.",
+    recommendations: ["Post more on LinkedIn, which drove the most engagement this week."],
+    metrics: {
+      post_count: 5,
+      platforms: [
+        {
+          platform: "linkedin",
+          snapshot_count: 5,
+          total_likes: 342,
+          total_comments: 12,
+          total_shares: 4,
+          total_impressions: 9000,
+          average_likes: 68.4,
+          average_comments: 2.4,
+          average_shares: 0.8,
+          average_impressions: 1800,
+        },
+      ],
+      overall: {
+        platform: "overall",
+        snapshot_count: 5,
+        total_likes: 342,
+        total_comments: 12,
+        total_shares: 4,
+        total_impressions: 9000,
+        average_likes: 68.4,
+        average_comments: 2.4,
+        average_shares: 0.8,
+        average_impressions: 1800,
+      },
+    },
+    model: "gpt-4o",
+    created_at: "2026-08-17T08:00:00Z",
+    ...overrides,
+  };
+}
+
+function renderPage() {
+  return render(
+    <AuthProvider>
+      <BrandProvider>
+        <ReportsPage />
+      </BrandProvider>
+    </AuthProvider>
+  );
+}
+
+describe("ReportsPage", () => {
+  beforeEach(() => {
+    fetchBrandsMock.mockReset();
+    fetchReportsMock.mockReset();
+    fetchReportMock.mockReset();
+
+    window.localStorage.clear();
+    window.localStorage.setItem("raindeer.auth.token", "test-token");
+
+    fetchBrandsMock.mockResolvedValue(BRANDS);
+    fetchReportsMock.mockResolvedValue([]);
+  });
+
+  it("lists the brand's reports, most recent first, with a period and summary excerpt", async () => {
+    const recent = makeReport({
+      id: "report-2",
+      period_start: "2026-08-17T00:00:00Z",
+      period_end: "2026-08-24T00:00:00Z",
+      summary: "This is the most recent report summary.",
+    });
+    const older = makeReport({
+      id: "report-1",
+      period_start: "2026-08-10T00:00:00Z",
+      period_end: "2026-08-17T00:00:00Z",
+      summary: "This is an older report summary.",
+    });
+    fetchReportsMock.mockResolvedValue([recent, older]);
+    fetchReportMock.mockResolvedValue(recent);
+
+    renderPage();
+
+    await screen.findByText("This is the most recent report summary.");
+    expect(screen.getByText("This is an older report summary.")).toBeInTheDocument();
+    expect(fetchReportsMock).toHaveBeenCalledWith("test-token", "brand-1");
+  });
+
+  it("selecting a report fetches and shows its detail (summary, recommendations, metrics)", async () => {
+    const first = makeReport({ id: "report-1", summary: "First report summary." });
+    const second = makeReport({
+      id: "report-2",
+      period_start: "2026-08-17T00:00:00Z",
+      period_end: "2026-08-24T00:00:00Z",
+      summary: "Second report summary.",
+      recommendations: ["Double down on video content on Instagram."],
+      metrics: {
+        post_count: 8,
+        platforms: [],
+        overall: {
+          platform: "overall",
+          snapshot_count: 8,
+          total_likes: 500,
+          total_comments: 20,
+          total_shares: 10,
+          total_impressions: 15000,
+          average_likes: 62.5,
+          average_comments: 2.5,
+          average_shares: 1.25,
+          average_impressions: 1875,
+        },
+      },
+    });
+    fetchReportsMock.mockResolvedValue([first, second]);
+    fetchReportMock.mockImplementation((_token: string, _brandId: string, reportId: string) =>
+      Promise.resolve(reportId === "report-1" ? first : second)
+    );
+    const user = userEvent.setup();
+
+    renderPage();
+
+    // First (most recent) report auto-selected on load.
+    await waitFor(() => expect(fetchReportMock).toHaveBeenCalledWith("test-token", "brand-1", "report-1"));
+    const detail = screen.getByRole("region", { name: "Report detail" });
+    await within(detail).findByText("First report summary.");
+
+    await act(async () => {
+      await user.click(screen.getByRole("button", { name: /Second report summary\./ }));
+    });
+
+    await waitFor(() => expect(fetchReportMock).toHaveBeenCalledWith("test-token", "brand-1", "report-2"));
+    await within(detail).findByText("Double down on video content on Instagram.");
+    expect(within(detail).getByText(/500 total likes/)).toBeInTheDocument();
+    expect(within(detail).getByText(/8 posts/)).toBeInTheDocument();
+  });
+
+  it("shows an empty state when the brand has no reports yet", async () => {
+    fetchReportsMock.mockResolvedValue([]);
+
+    renderPage();
+
+    await screen.findByText("No reports yet");
+    expect(screen.getByText(/generated automatically by a background job/)).toBeInTheDocument();
+    expect(fetchReportMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/app/reports/page.tsx
+++ b/apps/web/app/reports/page.tsx
@@ -1,0 +1,330 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { useCallback, useEffect, useState } from "react";
+import { fetchReport, fetchReports, type Report, type ReportMetrics } from "@/lib/api";
+import { useAuth } from "@/lib/auth-context";
+import { useBrand } from "@/lib/brand-context";
+import { Badge } from "@/components/ui/Badge";
+import { Card, CardBody, CardHeader } from "@/components/ui/Card";
+import { EmptyState } from "@/components/ui/EmptyState";
+import { PageHeader } from "@/components/ui/PageHeader";
+import { Skeleton } from "@/components/ui/Skeleton";
+import { cn } from "@/components/ui/cn";
+
+function IconReport() {
+  return (
+    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+      <path
+        d="M7 3h7l4 4v13a1 1 0 01-1 1H7a1 1 0 01-1-1V4a1 1 0 011-1Z"
+        stroke="currentColor"
+        strokeWidth="1.8"
+        strokeLinejoin="round"
+      />
+      <path d="M9 12h6M9 16h6M9 8h2" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" />
+    </svg>
+  );
+}
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+function formatPeriodLabel(report: Pick<Report, "period_start" | "period_end">): string {
+  return `${formatDate(report.period_start)} – ${formatDate(report.period_end)}`;
+}
+
+function excerpt(text: string, maxLength = 140): string {
+  const trimmed = text.trim();
+  if (trimmed.length <= maxLength) return trimmed;
+  return `${trimmed.slice(0, maxLength).trimEnd()}…`;
+}
+
+// `recommendations` is `list[Any]` server-side (see apps/api/schemas/
+// analytics.py::ReportOut) — weekly_report.py currently always writes
+// plain strings, but render generically since other shapes (e.g. a
+// `{title, detail}`-ish object) are contractually possible.
+function renderRecommendation(item: unknown): ReactNode {
+  if (typeof item === "string") return item;
+
+  if (item && typeof item === "object") {
+    const obj = item as Record<string, unknown>;
+    const title = typeof obj.title === "string" ? obj.title : undefined;
+    const detail =
+      typeof obj.detail === "string"
+        ? obj.detail
+        : typeof obj.description === "string"
+          ? obj.description
+          : undefined;
+
+    if (title || detail) {
+      return (
+        <>
+          {title ? <span className="font-medium text-slate-900">{title}</span> : null}
+          {title && detail ? ": " : null}
+          {detail}
+        </>
+      );
+    }
+  }
+
+  return JSON.stringify(item);
+}
+
+// Small "generated from these real numbers" grounding section — the full
+// analytics dashboard (#92) already covers charting this data, so a
+// compact sentence + stat row is enough here.
+function MetricsGrounding({ metrics }: { metrics: ReportMetrics }) {
+  const overall = metrics.overall;
+
+  if (!overall) {
+    return <p className="text-sm text-slate-500">No metrics were recorded for this period.</p>;
+  }
+
+  const postCount = metrics.post_count ?? 0;
+  const platformCount = metrics.platforms?.length ?? 0;
+
+  const stats: { label: string; value: number }[] = [
+    { label: "Posts", value: postCount },
+    { label: "Likes", value: overall.total_likes },
+    { label: "Comments", value: overall.total_comments },
+    { label: "Shares", value: overall.total_shares },
+    { label: "Impressions", value: overall.total_impressions },
+  ];
+
+  return (
+    <div>
+      <p className="text-sm text-slate-500">
+        Generated from {postCount} post{postCount === 1 ? "" : "s"} across{" "}
+        {platformCount} platform{platformCount === 1 ? "" : "s"}: {overall.total_likes} total likes,{" "}
+        {overall.total_comments} comments, {overall.total_shares} shares, and{" "}
+        {overall.total_impressions} impressions.
+      </p>
+      <div className="mt-3 grid grid-cols-2 gap-3 sm:grid-cols-5">
+        {stats.map((stat) => (
+          <div key={stat.label} className="rounded-lg bg-slate-50 px-3 py-2 text-center">
+            <div className="text-base font-semibold text-slate-900">{stat.value}</div>
+            <div className="text-xs text-slate-500">{stat.label}</div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function ReportDetail({
+  report,
+  isLoading,
+  error,
+}: {
+  report: Report | null;
+  isLoading: boolean;
+  error: string | null;
+}) {
+  if (error) {
+    return (
+      <Card>
+        <CardBody>
+          <p role="alert" className="text-sm text-red-600">
+            {error}
+          </p>
+        </CardBody>
+      </Card>
+    );
+  }
+
+  if (isLoading || !report) {
+    return (
+      <Card>
+        <CardBody className="space-y-3">
+          <Skeleton className="h-5 w-1/3" />
+          <Skeleton className="h-4 w-full" />
+          <Skeleton className="h-4 w-5/6" />
+          <Skeleton className="h-4 w-2/3" />
+        </CardBody>
+      </Card>
+    );
+  }
+
+  return (
+    <Card>
+      <CardHeader
+        title={formatPeriodLabel(report)}
+        description={`Generated ${formatDate(report.created_at)}`}
+        action={report.model ? <Badge tone="brand">{report.model}</Badge> : null}
+      />
+      <CardBody className="space-y-6">
+        <div>
+          <h4 className="mb-1.5 text-sm font-semibold text-slate-900">Summary</h4>
+          <p className="text-sm leading-relaxed text-slate-700">{report.summary}</p>
+        </div>
+
+        <div>
+          <h4 className="mb-1.5 text-sm font-semibold text-slate-900">Recommendations</h4>
+          {report.recommendations.length === 0 ? (
+            <p className="text-sm text-slate-500">No recommendations for this period.</p>
+          ) : (
+            <ul className="list-disc space-y-1.5 pl-5 text-sm text-slate-700">
+              {report.recommendations.map((item, index) => (
+                // eslint-disable-next-line react/no-array-index-key
+                <li key={index}>{renderRecommendation(item)}</li>
+              ))}
+            </ul>
+          )}
+        </div>
+
+        <div>
+          <h4 className="mb-1.5 text-sm font-semibold text-slate-900">Generated from</h4>
+          <MetricsGrounding metrics={report.metrics} />
+        </div>
+      </CardBody>
+    </Card>
+  );
+}
+
+export default function ReportsPage() {
+  const { token } = useAuth();
+  const { selectedBrand, selectedBrandId } = useBrand();
+
+  const [reports, setReports] = useState<Report[]>([]);
+  const [isListLoading, setIsListLoading] = useState(false);
+  const [listError, setListError] = useState<string | null>(null);
+
+  const [selectedReportId, setSelectedReportId] = useState<string | null>(null);
+  const [selectedReport, setSelectedReport] = useState<Report | null>(null);
+  const [isDetailLoading, setIsDetailLoading] = useState(false);
+  const [detailError, setDetailError] = useState<string | null>(null);
+
+  const loadReports = useCallback(async () => {
+    if (!token || !selectedBrandId) {
+      setReports([]);
+      setSelectedReportId(null);
+      return;
+    }
+    setIsListLoading(true);
+    setListError(null);
+    try {
+      const result = await fetchReports(token, selectedBrandId);
+      setReports(result);
+      setSelectedReportId((current) => {
+        if (current && result.some((report) => report.id === current)) {
+          return current;
+        }
+        return result[0]?.id ?? null;
+      });
+    } catch (err) {
+      setListError(err instanceof Error ? err.message : "Failed to load reports");
+    } finally {
+      setIsListLoading(false);
+    }
+  }, [token, selectedBrandId]);
+
+  // Reload whenever the token or the selected brand changes (brand switch
+  // re-scopes the report list), same convention as
+  // apps/web/app/calendar/page.tsx.
+  useEffect(() => {
+    setReports([]);
+    setSelectedReportId(null);
+    setSelectedReport(null);
+    loadReports();
+  }, [loadReports]);
+
+  // Fetch the full detail for whichever report is selected — the list
+  // response already carries every field, but going through
+  // GET .../reports/{id} keeps the list and detail views independently
+  // correct if the list response is ever slimmed down later.
+  useEffect(() => {
+    if (!token || !selectedBrandId || !selectedReportId) {
+      setSelectedReport(null);
+      return;
+    }
+    let cancelled = false;
+    setIsDetailLoading(true);
+    setDetailError(null);
+    fetchReport(token, selectedBrandId, selectedReportId)
+      .then((report) => {
+        if (!cancelled) setSelectedReport(report);
+      })
+      .catch((err) => {
+        if (!cancelled) {
+          setDetailError(err instanceof Error ? err.message : "Failed to load report");
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setIsDetailLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [token, selectedBrandId, selectedReportId]);
+
+  return (
+    <div>
+      <PageHeader
+        title="Reports"
+        description={
+          selectedBrand
+            ? `AI-generated weekly performance reports for ${selectedBrand.name}.`
+            : "AI-generated weekly performance reports."
+        }
+      />
+
+      {!selectedBrand ? (
+        <p className="text-sm text-slate-500">Select a brand to see its weekly reports.</p>
+      ) : listError ? (
+        <p role="alert" className="text-sm text-red-600">
+          {listError}
+        </p>
+      ) : isListLoading && reports.length === 0 ? (
+        <div className="grid grid-cols-1 gap-6 lg:grid-cols-[320px_1fr]">
+          <div className="space-y-3">
+            <Skeleton className="h-20 w-full" />
+            <Skeleton className="h-20 w-full" />
+            <Skeleton className="h-20 w-full" />
+          </div>
+          <Skeleton className="h-64 w-full" />
+        </div>
+      ) : reports.length === 0 ? (
+        <EmptyState
+          icon={<IconReport />}
+          title="No reports yet"
+          description="Weekly reports are generated automatically by a background job once a week. New brands won't have one until their first full week of activity has been recorded — check back soon."
+        />
+      ) : (
+        <div className="grid grid-cols-1 gap-6 lg:grid-cols-[320px_1fr]">
+          <ul className="space-y-3">
+            {reports.map((report) => {
+              const isSelected = report.id === selectedReportId;
+              return (
+                <li key={report.id}>
+                  <button
+                    type="button"
+                    aria-pressed={isSelected}
+                    onClick={() => setSelectedReportId(report.id)}
+                    className={cn(
+                      "block w-full rounded-xl border p-4 text-left shadow-card transition-colors",
+                      isSelected
+                        ? "border-brand-300 bg-brand-50"
+                        : "border-slate-200 bg-white hover:border-slate-300 hover:bg-slate-50",
+                    )}
+                  >
+                    <div className="text-sm font-semibold text-slate-900">{formatPeriodLabel(report)}</div>
+                    <p className="mt-1 line-clamp-2 text-sm text-slate-500">{excerpt(report.summary)}</p>
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+
+          <div role="region" aria-label="Report detail">
+            <ReportDetail report={selectedReport} isLoading={isDetailLoading} error={detailError} />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -338,3 +338,87 @@ export async function rescheduleReviewPost(
 
   return res.json();
 }
+
+// --- Weekly reports (Issue #93) ---
+
+// Mirrors apps/api/schemas/analytics.py::PlatformAggregate — the
+// per-platform totals/averages row nested inside a report's `metrics`.
+export interface PlatformAggregate {
+  platform: string;
+  snapshot_count: number;
+  total_likes: number;
+  total_comments: number;
+  total_shares: number;
+  total_impressions: number;
+  average_likes: number;
+  average_comments: number;
+  average_shares: number;
+  average_impressions: number;
+}
+
+// Mirrors the plain-dict shape packages/agents/reporting/weekly_report.py's
+// _metrics_dict() builds and Report.metrics stores — the exact
+// analytics_aggregation.BrandSummary a report was generated from, minus
+// the brand_id/date-range wrapper BrandAnalyticsSummary adds. The API's
+// own ReportOut.metrics is typed `dict[str, Any]`, so this is typed
+// loosely too — render defensively rather than assuming every key exists.
+export interface ReportMetrics {
+  post_count?: number;
+  platforms?: PlatformAggregate[];
+  overall?: PlatformAggregate;
+  [key: string]: unknown;
+}
+
+// Mirrors apps/api/schemas/analytics.py::ReportOut. `recommendations` is
+// `list[Any]` server-side — weekly_report.py currently always writes
+// plain strings, but other shapes (e.g. `{title, detail}`) are
+// contractually possible, so callers should render generically.
+export interface Report {
+  id: string;
+  brand_id: string;
+  period_start: string;
+  period_end: string;
+  summary: string;
+  recommendations: unknown[];
+  metrics: ReportMetrics;
+  model: string | null;
+  created_at: string;
+}
+
+// Mirrors apps/api/schemas/analytics.py::ReportListOut.
+export interface ReportListOut {
+  brand_id: string;
+  reports: Report[];
+}
+
+// apps/api/routers/analytics.py mounts these under
+// /brands/{brand_id}/analytics/reports — same brand-scoping convention as
+// calendarEventsUrl/reviewQueueUrl above.
+function analyticsReportsUrl(brandId: string, suffix = ""): string {
+  return `${API_URL}/brands/${brandId}/analytics/reports${suffix}`;
+}
+
+export async function fetchReports(token: string, brandId: string): Promise<Report[]> {
+  const res = await fetch(analyticsReportsUrl(brandId), {
+    headers: authHeaders(token),
+  });
+
+  if (!res.ok) {
+    throw new ApiError(await parseErrorDetail(res), res.status);
+  }
+
+  const data: ReportListOut = await res.json();
+  return data.reports;
+}
+
+export async function fetchReport(token: string, brandId: string, reportId: string): Promise<Report> {
+  const res = await fetch(analyticsReportsUrl(brandId, `/${reportId}`), {
+    headers: authHeaders(token),
+  });
+
+  if (!res.ok) {
+    throw new ApiError(await parseErrorDetail(res), res.status);
+  }
+
+  return res.json();
+}


### PR DESCRIPTION
## Summary
- Adds `/reports`: a list of a brand's AI-generated weekly reports (most recent first, one card per report showing its period and a one-line summary excerpt) with a detail panel for the selected report showing the full `summary`, `recommendations`, and a compact "generated from" metrics-grounding section (post count, likes, comments, shares, impressions).
- Adds `fetchReports`/`fetchReport` to `apps/web/lib/api.ts` (new `// --- Weekly reports (Issue #93) ---` banner near the end of the file), plus `Report`/`ReportMetrics`/`PlatformAggregate`/`ReportListOut` types mirroring `apps/api/schemas/analytics.py`.
- Renders `recommendations` generically (plain string today, per `packages/agents/reporting/weekly_report.py`, but tolerant of a `{title, detail}`-ish shape since the schema is `list[Any]`).
- Shows the design-system `EmptyState` when a brand has no reports yet, with copy explaining they're generated weekly by a background job.
- Built entirely with the `#88` design system (`Card`, `CardHeader`, `CardBody`, `Badge`, `PageHeader`, `EmptyState`, `Skeleton`). Nav already had the `/reports` link wired up.

## Why
Closes #93 — brand managers need a UI to read the weekly AI-generated performance reports instead of hitting the API directly.

## Test plan
- [x] `npm run lint --prefix apps/web`
- [x] `npm run test --prefix apps/web` (32/32 passing, including new `apps/web/__tests__/reports-page.test.tsx` covering list rendering, selecting a report to load its detail, and the empty state)
- [x] `npm run build --prefix apps/web` (`/reports` route builds successfully)
- [x] Manually reasoned through report shapes: list auto-selects the most recent report; selecting another report fetches its full detail via `GET /brands/{brand_id}/analytics/reports/{report_id}`.

Closes #93
