### PR TITLE
refactor(web): restyle calendar UI with design system

### DIFF
--- a/apps/web/app/calendar/event-form.tsx
+++ b/apps/web/app/calendar/event-form.tsx
@@ -3,6 +3,9 @@
 import { useState } from "react";
 import type { FormEvent } from "react";
 import type { CalendarEvent, CalendarEventInput, CalendarEventStatus, CalendarEventUpdateInput } from "@/lib/api";
+import { Button } from "@/components/ui/Button";
+import { Field, Input, Select, Textarea } from "@/components/ui/Input";
+import { Modal } from "@/components/ui/Modal";
 import { fromDatetimeLocalValue, toDatetimeLocalValue } from "./date-utils";
 import { CALENDAR_EVENT_STATUSES, STATUS_LABELS } from "./status";
 
@@ -93,107 +96,104 @@ export function EventForm({ event, defaultDate, onCancel, onCreate, onUpdate, on
   }
 
   return (
-    <div className="calendar-modal-backdrop" onClick={onCancel}>
-      <div
-        className="calendar-modal"
-        role="dialog"
-        aria-modal="true"
-        aria-label={isEdit ? "Edit event" : "New event"}
-        onClick={(clickEvent) => clickEvent.stopPropagation()}
-      >
-        <h2>{isEdit ? "Edit event" : "New event"}</h2>
-        <form onSubmit={handleSubmit}>
-          <label className="calendar-form-field">
-            <span>Title</span>
-            <input value={title} onChange={(e) => setTitle(e.target.value)} required />
-          </label>
+    <Modal open onClose={onCancel} title={isEdit ? "Edit event" : "New event"}>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <Field label="Title" htmlFor="event-title">
+          <Input id="event-title" value={title} onChange={(e) => setTitle(e.target.value)} required />
+        </Field>
 
-          <label className="calendar-form-field">
-            <span>Description</span>
-            <textarea value={description ?? ""} onChange={(e) => setDescription(e.target.value)} rows={3} />
-          </label>
+        <Field label="Description" htmlFor="event-description">
+          <Textarea
+            id="event-description"
+            value={description ?? ""}
+            onChange={(e) => setDescription(e.target.value)}
+            rows={3}
+          />
+        </Field>
 
-          <fieldset className="calendar-form-field calendar-form-fieldset">
-            <legend>Platforms</legend>
+        <fieldset className="space-y-1.5">
+          <legend className="block text-sm font-medium text-slate-700">Platforms</legend>
+          <div className="flex flex-wrap gap-4">
             {PLATFORM_OPTIONS.map((option) => (
-              <label key={option.value} className="calendar-checkbox">
+              <label key={option.value} className="flex items-center gap-2 text-sm text-slate-700">
                 <input
                   type="checkbox"
                   checked={platforms.includes(option.value)}
                   onChange={() => togglePlatform(option.value)}
+                  className="h-4 w-4 rounded border-slate-300 text-brand-600 focus:ring-2 focus:ring-brand-500/30"
                 />
                 {option.label}
               </label>
             ))}
-          </fieldset>
-
-          <label className="calendar-form-field">
-            <span>Format</span>
-            <input
-              value={desiredFormat}
-              onChange={(e) => setDesiredFormat(e.target.value)}
-              required
-              list="calendar-format-suggestions"
-              placeholder="e.g. image, video, carousel"
-            />
-            <datalist id="calendar-format-suggestions">
-              {FORMAT_SUGGESTIONS.map((suggestion) => (
-                <option key={suggestion} value={suggestion} />
-              ))}
-            </datalist>
-          </label>
-
-          <label className="calendar-form-field">
-            <span>Date and time</span>
-            <input
-              type="datetime-local"
-              value={targetDatetime}
-              onChange={(e) => setTargetDatetime(e.target.value)}
-              required
-            />
-          </label>
-
-          {isEdit && (
-            <label className="calendar-form-field">
-              <span>Status</span>
-              <select value={status} onChange={(e) => setStatus(e.target.value as CalendarEventStatus)}>
-                {CALENDAR_EVENT_STATUSES.map((s) => (
-                  <option key={s} value={s}>
-                    {STATUS_LABELS[s]}
-                  </option>
-                ))}
-              </select>
-            </label>
-          )}
-
-          {error && (
-            <p className="calendar-form-error" role="alert">
-              {error}
-            </p>
-          )}
-
-          <div className="calendar-form-actions">
-            {isEdit && (
-              <button
-                type="button"
-                className="calendar-delete-button"
-                onClick={handleDelete}
-                disabled={isSubmitting}
-              >
-                Delete
-              </button>
-            )}
-            <div className="calendar-form-actions-right">
-              <button type="button" onClick={onCancel} disabled={isSubmitting}>
-                Cancel
-              </button>
-              <button type="submit" className="calendar-submit-button" disabled={isSubmitting}>
-                {isEdit ? "Save" : "Create"}
-              </button>
-            </div>
           </div>
-        </form>
-      </div>
-    </div>
+        </fieldset>
+
+        <Field label="Format" htmlFor="event-format">
+          <Input
+            id="event-format"
+            value={desiredFormat}
+            onChange={(e) => setDesiredFormat(e.target.value)}
+            required
+            list="calendar-format-suggestions"
+            placeholder="e.g. image, video, carousel"
+          />
+          <datalist id="calendar-format-suggestions">
+            {FORMAT_SUGGESTIONS.map((suggestion) => (
+              <option key={suggestion} value={suggestion} />
+            ))}
+          </datalist>
+        </Field>
+
+        <Field label="Date and time" htmlFor="event-datetime">
+          <Input
+            id="event-datetime"
+            type="datetime-local"
+            value={targetDatetime}
+            onChange={(e) => setTargetDatetime(e.target.value)}
+            required
+          />
+        </Field>
+
+        {isEdit && (
+          <Field label="Status" htmlFor="event-status">
+            <Select
+              id="event-status"
+              value={status}
+              onChange={(e) => setStatus(e.target.value as CalendarEventStatus)}
+            >
+              {CALENDAR_EVENT_STATUSES.map((s) => (
+                <option key={s} value={s}>
+                  {STATUS_LABELS[s]}
+                </option>
+              ))}
+            </Select>
+          </Field>
+        )}
+
+        {error && (
+          <p role="alert" className="text-sm font-medium text-red-600">
+            {error}
+          </p>
+        )}
+
+        <div className="flex items-center justify-between gap-2 pt-2">
+          <div>
+            {isEdit && (
+              <Button type="button" variant="danger" onClick={handleDelete} disabled={isSubmitting}>
+                Delete
+              </Button>
+            )}
+          </div>
+          <div className="flex items-center gap-2">
+            <Button type="button" variant="outline" onClick={onCancel} disabled={isSubmitting}>
+              Cancel
+            </Button>
+            <Button type="submit" isLoading={isSubmitting}>
+              {isEdit ? "Save" : "Create"}
+            </Button>
+          </div>
+        </div>
+      </form>
+    </Modal>
   );
 }

--- a/apps/web/app/calendar/month-view.tsx
+++ b/apps/web/app/calendar/month-view.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import type { CalendarEvent } from "@/lib/api";
+import { cn } from "@/components/ui/cn";
 import { dayKey, getMonthGrid, isSameDay } from "./date-utils";
-import { STATUS_CLASS, STATUS_LABELS } from "./status";
+import { STATUS_CHIP_CLASSES, STATUS_CLASS, STATUS_LABELS } from "./status";
 
 const WEEKDAY_LABELS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
 
@@ -31,67 +32,79 @@ function groupByDay(events: CalendarEvent[]): Map<string, CalendarEvent[]> {
 export function MonthView({ referenceDate, events, today, onSelectEvent, onAddEvent }: MonthViewProps) {
   const days = getMonthGrid(referenceDate);
   const eventsByDay = groupByDay(events);
-  const weeks: Date[][] = [];
-  for (let i = 0; i < days.length; i += 7) {
-    weeks.push(days.slice(i, i + 7));
-  }
 
   return (
-    <div className="calendar-month" data-testid="month-view">
-      <div className="calendar-weekday-row">
+    <div className="overflow-hidden rounded-xl border border-slate-200 bg-white shadow-card" data-testid="month-view">
+      <div className="grid grid-cols-7 border-b border-slate-100 bg-slate-50">
         {WEEKDAY_LABELS.map((label) => (
-          <div key={label} className="calendar-weekday">
+          <div
+            key={label}
+            className="px-2 py-2 text-center text-xs font-semibold uppercase tracking-wide text-slate-500"
+          >
             {label}
           </div>
         ))}
       </div>
-      {weeks.map((week) => (
-        <div className="calendar-week-row" key={dayKey(week[0])}>
-          {week.map((day) => {
-            const key = dayKey(day);
-            const dayEvents = eventsByDay.get(key) ?? [];
-            const inMonth = day.getMonth() === referenceDate.getMonth();
-            const isToday = isSameDay(day, today);
-            const classes = [
-              "calendar-day-cell",
-              inMonth ? "" : "calendar-day-cell-outside",
-              isToday ? "calendar-day-cell-today" : "",
-            ]
-              .filter(Boolean)
-              .join(" ");
+      <div className="grid grid-cols-7 gap-px bg-slate-100">
+        {days.map((day) => {
+          const key = dayKey(day);
+          const dayEvents = eventsByDay.get(key) ?? [];
+          const inMonth = day.getMonth() === referenceDate.getMonth();
+          const isToday = isSameDay(day, today);
 
-            return (
-              <div className={classes} key={key} data-testid={`day-${key}`}>
-                <div className="calendar-day-header">
-                  <span className="calendar-day-number">{day.getDate()}</span>
-                  <button
-                    type="button"
-                    className="calendar-add-event"
-                    aria-label={`Add event on ${key}`}
-                    onClick={() => onAddEvent(day)}
-                  >
-                    +
-                  </button>
-                </div>
-                <ul className="calendar-day-events">
-                  {dayEvents.map((event) => (
-                    <li key={event.id}>
-                      <button
-                        type="button"
-                        className={`calendar-event-chip ${STATUS_CLASS[event.status]}`}
-                        onClick={() => onSelectEvent(event)}
-                        title={`${event.title} — ${STATUS_LABELS[event.status]}`}
-                      >
-                        {event.title}
-                      </button>
-                    </li>
-                  ))}
-                </ul>
+          return (
+            <div
+              key={key}
+              data-testid={`day-${key}`}
+              className={cn(
+                "group flex min-h-[6.5rem] flex-col gap-1 bg-white p-1.5 sm:min-h-[8rem] sm:p-2",
+                !inMonth && "bg-slate-50",
+              )}
+            >
+              <div className="flex items-center justify-between">
+                <span
+                  className={cn(
+                    "flex h-6 w-6 items-center justify-center rounded-full text-xs font-medium",
+                    isToday
+                      ? "bg-brand-600 text-white"
+                      : inMonth
+                        ? "text-slate-700"
+                        : "text-slate-400",
+                  )}
+                >
+                  {day.getDate()}
+                </span>
+                <button
+                  type="button"
+                  aria-label={`Add event on ${key}`}
+                  onClick={() => onAddEvent(day)}
+                  className="flex h-5 w-5 items-center justify-center rounded text-slate-400 opacity-0 transition-opacity hover:bg-slate-100 hover:text-slate-600 focus-visible:opacity-100 group-hover:opacity-100"
+                >
+                  +
+                </button>
               </div>
-            );
-          })}
-        </div>
-      ))}
+              <ul className="flex flex-1 flex-col gap-1 overflow-y-auto">
+                {dayEvents.map((event) => (
+                  <li key={event.id}>
+                    <button
+                      type="button"
+                      onClick={() => onSelectEvent(event)}
+                      title={`${event.title} — ${STATUS_LABELS[event.status]}`}
+                      className={cn(
+                        "block w-full truncate rounded-md px-1.5 py-1 text-left text-xs font-medium transition-colors",
+                        STATUS_CLASS[event.status],
+                        STATUS_CHIP_CLASSES[event.status],
+                      )}
+                    >
+                      {event.title}
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          );
+        })}
+      </div>
     </div>
   );
 }

--- a/apps/web/app/calendar/page.tsx
+++ b/apps/web/app/calendar/page.tsx
@@ -12,6 +12,10 @@ import {
 } from "@/lib/api";
 import { useAuth } from "@/lib/auth-context";
 import { useBrand } from "@/lib/brand-context";
+import { Button } from "@/components/ui/Button";
+import { cn } from "@/components/ui/cn";
+import { EmptyState } from "@/components/ui/EmptyState";
+import { PageHeader } from "@/components/ui/PageHeader";
 import { addDays, addMonths, formatMonthLabel, formatWeekRangeLabel } from "./date-utils";
 import { EventForm } from "./event-form";
 import { MonthView } from "./month-view";
@@ -126,56 +130,82 @@ export default function CalendarPage() {
   const today = new Date();
 
   return (
-    <section className="calendar-page">
-      <div className="calendar-toolbar">
-        <div className="calendar-toolbar-left">
-          <h1>Calendar</h1>
-          <p className="scoped-brand">
-            Showing data for: <strong>{selectedBrand ? selectedBrand.name : "no brand selected"}</strong>
-          </p>
-        </div>
+    <div>
+      <PageHeader
+        title="Calendar"
+        description={
+          <>
+            Showing data for: <strong className="font-semibold text-slate-700">{selectedBrand ? selectedBrand.name : "no brand selected"}</strong>
+          </>
+        }
+        action={
+          selectedBrand ? (
+            <div className="flex flex-wrap items-center gap-2">
+              <div
+                className="inline-flex items-center rounded-lg border border-slate-200 bg-white p-0.5"
+                role="group"
+                aria-label="Calendar view"
+              >
+                <button
+                  type="button"
+                  aria-pressed={view === "month"}
+                  onClick={() => setView("month")}
+                  className={cn(
+                    "rounded-md px-3 py-1.5 text-sm font-medium transition-colors",
+                    view === "month" ? "bg-brand-600 text-white shadow-sm" : "text-slate-600 hover:bg-slate-100",
+                  )}
+                >
+                  Month
+                </button>
+                <button
+                  type="button"
+                  aria-pressed={view === "week"}
+                  onClick={() => setView("week")}
+                  className={cn(
+                    "rounded-md px-3 py-1.5 text-sm font-medium transition-colors",
+                    view === "week" ? "bg-brand-600 text-white shadow-sm" : "text-slate-600 hover:bg-slate-100",
+                  )}
+                >
+                  Week
+                </button>
+              </div>
+              <Button onClick={() => openCreateForm(referenceDate)}>+ New event</Button>
+            </div>
+          ) : null
+        }
+      />
 
-        {selectedBrand && (
-          <div className="calendar-toolbar-right">
-            <div className="calendar-view-toggle" role="group" aria-label="Calendar view">
-              <button type="button" aria-pressed={view === "month"} onClick={() => setView("month")}>
-                Month
-              </button>
-              <button type="button" aria-pressed={view === "week"} onClick={() => setView("week")}>
-                Week
-              </button>
-            </div>
-            <div className="calendar-nav">
-              <button type="button" onClick={goPrevious} aria-label="Previous period">
-                &larr;
-              </button>
-              <button type="button" onClick={goToday}>
-                Today
-              </button>
-              <button type="button" onClick={goNext} aria-label="Next period">
-                &rarr;
-              </button>
-            </div>
-            <span className="calendar-period-label">
-              {view === "month" ? formatMonthLabel(referenceDate) : formatWeekRangeLabel(referenceDate)}
-            </span>
-            <button type="button" className="calendar-new-event" onClick={() => openCreateForm(referenceDate)}>
-              + New event
-            </button>
+      {selectedBrand && (
+        <div className="mb-4 flex flex-wrap items-center justify-between gap-3">
+          <div className="flex items-center gap-1.5">
+            <Button variant="outline" size="sm" aria-label="Previous period" onClick={goPrevious}>
+              &larr;
+            </Button>
+            <Button variant="outline" size="sm" onClick={goToday}>
+              Today
+            </Button>
+            <Button variant="outline" size="sm" aria-label="Next period" onClick={goNext}>
+              &rarr;
+            </Button>
           </div>
-        )}
-      </div>
+          <span className="text-sm font-medium text-slate-600">
+            {view === "month" ? formatMonthLabel(referenceDate) : formatWeekRangeLabel(referenceDate)}
+          </span>
+        </div>
+      )}
 
       {error && (
-        <p className="calendar-error" role="alert">
+        <p role="alert" className="mb-4 rounded-lg bg-red-50 px-3 py-2 text-sm font-medium text-red-700">
           {error}
         </p>
       )}
 
       {!selectedBrand ? (
-        <p>Select a brand to see its calendar.</p>
+        <EmptyState title="Select a brand to see its calendar." />
       ) : isLoading && events.length === 0 ? (
-        <p role="status">Loading events…</p>
+        <p role="status" className="py-10 text-center text-sm text-slate-500">
+          Loading events…
+        </p>
       ) : view === "month" ? (
         <MonthView
           referenceDate={referenceDate}
@@ -204,6 +234,6 @@ export default function CalendarPage() {
           onDelete={handleDelete}
         />
       )}
-    </section>
+    </div>
   );
 }

--- a/apps/web/app/calendar/status-badge.tsx
+++ b/apps/web/app/calendar/status-badge.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import type { CalendarEventStatus } from "@/lib/api";
-import { STATUS_CLASS, STATUS_LABELS } from "./status";
+import { Badge } from "@/components/ui/Badge";
+import { STATUS_BADGE_TONE, STATUS_LABELS } from "./status";
 
 export function StatusBadge({ status }: { status: CalendarEventStatus }) {
-  return <span className={`status-badge ${STATUS_CLASS[status]}`}>{STATUS_LABELS[status]}</span>;
+  return <Badge tone={STATUS_BADGE_TONE[status]}>{STATUS_LABELS[status]}</Badge>;
 }

--- a/apps/web/app/calendar/status.ts
+++ b/apps/web/app/calendar/status.ts
@@ -1,7 +1,8 @@
 import type { CalendarEventStatus } from "@/lib/api";
+import type { BadgeTone } from "@/components/ui/Badge";
 
 // Mirrors apps/api/models/content_calendar_event.py::CalendarEventStatus —
-// keep this list and the CSS classes below in sync with that enum.
+// keep this list and the style maps below in sync with that enum.
 export const CALENDAR_EVENT_STATUSES: CalendarEventStatus[] = [
   "scheduled",
   "pipeline_running",
@@ -20,8 +21,11 @@ export const STATUS_LABELS: Record<CalendarEventStatus, string> = {
   failed: "Failed",
 };
 
-// className applied per-status so each state gets a visually distinct color
-// (see .status-* rules in globals.css).
+// A stable, semantic class-name token per status. These carry no CSS rules
+// of their own (styling now comes from the Tailwind maps below) — they
+// exist so tests can assert which status an element represents without
+// depending on visual styling. Keep the string values unchanged; see
+// calendar-page.test.tsx / calendar-views.test.tsx.
 export const STATUS_CLASS: Record<CalendarEventStatus, string> = {
   scheduled: "status-scheduled",
   pipeline_running: "status-pipeline-running",
@@ -29,4 +33,34 @@ export const STATUS_CLASS: Record<CalendarEventStatus, string> = {
   approved: "status-approved",
   published: "status-published",
   failed: "status-failed",
+};
+
+// Badge tone per status, used by <StatusBadge>.
+export const STATUS_BADGE_TONE: Record<CalendarEventStatus, BadgeTone> = {
+  scheduled: "slate",
+  pipeline_running: "blue",
+  ready_for_review: "amber",
+  approved: "brand",
+  published: "green",
+  failed: "red",
+};
+
+// Tailwind classes for the compact event chips in the month grid.
+export const STATUS_CHIP_CLASSES: Record<CalendarEventStatus, string> = {
+  scheduled: "bg-slate-100 text-slate-700 hover:bg-slate-200",
+  pipeline_running: "bg-blue-100 text-blue-700 hover:bg-blue-200",
+  ready_for_review: "bg-amber-100 text-amber-800 hover:bg-amber-200",
+  approved: "bg-brand-100 text-brand-700 hover:bg-brand-200",
+  published: "bg-emerald-100 text-emerald-700 hover:bg-emerald-200",
+  failed: "bg-red-100 text-red-700 hover:bg-red-200",
+};
+
+// Tailwind classes for the event rows in the week view (lighter tint + border).
+export const STATUS_ROW_CLASSES: Record<CalendarEventStatus, string> = {
+  scheduled: "border-slate-200 bg-slate-50 hover:bg-slate-100",
+  pipeline_running: "border-blue-200 bg-blue-50 hover:bg-blue-100",
+  ready_for_review: "border-amber-200 bg-amber-50 hover:bg-amber-100",
+  approved: "border-brand-200 bg-brand-50 hover:bg-brand-100",
+  published: "border-emerald-200 bg-emerald-50 hover:bg-emerald-100",
+  failed: "border-red-200 bg-red-50 hover:bg-red-100",
 };

--- a/apps/web/app/calendar/week-view.tsx
+++ b/apps/web/app/calendar/week-view.tsx
@@ -1,8 +1,10 @@
 "use client";
 
 import type { CalendarEvent } from "@/lib/api";
+import { cn } from "@/components/ui/cn";
 import { dayKey, getWeekDays, isSameDay } from "./date-utils";
 import { StatusBadge } from "./status-badge";
+import { STATUS_ROW_CLASSES } from "./status";
 
 interface WeekViewProps {
   referenceDate: Date;
@@ -31,7 +33,10 @@ export function WeekView({ referenceDate, events, today, onSelectEvent, onAddEve
   const eventsByDay = groupByDay(events);
 
   return (
-    <div className="calendar-week" data-testid="week-view">
+    <div
+      className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-7"
+      data-testid="week-view"
+    >
       {days.map((day) => {
         const key = dayKey(day);
         const dayEvents = (eventsByDay.get(key) ?? [])
@@ -42,38 +47,54 @@ export function WeekView({ referenceDate, events, today, onSelectEvent, onAddEve
         return (
           <div
             key={key}
-            className={`calendar-week-day${isToday ? " calendar-day-cell-today" : ""}`}
             data-testid={`day-${key}`}
+            className={cn(
+              "flex flex-col rounded-xl border border-slate-200 bg-white shadow-card",
+              isToday && "ring-2 ring-brand-500",
+            )}
           >
-            <div className="calendar-day-header">
-              <span className="calendar-day-number">
+            <div className="flex items-center justify-between border-b border-slate-100 px-3 py-2">
+              <span className={cn("text-sm font-semibold", isToday ? "text-brand-700" : "text-slate-700")}>
                 {day.toLocaleDateString(undefined, { weekday: "short", month: "short", day: "numeric" })}
               </span>
               <button
                 type="button"
-                className="calendar-add-event"
                 aria-label={`Add event on ${key}`}
                 onClick={() => onAddEvent(day)}
+                className="flex h-6 w-6 items-center justify-center rounded-md text-slate-400 transition-colors hover:bg-slate-100 hover:text-slate-600"
               >
                 +
               </button>
             </div>
-            <ul className="calendar-week-events">
+            <ul className="flex flex-1 flex-col gap-2 p-2">
               {dayEvents.map((event) => (
                 <li key={event.id}>
-                  <button type="button" className="calendar-week-event" onClick={() => onSelectEvent(event)}>
-                    <span className="calendar-event-time">
-                      {new Date(event.target_datetime).toLocaleTimeString(undefined, {
-                        hour: "numeric",
-                        minute: "2-digit",
-                      })}
+                  <button
+                    type="button"
+                    onClick={() => onSelectEvent(event)}
+                    className={cn(
+                      "flex w-full flex-col gap-1 rounded-lg border px-2.5 py-2 text-left transition-colors",
+                      STATUS_ROW_CLASSES[event.status],
+                    )}
+                  >
+                    <span className="flex items-center justify-between gap-2">
+                      <span className="text-xs font-medium text-slate-500">
+                        {new Date(event.target_datetime).toLocaleTimeString(undefined, {
+                          hour: "numeric",
+                          minute: "2-digit",
+                        })}
+                      </span>
+                      <StatusBadge status={event.status} />
                     </span>
-                    <span className="calendar-event-title">{event.title}</span>
-                    <StatusBadge status={event.status} />
+                    <span className="truncate text-sm font-medium text-slate-900">{event.title}</span>
                   </button>
                 </li>
               ))}
-              {dayEvents.length === 0 && <li className="calendar-week-empty">No events</li>}
+              {dayEvents.length === 0 && (
+                <li className="flex flex-1 items-center justify-center rounded-lg border border-dashed border-slate-200 py-6 text-xs text-slate-400">
+                  No events
+                </li>
+              )}
             </ul>
           </div>
         );

--- a/apps/web/components/ui/Modal.tsx
+++ b/apps/web/components/ui/Modal.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { ReactNode } from "react";
-import { useEffect } from "react";
+import { useEffect, useId } from "react";
 import { createPortal } from "react-dom";
 import { cn } from "./cn";
 
@@ -20,6 +20,8 @@ export function Modal({
   footer?: ReactNode;
   size?: "sm" | "md" | "lg";
 }) {
+  const titleId = useId();
+
   useEffect(() => {
     if (!open) return;
     function onKeyDown(event: KeyboardEvent) {
@@ -43,6 +45,7 @@ export function Modal({
       <div
         role="dialog"
         aria-modal="true"
+        aria-labelledby={title ? titleId : undefined}
         className={cn(
           "relative w-full animate-slide-up rounded-xl bg-white shadow-popover",
           sizeClass,
@@ -50,7 +53,9 @@ export function Modal({
       >
         {title ? (
           <div className="flex items-center justify-between border-b border-slate-100 px-5 py-4">
-            <h2 className="text-base font-semibold text-slate-900">{title}</h2>
+            <h2 id={titleId} className="text-base font-semibold text-slate-900">
+              {title}
+            </h2>
             <button
               type="button"
               onClick={onClose}


### PR DESCRIPTION
## Summary
- Pure restyle of the `/calendar` page (month view, week view, event form, status badges) to use the shared Tailwind design system + `components/ui/` primitives introduced in #88, replacing the hand-rolled `.calendar-*` CSS classes that were removed from `globals.css`.
- No data-fetching logic, API calls, state management, or behavior changes — this is a visual-only restyle.

## What changed
- `app/calendar/event-form.tsx`: now renders inside `components/ui/Modal.tsx`, using `Field`/`Input`/`Select`/`Textarea` from `components/ui/Input.tsx` and `Button` for actions (Cancel / Delete / Create-Save).
- `app/calendar/status-badge.tsx`: now backed by `components/ui/Badge.tsx`, with each `CalendarEventStatus` mapped to a distinct `BadgeTone` (`scheduled`→slate, `pipeline_running`→blue, `ready_for_review`→amber, `approved`→brand, `published`→green, `failed`→red).
- `app/calendar/month-view.tsx`: rebuilt as a real Tailwind grid — clear weekday/date headers, today highlighted, outside-month days dimmed, a hover-reveal "add event" affordance, and events shown as compact colored chips per status.
- `app/calendar/week-view.tsx`: rebuilt as a responsive row of day cards, today highlighted with a ring, events shown as status-tinted rows with time + `StatusBadge`.
- `app/calendar/page.tsx`: header/toolbar restyled with `PageHeader`, `Button` for `+ New event`/Today/Prev/Next, and a simple two-button group for the Month/Week toggle.
- `app/calendar/status.ts`: kept the existing `STATUS_CLASS` tokens (`status-scheduled`, etc.) unchanged as inert class-name hooks (no CSS behind them anymore) since the existing test suite asserts on them; added new `STATUS_BADGE_TONE` / `STATUS_CHIP_CLASSES` / `STATUS_ROW_CLASSES` maps for the actual Tailwind styling.
- `components/ui/Modal.tsx`: small accessibility fix — wired `aria-labelledby` from the dialog's `title` prop (via `useId`) so `role="dialog"` gets a proper accessible name. This is the first real consumer of `Modal.tsx`; without it, `getByRole("dialog", { name: ... })` couldn't resolve a name from the rendered `<h2>` alone.

## Why
Closes #94. The design system landed in #88 and removed the old hand-rolled calendar CSS classes; this restyles the calendar feature onto the new system without touching its behavior.

## Test plan
- [x] `npm run lint --prefix apps/web` — passes (only a pre-existing, unrelated `Avatar.tsx` `<img>` warning)
- [x] `npm run test --prefix apps/web` — all 29 tests pass across 6 files, including `calendar-page.test.tsx` and `calendar-views.test.tsx` unmodified
- [x] `npm run build --prefix apps/web` — builds successfully
- [x] Manually traced every existing `data-testid`/`aria-*`/role hook used by `calendar-page.test.tsx` and `calendar-views.test.tsx` through the new markup (month/week `data-testid`s, "Add event on …" labels, dialog names "New event"/"Edit event", field labels, button names, `status-*` class tokens) — all preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012iWB6uxCB3Rsp97RmVgBW6