### PR TITLE
feat(web): add analytics dashboard UI

### DIFF
--- a/apps/web/__tests__/analytics-page.test.tsx
+++ b/apps/web/__tests__/analytics-page.test.tsx
@@ -1,0 +1,249 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { act, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import AnalyticsPage from "@/app/analytics/page";
+import { AuthProvider } from "@/lib/auth-context";
+import { BrandProvider } from "@/lib/brand-context";
+import type { BrandAnalyticsSummary, PlatformAggregate, PostAnalyticsAggregate, PostAnalyticsTrend } from "@/lib/api";
+
+const fetchBrandsMock = vi.fn();
+const fetchAnalyticsSummaryMock = vi.fn();
+const fetchPostAnalyticsAggregateMock = vi.fn();
+const fetchPostAnalyticsTrendMock = vi.fn();
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return {
+    ...actual,
+    fetchBrands: (...args: unknown[]) => fetchBrandsMock(...args),
+    fetchAnalyticsSummary: (...args: unknown[]) => fetchAnalyticsSummaryMock(...args),
+    fetchPostAnalyticsAggregate: (...args: unknown[]) => fetchPostAnalyticsAggregateMock(...args),
+    fetchPostAnalyticsTrend: (...args: unknown[]) => fetchPostAnalyticsTrendMock(...args),
+  };
+});
+
+const BRANDS = [
+  {
+    id: "brand-1",
+    organization_id: "org-1",
+    name: "Acme Co",
+    industry: null,
+    logo_url: null,
+    target_audience: null,
+    colors: null,
+    tone_descriptors: null,
+    product_catalog: null,
+    brand_report: null,
+    created_at: "2026-01-01",
+    updated_at: "2026-01-01",
+  },
+];
+
+function makePlatformAggregate(overrides: Partial<PlatformAggregate> = {}): PlatformAggregate {
+  return {
+    platform: "linkedin",
+    snapshot_count: 10,
+    total_likes: 1284,
+    total_comments: 340,
+    total_shares: 88,
+    total_impressions: 12987,
+    average_likes: 128.4,
+    average_comments: 34.0,
+    average_shares: 8.8,
+    average_impressions: 1298.7,
+    ...overrides,
+  };
+}
+
+function makeSummary(overrides: Partial<BrandAnalyticsSummary> = {}): BrandAnalyticsSummary {
+  const linkedin = makePlatformAggregate({ platform: "linkedin" });
+  const x = makePlatformAggregate({
+    platform: "x",
+    total_likes: 420,
+    total_comments: 60,
+    total_shares: 30,
+    total_impressions: 5000,
+    average_likes: 42,
+    average_comments: 6,
+    average_shares: 3,
+    average_impressions: 500,
+    snapshot_count: 10,
+  });
+  return {
+    brand_id: "brand-1",
+    start_date: "2026-07-27T00:00:00Z",
+    end_date: "2026-08-26T00:00:00Z",
+    post_count: 6,
+    platforms: [linkedin, x],
+    overall: makePlatformAggregate({
+      platform: "overall",
+      total_likes: 1704,
+      total_comments: 400,
+      total_shares: 118,
+      total_impressions: 17987,
+      average_likes: 85.2,
+      average_comments: 20,
+      average_shares: 5.9,
+      average_impressions: 899.35,
+      snapshot_count: 20,
+    }),
+    ...overrides,
+  };
+}
+
+function makeEmptySummary(): BrandAnalyticsSummary {
+  return {
+    brand_id: "brand-1",
+    start_date: "2026-07-27T00:00:00Z",
+    end_date: "2026-08-26T00:00:00Z",
+    post_count: 0,
+    platforms: [],
+    overall: makePlatformAggregate({
+      platform: "overall",
+      snapshot_count: 0,
+      total_likes: 0,
+      total_comments: 0,
+      total_shares: 0,
+      total_impressions: 0,
+      average_likes: 0,
+      average_comments: 0,
+      average_shares: 0,
+      average_impressions: 0,
+    }),
+  };
+}
+
+function makePostAggregate(overrides: Partial<PostAnalyticsAggregate> = {}): PostAnalyticsAggregate {
+  const linkedin = makePlatformAggregate({ platform: "linkedin" });
+  return {
+    post_id: "post-1",
+    start_date: "2026-07-27T00:00:00Z",
+    end_date: "2026-08-26T00:00:00Z",
+    platforms: [linkedin],
+    overall: linkedin,
+    ...overrides,
+  };
+}
+
+function makeTrend(overrides: Partial<PostAnalyticsTrend> = {}): PostAnalyticsTrend {
+  return {
+    post_id: "post-1",
+    start_date: "2026-07-27T00:00:00Z",
+    end_date: "2026-08-26T00:00:00Z",
+    points: [
+      { platform: "linkedin", likes: 10, comments: 2, shares: 1, impressions: 100, polled_at: "2026-08-01T10:00:00Z" },
+      { platform: "linkedin", likes: 25, comments: 5, shares: 2, impressions: 300, polled_at: "2026-08-10T10:00:00Z" },
+    ],
+    ...overrides,
+  };
+}
+
+function renderPage() {
+  return render(
+    <AuthProvider>
+      <BrandProvider>
+        <AnalyticsPage />
+      </BrandProvider>
+    </AuthProvider>
+  );
+}
+
+describe("AnalyticsPage", () => {
+  beforeEach(() => {
+    fetchBrandsMock.mockReset();
+    fetchAnalyticsSummaryMock.mockReset();
+    fetchPostAnalyticsAggregateMock.mockReset();
+    fetchPostAnalyticsTrendMock.mockReset();
+
+    window.localStorage.clear();
+    window.localStorage.setItem("raindeer.auth.token", "test-token");
+
+    fetchBrandsMock.mockResolvedValue(BRANDS);
+    fetchAnalyticsSummaryMock.mockResolvedValue(makeSummary());
+  });
+
+  it("fetches and renders the brand summary with real numbers", async () => {
+    renderPage();
+
+    await waitFor(() => expect(fetchAnalyticsSummaryMock).toHaveBeenCalledWith("test-token", "brand-1", expect.any(Object)));
+
+    expect(await screen.findByText("6")).toBeInTheDocument(); // post_count tile
+    expect(screen.getByText("1.7K")).toBeInTheDocument(); // total likes, compacted
+    expect(screen.getAllByText("linkedin").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("x").length).toBeGreaterThan(0);
+  });
+
+  it("re-fetches the summary when the date range preset changes", async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    await waitFor(() => expect(fetchAnalyticsSummaryMock).toHaveBeenCalledTimes(1));
+
+    await user.click(screen.getByRole("button", { name: "Last 7 days" }));
+
+    await waitFor(() => expect(fetchAnalyticsSummaryMock).toHaveBeenCalledTimes(2));
+    const secondCallRange = fetchAnalyticsSummaryMock.mock.calls[1][2];
+    const firstCallRange = fetchAnalyticsSummaryMock.mock.calls[0][2];
+    expect(secondCallRange.startDate).not.toEqual(firstCallRange.startDate);
+  });
+
+  it("shows an empty state when there is no engagement data in range", async () => {
+    fetchAnalyticsSummaryMock.mockResolvedValue(makeEmptySummary());
+
+    renderPage();
+
+    expect(await screen.findByText("No engagement data in this range")).toBeInTheDocument();
+    expect(screen.queryByText("linkedin")).not.toBeInTheDocument();
+  });
+
+  it("shows an alert when the summary request fails", async () => {
+    fetchAnalyticsSummaryMock.mockRejectedValue(new Error("Failed to load the analytics summary"));
+
+    renderPage();
+
+    expect(await screen.findByRole("alert")).toHaveTextContent("Failed to load the analytics summary");
+  });
+
+  it("looks up a post's trend by id and renders its chart data", async () => {
+    fetchPostAnalyticsAggregateMock.mockResolvedValue(makePostAggregate());
+    fetchPostAnalyticsTrendMock.mockResolvedValue(makeTrend());
+    const user = userEvent.setup();
+
+    renderPage();
+    await waitFor(() => expect(fetchAnalyticsSummaryMock).toHaveBeenCalled());
+
+    await user.type(screen.getByLabelText("Enter a Post ID to view its trend"), "post-1");
+    await act(async () => {
+      await user.click(screen.getByRole("button", { name: "View trend" }));
+    });
+
+    await waitFor(() =>
+      expect(fetchPostAnalyticsAggregateMock).toHaveBeenCalledWith("test-token", "brand-1", "post-1", expect.any(Object))
+    );
+    expect(fetchPostAnalyticsTrendMock).toHaveBeenCalledWith(
+      "test-token",
+      "brand-1",
+      "post-1",
+      expect.objectContaining({ startDate: expect.any(String), endDate: expect.any(String) })
+    );
+
+    expect(await screen.findByText("Likes over time")).toBeInTheDocument();
+    expect(screen.getByText("Raw snapshots")).toBeInTheDocument();
+  });
+
+  it("shows an empty state when a post has no engagement snapshots yet", async () => {
+    fetchPostAnalyticsAggregateMock.mockResolvedValue(makePostAggregate());
+    fetchPostAnalyticsTrendMock.mockResolvedValue(makeTrend({ points: [] }));
+    const user = userEvent.setup();
+
+    renderPage();
+    await waitFor(() => expect(fetchAnalyticsSummaryMock).toHaveBeenCalled());
+
+    await user.type(screen.getByLabelText("Enter a Post ID to view its trend"), "post-2");
+    await act(async () => {
+      await user.click(screen.getByRole("button", { name: "View trend" }));
+    });
+
+    expect(await screen.findByText("No engagement snapshots yet")).toBeInTheDocument();
+  });
+});

--- a/apps/web/app/analytics/bar-chart.tsx
+++ b/apps/web/app/analytics/bar-chart.tsx
@@ -1,0 +1,175 @@
+"use client";
+
+import { useState } from "react";
+import { CHART_CHROME } from "./colors";
+
+export interface BarDatum {
+  label: string;
+  value: number;
+  color: string;
+}
+
+// A single-metric comparison across a handful of categories (platforms).
+// One series -> one color per bar comes from the caller (anti-patterns.md:
+// never a value-ramp over nominal categories), so this component just
+// lays out whatever colors it's given.
+//
+// Mark spec (dataviz skill, marks-and-anatomy.md): bars <= 24px thick with
+// a 4px rounded data-end, square at the baseline; hairline recessive
+// gridlines; direct value label at the bar's tip when it fits, else the
+// tooltip carries it. The plot height below includes the x-axis label
+// band so this card never needs a nested scroll.
+export function BarChart({
+  data,
+  formatValue,
+  ariaLabel,
+}: {
+  data: BarDatum[];
+  formatValue: (value: number) => string;
+  ariaLabel: string;
+}) {
+  const [hovered, setHovered] = useState<number | null>(null);
+
+  const width = 480;
+  const height = 220;
+  const paddingLeft = 8;
+  const paddingRight = 8;
+  const paddingTop = 24;
+  const axisBand = 28;
+  const plotHeight = height - axisBand - paddingTop;
+  const plotWidth = width - paddingLeft - paddingRight;
+
+  const maxValue = Math.max(1, ...data.map((d) => d.value));
+  // Round the axis ceiling up to a clean step so gridline ticks read as
+  // 0 / round-number / ... rather than an arbitrary max.
+  const niceMax = niceCeiling(maxValue);
+  const ticks = [0, 0.25, 0.5, 0.75, 1].map((f) => f * niceMax);
+
+  const barSlot = plotWidth / Math.max(data.length, 1);
+  const barWidth = Math.min(40, barSlot * 0.5);
+
+  if (data.length === 0) {
+    return null;
+  }
+
+  return (
+    <div role="img" aria-label={ariaLabel} className="w-full">
+      <svg viewBox={`0 0 ${width} ${height}`} className="w-full" style={{ maxHeight: 260 }}>
+        {/* gridlines */}
+        {ticks.map((tick) => {
+          const y = paddingTop + plotHeight - (tick / niceMax) * plotHeight;
+          return (
+            <g key={tick}>
+              <line
+                x1={paddingLeft}
+                x2={width - paddingRight}
+                y1={y}
+                y2={y}
+                stroke={CHART_CHROME.gridline}
+                strokeWidth={1}
+              />
+              <text x={0} y={y - 3} fontSize={9} fill={CHART_CHROME.mutedText}>
+                {formatValue(tick)}
+              </text>
+            </g>
+          );
+        })}
+
+        {data.map((d, i) => {
+          const barHeight = (d.value / niceMax) * plotHeight;
+          const x = paddingLeft + i * barSlot + (barSlot - barWidth) / 2;
+          const y = paddingTop + plotHeight - barHeight;
+          const isHovered = hovered === i;
+          const labelFits = barHeight > 14;
+          return (
+            <g
+              key={d.label}
+              onMouseEnter={() => setHovered(i)}
+              onMouseLeave={() => setHovered((current) => (current === i ? null : current))}
+              onFocus={() => setHovered(i)}
+              onBlur={() => setHovered((current) => (current === i ? null : current))}
+              tabIndex={0}
+              role="graphics-symbol"
+              aria-label={`${d.label}: ${formatValue(d.value)}`}
+              style={{ cursor: "pointer", outline: "none" }}
+            >
+              {/* transparent full-height hit target, bigger than the bar */}
+              <rect
+                x={paddingLeft + i * barSlot}
+                y={paddingTop}
+                width={barSlot}
+                height={plotHeight}
+                fill="transparent"
+              />
+              <rect
+                x={x}
+                y={y}
+                width={barWidth}
+                height={Math.max(barHeight, 1)}
+                rx={4}
+                fill={d.color}
+                opacity={isHovered ? 0.85 : 1}
+              />
+              {labelFits ? (
+                <text
+                  x={x + barWidth / 2}
+                  y={y - 5}
+                  fontSize={10}
+                  textAnchor="middle"
+                  fill={CHART_CHROME.secondaryText}
+                >
+                  {formatValue(d.value)}
+                </text>
+              ) : null}
+              <text
+                x={x + barWidth / 2}
+                y={height - axisBand + 16}
+                fontSize={10}
+                textAnchor="middle"
+                fill={CHART_CHROME.secondaryText}
+              >
+                {d.label}
+              </text>
+              {isHovered ? (
+                <g transform={`translate(${x + barWidth / 2}, ${y - 22})`}>
+                  <rect
+                    x={-34}
+                    y={-16}
+                    width={68}
+                    height={20}
+                    rx={4}
+                    fill={CHART_CHROME.primaryText}
+                    opacity={0.9}
+                  />
+                  <text x={0} y={-2} fontSize={10} textAnchor="middle" fill="#ffffff">
+                    {formatValue(d.value)}
+                  </text>
+                </g>
+              ) : null}
+            </g>
+          );
+        })}
+        <line
+          x1={paddingLeft}
+          x2={width - paddingRight}
+          y1={paddingTop + plotHeight}
+          y2={paddingTop + plotHeight}
+          stroke={CHART_CHROME.axis}
+          strokeWidth={1}
+        />
+      </svg>
+    </div>
+  );
+}
+
+function niceCeiling(value: number): number {
+  if (value <= 0) return 1;
+  const magnitude = Math.pow(10, Math.floor(Math.log10(value)));
+  const normalized = value / magnitude;
+  let niceNormalized: number;
+  if (normalized <= 1) niceNormalized = 1;
+  else if (normalized <= 2) niceNormalized = 2;
+  else if (normalized <= 5) niceNormalized = 5;
+  else niceNormalized = 10;
+  return niceNormalized * magnitude;
+}

--- a/apps/web/app/analytics/colors.ts
+++ b/apps/web/app/analytics/colors.ts
@@ -1,0 +1,125 @@
+import type { EngagementSnapshotPoint, PlatformAggregate } from "@/lib/api";
+
+// Chart color roles — dataviz skill's validated default categorical palette
+// (references/palette.md), copied verbatim: this fixed 8-hue order clears
+// the CVD/contrast checks in the skill's validator, so slot assignment
+// must stay in this order rather than being generated per chart.
+//
+// Light-mode only: this app's design system (apps/web/components/ui/) has
+// no dark-mode variants anywhere yet, so the chart layer matches it rather
+// than introducing a dark theme unilaterally.
+export const CATEGORICAL_PALETTE = [
+  "#2a78d6", // slot 1 — blue
+  "#eb6834", // slot 2 — orange
+  "#1baf7a", // slot 3 — aqua
+  "#eda100", // slot 4 — yellow
+  "#e87ba4", // slot 5 — magenta
+  "#008300", // slot 6 — green
+  "#4a3aa7", // slot 7 — violet
+  "#e34948", // slot 8 — red
+] as const;
+
+// A single series (one metric, one bar chart) always uses slot 1 — see
+// anti-patterns.md: "one series -> one color (slot 1) for every bar,"
+// never a value-ramp over nominal categories like platform names.
+export const SINGLE_SERIES_COLOR = CATEGORICAL_PALETTE[0];
+
+// Chart chrome — one step off the app's existing slate scale, so charts
+// read as part of this design system rather than importing a second gray
+// ramp. Mirrors the roles in palette.md's "Chart chrome & ink" table.
+export const CHART_CHROME = {
+  gridline: "#e2e8f0", // slate-200 hairline
+  axis: "#cbd5e1", // slate-300 baseline
+  mutedText: "#94a3b8", // slate-400 axis/tick labels
+  secondaryText: "#64748b", // slate-500
+  primaryText: "#0f172a", // slate-900
+  surface: "#ffffff",
+};
+
+// Platforms known ahead of time get a pinned slot so the same platform is
+// always the same color across every chart on the page (color follows the
+// entity, never its rank in the current response — anti-patterns.md).
+// apps/api/models/content_calendar_event.py::SUPPORTED_PLATFORMS is
+// ("linkedin", "x") today; the rest are reserved for platforms this app
+// is likely to add next (apps/api/models/social_account.py::SocialPlatform
+// currently only defines LINKEDIN, but EngagementSnapshot.platform is a
+// free string sourced from Post.publish_results, so future platforms can
+// show up in analytics data before they get a dedicated enum member).
+const KNOWN_PLATFORM_SLOTS: Record<string, number> = {
+  linkedin: 0,
+  x: 1,
+  twitter: 1, // alias, in case a caller ever sends the old name
+  instagram: 2,
+  facebook: 3,
+  tiktok: 4,
+  youtube: 5,
+  pinterest: 6,
+  threads: 7,
+};
+
+/**
+ * Stable color for a platform name. Known platforms get a pinned slot;
+ * anything else falls back to a slot chosen from its position in
+ * `fallbackOrder` (the order platforms first appeared in this response),
+ * so an unrecognized platform is still consistent within one page load.
+ */
+export function colorForPlatform(platform: string, fallbackOrder: string[]): string {
+  const key = platform.toLowerCase();
+  const knownSlot = KNOWN_PLATFORM_SLOTS[key];
+  if (knownSlot !== undefined) {
+    return CATEGORICAL_PALETTE[knownSlot];
+  }
+  const index = fallbackOrder.indexOf(platform);
+  const slot = (Object.keys(KNOWN_PLATFORM_SLOTS).length + Math.max(index, 0)) % CATEGORICAL_PALETTE.length;
+  return CATEGORICAL_PALETTE[slot];
+}
+
+export const METRIC_LABELS = {
+  likes: "Likes",
+  comments: "Comments",
+  shares: "Shares",
+  impressions: "Impressions",
+} as const;
+
+export type MetricKey = keyof typeof METRIC_LABELS;
+
+export const METRIC_KEYS: MetricKey[] = ["likes", "comments", "shares", "impressions"];
+
+export function metricTotal(aggregate: PlatformAggregate, metric: MetricKey): number {
+  switch (metric) {
+    case "likes":
+      return aggregate.total_likes;
+    case "comments":
+      return aggregate.total_comments;
+    case "shares":
+      return aggregate.total_shares;
+    case "impressions":
+      return aggregate.total_impressions;
+  }
+}
+
+export function metricAverage(aggregate: PlatformAggregate, metric: MetricKey): number {
+  switch (metric) {
+    case "likes":
+      return aggregate.average_likes;
+    case "comments":
+      return aggregate.average_comments;
+    case "shares":
+      return aggregate.average_shares;
+    case "impressions":
+      return aggregate.average_impressions;
+  }
+}
+
+export function metricFromSnapshot(point: EngagementSnapshotPoint, metric: MetricKey): number {
+  switch (metric) {
+    case "likes":
+      return point.likes;
+    case "comments":
+      return point.comments;
+    case "shares":
+      return point.shares;
+    case "impressions":
+      return point.impressions;
+  }
+}

--- a/apps/web/app/analytics/date-range-filter.tsx
+++ b/apps/web/app/analytics/date-range-filter.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { Button } from "@/components/ui/Button";
+import { Field, Input } from "@/components/ui/Input";
+import { cn } from "@/components/ui/cn";
+import { PRESET_LABELS, type DateRangeValue, type DateRangePreset } from "./date-range";
+
+const PRESET_ORDER: Exclude<DateRangePreset, "custom">[] = ["7d", "30d", "90d"];
+
+// One filter row above everything it scopes (interaction.md: "Every
+// chart, stat, and table re-renders against the same slice, so the
+// numbers always agree") — this same value drives both the brand summary
+// and, when a post id is entered, the per-post aggregate/trend below it.
+export function DateRangeFilter({
+  value,
+  onChange,
+}: {
+  value: DateRangeValue;
+  onChange: (next: DateRangeValue) => void;
+}) {
+  return (
+    <div className="flex flex-wrap items-end gap-3">
+      <div className="flex items-center gap-1.5" role="group" aria-label="Date range">
+        {PRESET_ORDER.map((preset) => (
+          <Button
+            key={preset}
+            type="button"
+            size="sm"
+            variant={value.preset === preset ? "primary" : "outline"}
+            aria-pressed={value.preset === preset}
+            onClick={() => onChange({ ...value, preset })}
+          >
+            {PRESET_LABELS[preset]}
+          </Button>
+        ))}
+        <Button
+          type="button"
+          size="sm"
+          variant={value.preset === "custom" ? "primary" : "outline"}
+          aria-pressed={value.preset === "custom"}
+          onClick={() => onChange({ ...value, preset: "custom" })}
+        >
+          Custom
+        </Button>
+      </div>
+
+      <div className={cn("flex items-end gap-2", value.preset !== "custom" && "opacity-50")}>
+        <Field label="Start" htmlFor="analytics-range-start">
+          <Input
+            id="analytics-range-start"
+            type="date"
+            value={value.customStart}
+            max={value.customEnd}
+            disabled={value.preset !== "custom"}
+            onChange={(event) => onChange({ ...value, preset: "custom", customStart: event.target.value })}
+          />
+        </Field>
+        <Field label="End" htmlFor="analytics-range-end">
+          <Input
+            id="analytics-range-end"
+            type="date"
+            value={value.customEnd}
+            min={value.customStart}
+            disabled={value.preset !== "custom"}
+            onChange={(event) => onChange({ ...value, preset: "custom", customEnd: event.target.value })}
+          />
+        </Field>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/analytics/date-range.ts
+++ b/apps/web/app/analytics/date-range.ts
@@ -1,0 +1,45 @@
+import { formatDateInput } from "./format";
+
+// Mirrors apps/api/routers/analytics.py::DEFAULT_WINDOW_DAYS — the "30d"
+// preset below reproduces the backend's own default range, so a caller
+// who never touches the picker still sees exactly what the API would
+// have defaulted to if no start_date/end_date were sent at all.
+export type DateRangePreset = "7d" | "30d" | "90d" | "custom";
+
+export interface DateRangeValue {
+  preset: DateRangePreset;
+  customStart: string; // YYYY-MM-DD, only used when preset === "custom"
+  customEnd: string;
+}
+
+export const PRESET_LABELS: Record<Exclude<DateRangePreset, "custom">, string> = {
+  "7d": "Last 7 days",
+  "30d": "Last 30 days",
+  "90d": "Last 90 days",
+};
+
+export function defaultDateRangeValue(): DateRangeValue {
+  const now = new Date();
+  return {
+    preset: "30d",
+    customStart: formatDateInput(new Date(now.getTime() - 30 * 86_400_000)),
+    customEnd: formatDateInput(now),
+  };
+}
+
+/** Resolves a DateRangeValue to concrete ISO instants at the moment it's
+ * called (rather than storing a computed "now" in state), so presets like
+ * "last 7 days" stay anchored to whenever the caller actually fetches. */
+export function resolveDateRange(value: DateRangeValue): { startDate: Date; endDate: Date } {
+  if (value.preset === "custom") {
+    const startDate = new Date(`${value.customStart}T00:00:00`);
+    // Inclusive of the whole end day — the backend's upper bound is
+    // exclusive (< end_date), so anchor it to the end of that day.
+    const endDate = new Date(`${value.customEnd}T23:59:59.999`);
+    return { startDate, endDate };
+  }
+  const days = { "7d": 7, "30d": 30, "90d": 90 }[value.preset];
+  const endDate = new Date();
+  const startDate = new Date(endDate.getTime() - days * 86_400_000);
+  return { startDate, endDate };
+}

--- a/apps/web/app/analytics/format.ts
+++ b/apps/web/app/analytics/format.ts
@@ -1,0 +1,41 @@
+// Formatting helpers for the analytics dashboard. Kept tiny and
+// dependency-free, matching the rest of this app.
+
+/** 1284 -> "1,284", 12987 -> "13.0K", 4230000 -> "4.2M". Proportional
+ * figures everywhere these are used (stat tiles, bar labels) — see the
+ * dataviz skill's marks-and-anatomy.md: tabular-nums is reserved for
+ * columns that must align vertically (table cells), not standalone
+ * numbers. */
+export function formatCompactNumber(value: number): string {
+  const abs = Math.abs(value);
+  if (abs < 1000) {
+    return Math.round(value).toLocaleString("en-US");
+  }
+  if (abs < 1_000_000) {
+    return `${(value / 1000).toFixed(1)}K`;
+  }
+  return `${(value / 1_000_000).toFixed(1)}M`;
+}
+
+/** Fixed one-decimal average, e.g. 12.375 -> "12.4". */
+export function formatAverage(value: number): string {
+  return value.toFixed(1);
+}
+
+export function formatDateInput(date: Date): string {
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}`;
+}
+
+export function formatDateLabel(iso: string): string {
+  return new Date(iso).toLocaleDateString("en-US", { month: "short", day: "numeric" });
+}
+
+export function formatDateTimeLabel(iso: string): string {
+  return new Date(iso).toLocaleString("en-US", {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}

--- a/apps/web/app/analytics/line-chart.tsx
+++ b/apps/web/app/analytics/line-chart.tsx
@@ -1,0 +1,220 @@
+"use client";
+
+import type { PointerEvent as ReactPointerEvent } from "react";
+import { useMemo, useRef, useState } from "react";
+import { CHART_CHROME } from "./colors";
+
+export interface LineSeries {
+  name: string;
+  color: string;
+  points: { t: number; value: number }[]; // t = epoch ms
+}
+
+// A real time-series chart (per the issue: "Render the trend as a real
+// line/time-series chart per metric"). Mark spec (marks-and-anatomy.md):
+// 2px lines, >=8px end markers with a 2px surface ring, a crosshair that
+// snaps to the nearest x, one tooltip listing every series at that x, and
+// a legend whenever there are 2+ series (color follows the platform
+// entity, assigned by the caller so it stays consistent with the bar
+// chart/table above).
+export function LineChart({
+  series,
+  formatValue,
+  formatTime,
+  ariaLabel,
+}: {
+  series: LineSeries[];
+  formatValue: (value: number) => string;
+  formatTime: (t: number) => string;
+  ariaLabel: string;
+}) {
+  const svgRef = useRef<SVGSVGElement | null>(null);
+  const [hoverX, setHoverX] = useState<number | null>(null);
+
+  const width = 560;
+  const height = 220;
+  const paddingLeft = 42;
+  const paddingRight = 56;
+  const paddingTop = 16;
+  const axisBand = 24;
+  const plotHeight = height - axisBand - paddingTop;
+  const plotWidth = width - paddingLeft - paddingRight;
+
+  const allPoints = series.flatMap((s) => s.points);
+  const hasData = allPoints.length > 0;
+
+  const minT = hasData ? Math.min(...allPoints.map((p) => p.t)) : 0;
+  const maxT = hasData ? Math.max(...allPoints.map((p) => p.t)) : 1;
+  const maxValue = hasData ? Math.max(...allPoints.map((p) => p.value)) : 1;
+  const niceMax = niceCeiling(Math.max(maxValue, 1));
+  const tSpan = Math.max(maxT - minT, 1);
+
+  const xFor = (t: number) => paddingLeft + ((t - minT) / tSpan) * plotWidth;
+  const yFor = (value: number) => paddingTop + plotHeight - (value / niceMax) * plotHeight;
+
+  const ticks = [0, 0.25, 0.5, 0.75, 1].map((f) => f * niceMax);
+
+  const nearestBySeries = useMemo(() => {
+    if (hoverX === null) return null;
+    const hoveredT = minT + ((hoverX - paddingLeft) / plotWidth) * tSpan;
+    return series.map((s) => {
+      if (s.points.length === 0) return null;
+      let closest = s.points[0];
+      let bestDiff = Math.abs(closest.t - hoveredT);
+      for (const p of s.points) {
+        const diff = Math.abs(p.t - hoveredT);
+        if (diff < bestDiff) {
+          closest = p;
+          bestDiff = diff;
+        }
+      }
+      return closest;
+    });
+  }, [hoverX, series, minT, tSpan, plotWidth]);
+
+  function handleMove(event: ReactPointerEvent<SVGSVGElement>) {
+    const svg = svgRef.current;
+    if (!svg) return;
+    const rect = svg.getBoundingClientRect();
+    const scaleX = width / rect.width;
+    const localX = (event.clientX - rect.left) * scaleX;
+    setHoverX(Math.min(Math.max(localX, paddingLeft), width - paddingRight));
+  }
+
+  if (!hasData) {
+    return null;
+  }
+
+  return (
+    <div>
+      {series.length >= 2 ? (
+        <div className="mb-2 flex flex-wrap gap-x-4 gap-y-1">
+          {series.map((s) => (
+            <div key={s.name} className="flex items-center gap-1.5 text-xs text-slate-600">
+              <span aria-hidden="true" className="inline-block h-0.5 w-3 rounded" style={{ backgroundColor: s.color }} />
+              {s.name}
+            </div>
+          ))}
+        </div>
+      ) : null}
+      <div role="img" aria-label={ariaLabel} className="w-full">
+        <svg
+          ref={svgRef}
+          viewBox={`0 0 ${width} ${height}`}
+          className="w-full"
+          style={{ maxHeight: 260 }}
+          onPointerMove={handleMove}
+          onPointerLeave={() => setHoverX(null)}
+        >
+          {ticks.map((tick) => {
+            const y = yFor(tick);
+            return (
+              <g key={tick}>
+                <line
+                  x1={paddingLeft}
+                  x2={width - paddingRight}
+                  y1={y}
+                  y2={y}
+                  stroke={CHART_CHROME.gridline}
+                  strokeWidth={1}
+                />
+                <text x={0} y={y + 3} fontSize={9} fill={CHART_CHROME.mutedText}>
+                  {formatValue(tick)}
+                </text>
+              </g>
+            );
+          })}
+
+          <line
+            x1={paddingLeft}
+            x2={width - paddingRight}
+            y1={paddingTop + plotHeight}
+            y2={paddingTop + plotHeight}
+            stroke={CHART_CHROME.axis}
+            strokeWidth={1}
+          />
+          <text x={paddingLeft} y={height - 4} fontSize={9} fill={CHART_CHROME.mutedText}>
+            {formatTime(minT)}
+          </text>
+          <text x={width - paddingRight} y={height - 4} fontSize={9} textAnchor="end" fill={CHART_CHROME.mutedText}>
+            {formatTime(maxT)}
+          </text>
+
+          {series.map((s) => {
+            if (s.points.length === 0) return null;
+            const sorted = [...s.points].sort((a, b) => a.t - b.t);
+            const d = sorted
+              .map((p, i) => `${i === 0 ? "M" : "L"} ${xFor(p.t)} ${yFor(p.value)}`)
+              .join(" ");
+            const last = sorted[sorted.length - 1];
+            return (
+              <g key={s.name}>
+                <path d={d} fill="none" stroke={s.color} strokeWidth={2} strokeLinejoin="round" strokeLinecap="round" />
+                {sorted.map((p) => (
+                  <circle
+                    key={p.t}
+                    cx={xFor(p.t)}
+                    cy={yFor(p.value)}
+                    r={4}
+                    fill={s.color}
+                    stroke={CHART_CHROME.surface}
+                    strokeWidth={2}
+                  />
+                ))}
+                <text
+                  x={xFor(last.t) + 6}
+                  y={yFor(last.value) + 3}
+                  fontSize={10}
+                  fill={CHART_CHROME.secondaryText}
+                >
+                  {formatValue(last.value)}
+                </text>
+              </g>
+            );
+          })}
+
+          {hoverX !== null ? (
+            <line
+              x1={hoverX}
+              x2={hoverX}
+              y1={paddingTop}
+              y2={paddingTop + plotHeight}
+              stroke={CHART_CHROME.axis}
+              strokeWidth={1}
+            />
+          ) : null}
+        </svg>
+      </div>
+      {hoverX !== null && nearestBySeries ? (
+        <div className="mt-2 rounded-lg border border-slate-200 bg-white p-2 text-xs shadow-card">
+          {series.map((s, i) => {
+            const point = nearestBySeries[i];
+            if (!point) return null;
+            return (
+              <div key={s.name} className="flex items-center justify-between gap-4 py-0.5">
+                <span className="flex items-center gap-1.5 text-slate-500">
+                  <span aria-hidden="true" className="inline-block h-0.5 w-3 rounded" style={{ backgroundColor: s.color }} />
+                  {s.name}
+                  <span className="text-slate-400">{formatTime(point.t)}</span>
+                </span>
+                <span className="font-semibold text-slate-900">{formatValue(point.value)}</span>
+              </div>
+            );
+          })}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function niceCeiling(value: number): number {
+  if (value <= 0) return 1;
+  const magnitude = Math.pow(10, Math.floor(Math.log10(value)));
+  const normalized = value / magnitude;
+  let niceNormalized: number;
+  if (normalized <= 1) niceNormalized = 1;
+  else if (normalized <= 2) niceNormalized = 2;
+  else if (normalized <= 5) niceNormalized = 5;
+  else niceNormalized = 10;
+  return niceNormalized * magnitude;
+}

--- a/apps/web/app/analytics/page.tsx
+++ b/apps/web/app/analytics/page.tsx
@@ -1,18 +1,383 @@
 "use client";
 
+import type { FormEvent } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  ApiError,
+  type BrandAnalyticsSummary,
+  type PostAnalyticsAggregate,
+  type PostAnalyticsTrend,
+  fetchAnalyticsSummary,
+  fetchPostAnalyticsAggregate,
+  fetchPostAnalyticsTrend,
+} from "@/lib/api";
+import { useAuth } from "@/lib/auth-context";
 import { useBrand } from "@/lib/brand-context";
+import { Button } from "@/components/ui/Button";
+import { Card, CardBody, CardHeader } from "@/components/ui/Card";
+import { EmptyState } from "@/components/ui/EmptyState";
+import { Field, Input, Select } from "@/components/ui/Input";
+import { Skeleton } from "@/components/ui/Skeleton";
+import { PageHeader } from "@/components/ui/PageHeader";
+import { BarChart } from "./bar-chart";
+import {
+  colorForPlatform,
+  METRIC_KEYS,
+  METRIC_LABELS,
+  metricAverage,
+  metricFromSnapshot,
+  metricTotal,
+  type MetricKey,
+} from "./colors";
+import { DateRangeFilter } from "./date-range-filter";
+import { defaultDateRangeValue, resolveDateRange, type DateRangeValue } from "./date-range";
+import { formatAverage, formatCompactNumber, formatDateLabel, formatDateTimeLabel } from "./format";
+import { LineChart, type LineSeries } from "./line-chart";
+import { PlatformTable } from "./platform-table";
+import { StatTile } from "./stat-tile";
 
-// Stub for #34 / #35 — replace with the real analytics dashboards.
 export default function AnalyticsPage() {
-  const { selectedBrand } = useBrand();
+  const { token } = useAuth();
+  const { selectedBrand, selectedBrandId } = useBrand();
+
+  const [dateRange, setDateRange] = useState<DateRangeValue>(() => defaultDateRangeValue());
+
+  const [summary, setSummary] = useState<BrandAnalyticsSummary | null>(null);
+  const [isLoadingSummary, setIsLoadingSummary] = useState(false);
+  const [summaryError, setSummaryError] = useState<string | null>(null);
+  const [barMetric, setBarMetric] = useState<MetricKey>("likes");
+
+  const [postIdInput, setPostIdInput] = useState("");
+  const [platformFilterInput, setPlatformFilterInput] = useState("");
+  const [activePostId, setActivePostId] = useState<string | null>(null);
+  const [activePlatformFilter, setActivePlatformFilter] = useState("");
+  const [postAggregate, setPostAggregate] = useState<PostAnalyticsAggregate | null>(null);
+  const [postTrend, setPostTrend] = useState<PostAnalyticsTrend | null>(null);
+  const [isLoadingPost, setIsLoadingPost] = useState(false);
+  const [postError, setPostError] = useState<string | null>(null);
+
+  const loadSummary = useCallback(async () => {
+    if (!token || !selectedBrandId) {
+      setSummary(null);
+      return;
+    }
+    setIsLoadingSummary(true);
+    setSummaryError(null);
+    try {
+      const { startDate, endDate } = resolveDateRange(dateRange);
+      const result = await fetchAnalyticsSummary(token, selectedBrandId, {
+        startDate: startDate.toISOString(),
+        endDate: endDate.toISOString(),
+      });
+      setSummary(result);
+    } catch (err) {
+      setSummaryError(err instanceof ApiError ? err.message : "Failed to load the analytics summary");
+      setSummary(null);
+    } finally {
+      setIsLoadingSummary(false);
+    }
+  }, [token, selectedBrandId, dateRange]);
+
+  useEffect(() => {
+    loadSummary();
+  }, [loadSummary]);
+
+  const loadPostData = useCallback(async () => {
+    if (!token || !selectedBrandId || !activePostId) return;
+    setIsLoadingPost(true);
+    setPostError(null);
+    try {
+      const { startDate, endDate } = resolveDateRange(dateRange);
+      const rangeInput = { startDate: startDate.toISOString(), endDate: endDate.toISOString() };
+      const [aggregate, trend] = await Promise.all([
+        fetchPostAnalyticsAggregate(token, selectedBrandId, activePostId, rangeInput),
+        fetchPostAnalyticsTrend(token, selectedBrandId, activePostId, {
+          ...rangeInput,
+          platform: activePlatformFilter || undefined,
+        }),
+      ]);
+      setPostAggregate(aggregate);
+      setPostTrend(trend);
+    } catch (err) {
+      setPostError(err instanceof ApiError ? err.message : "Failed to load this post's analytics");
+      setPostAggregate(null);
+      setPostTrend(null);
+    } finally {
+      setIsLoadingPost(false);
+    }
+  }, [token, selectedBrandId, activePostId, activePlatformFilter, dateRange]);
+
+  useEffect(() => {
+    if (activePostId) {
+      loadPostData();
+    }
+  }, [loadPostData, activePostId]);
+
+  function handlePostSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const trimmed = postIdInput.trim();
+    if (!trimmed) return;
+    setActivePlatformFilter(platformFilterInput.trim());
+    setActivePostId(trimmed);
+  }
+
+  const platformNames = useMemo(() => summary?.platforms.map((p) => p.platform) ?? [], [summary]);
+
+  const barData = useMemo(() => {
+    if (!summary) return [];
+    return summary.platforms.map((platform) => ({
+      label: platform.platform,
+      value: metricTotal(platform, barMetric),
+      color: colorForPlatform(platform.platform, platformNames),
+    }));
+  }, [summary, barMetric, platformNames]);
+
+  const trendSeriesByMetric = useMemo(() => {
+    if (!postTrend) return null;
+    const names = Array.from(new Set(postTrend.points.map((p) => p.platform)));
+    const byMetric: Record<MetricKey, LineSeries[]> = {
+      likes: [],
+      comments: [],
+      shares: [],
+      impressions: [],
+    };
+    for (const metric of METRIC_KEYS) {
+      byMetric[metric] = names.map((name) => ({
+        name,
+        color: colorForPlatform(name, names),
+        points: postTrend.points
+          .filter((p) => p.platform === name)
+          .map((p) => ({ t: new Date(p.polled_at).getTime(), value: metricFromSnapshot(p, metric) })),
+      }));
+    }
+    return byMetric;
+  }, [postTrend]);
+
+  if (!selectedBrand) {
+    return (
+      <div>
+        <PageHeader title="Analytics" description="Track engagement across every published post." />
+        <EmptyState title="Select a brand" description="Choose a brand to see its analytics." />
+      </div>
+    );
+  }
 
   return (
-    <section className="stub-page">
-      <h1>Analytics</h1>
-      <p>Coming soon.</p>
-      <p className="scoped-brand">
-        Showing data for: <strong>{selectedBrand ? selectedBrand.name : "no brand selected"}</strong>
-      </p>
-    </section>
+    <div className="space-y-8">
+      <PageHeader
+        title="Analytics"
+        description={
+          <>
+            Showing data for: <strong className="text-slate-700">{selectedBrand.name}</strong>
+          </>
+        }
+      />
+
+      <Card>
+        <CardBody>
+          <DateRangeFilter value={dateRange} onChange={setDateRange} />
+        </CardBody>
+      </Card>
+
+      <section aria-labelledby="analytics-summary-heading" className="space-y-4">
+        <h2 id="analytics-summary-heading" className="text-lg font-semibold text-slate-900">
+          Brand summary
+        </h2>
+
+        {summaryError ? (
+          <p role="alert" className="rounded-lg bg-red-50 px-3 py-2 text-sm font-medium text-red-700">
+            {summaryError}
+          </p>
+        ) : null}
+
+        {isLoadingSummary && !summary ? (
+          <div className="grid grid-cols-2 gap-4 sm:grid-cols-5">
+            {Array.from({ length: 5 }).map((_, i) => (
+              <Skeleton key={i} className="h-24 w-full" />
+            ))}
+          </div>
+        ) : summary && summary.overall.snapshot_count === 0 ? (
+          <EmptyState
+            title="No engagement data in this range"
+            description="No engagement snapshots were recorded for this brand's posts in the selected date range. Try widening the range, or check back once posts have published and been polled for engagement."
+          />
+        ) : summary ? (
+          <>
+            <div className="grid grid-cols-2 gap-4 sm:grid-cols-5">
+              <StatTile label="Posts in range" value={summary.post_count.toLocaleString("en-US")} />
+              {METRIC_KEYS.map((metric) => (
+                <StatTile
+                  key={metric}
+                  label={`Total ${METRIC_LABELS[metric].toLowerCase()}`}
+                  value={formatCompactNumber(metricTotal(summary.overall, metric))}
+                  secondary={`avg ${formatAverage(metricAverage(summary.overall, metric))} / snapshot`}
+                />
+              ))}
+            </div>
+
+            <Card>
+              <CardHeader
+                title="Engagement by platform"
+                description="Compare one metric across every platform this brand published to in this range."
+                action={
+                  <Field label="Metric" htmlFor="analytics-bar-metric">
+                    <Select
+                      id="analytics-bar-metric"
+                      value={barMetric}
+                      onChange={(event) => setBarMetric(event.target.value as MetricKey)}
+                    >
+                      {METRIC_KEYS.map((metric) => (
+                        <option key={metric} value={metric}>
+                          {METRIC_LABELS[metric]}
+                        </option>
+                      ))}
+                    </Select>
+                  </Field>
+                }
+              />
+              <CardBody className="space-y-6">
+                <BarChart
+                  data={barData}
+                  formatValue={formatCompactNumber}
+                  ariaLabel={`Total ${METRIC_LABELS[barMetric].toLowerCase()} by platform`}
+                />
+                <PlatformTable platforms={summary.platforms} />
+              </CardBody>
+            </Card>
+          </>
+        ) : null}
+      </section>
+
+      <section aria-labelledby="analytics-post-heading" className="space-y-4">
+        <h2 id="analytics-post-heading" className="text-lg font-semibold text-slate-900">
+          Post trend
+        </h2>
+        <Card>
+          <CardBody>
+            <form onSubmit={handlePostSubmit} className="flex flex-wrap items-end gap-3">
+              <div className="min-w-[20rem] flex-1">
+                <Field label="Enter a Post ID to view its trend" htmlFor="analytics-post-id">
+                  <Input
+                    id="analytics-post-id"
+                    value={postIdInput}
+                    onChange={(event) => setPostIdInput(event.target.value)}
+                    placeholder="e.g. 3f9a1c2e-6b7d-4e8a-9c1a-2b3c4d5e6f7a"
+                  />
+                </Field>
+              </div>
+              <Field label="Platform (optional)" htmlFor="analytics-post-platform">
+                <Input
+                  id="analytics-post-platform"
+                  value={platformFilterInput}
+                  onChange={(event) => setPlatformFilterInput(event.target.value)}
+                  placeholder="linkedin"
+                  className="w-40"
+                />
+              </Field>
+              <Button type="submit" isLoading={isLoadingPost}>
+                View trend
+              </Button>
+            </form>
+            <p className="mt-2 text-xs text-slate-400">
+              There&apos;s no post picker yet — the calendar and review queue don&apos;t expose a post list either. A
+              proper picker reusing one of those is a reasonable follow-up once they do; entering an id directly is
+              enough to unblock this view for now.
+            </p>
+          </CardBody>
+        </Card>
+
+        {postError ? (
+          <p role="alert" className="rounded-lg bg-red-50 px-3 py-2 text-sm font-medium text-red-700">
+            {postError}
+          </p>
+        ) : null}
+
+        {isLoadingPost && !postAggregate ? (
+          <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+            {Array.from({ length: 4 }).map((_, i) => (
+              <Skeleton key={i} className="h-24 w-full" />
+            ))}
+          </div>
+        ) : postAggregate && postTrend ? (
+          postTrend.points.length === 0 ? (
+            <EmptyState
+              title="No engagement snapshots yet"
+              description="This post hasn't been polled for engagement in the selected date range yet. Try widening the range, or check back after the next poll."
+            />
+          ) : (
+            <>
+              <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+                {METRIC_KEYS.map((metric) => (
+                  <StatTile
+                    key={metric}
+                    label={`Total ${METRIC_LABELS[metric].toLowerCase()}`}
+                    value={formatCompactNumber(metricTotal(postAggregate.overall, metric))}
+                    secondary={`avg ${formatAverage(metricAverage(postAggregate.overall, metric))} / snapshot`}
+                  />
+                ))}
+              </div>
+
+              <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+                {METRIC_KEYS.map((metric) => (
+                  <Card key={metric}>
+                    <CardHeader title={`${METRIC_LABELS[metric]} over time`} />
+                    <CardBody>
+                      <LineChart
+                        series={trendSeriesByMetric?.[metric] ?? []}
+                        formatValue={formatCompactNumber}
+                        formatTime={(t) => formatDateTimeLabel(new Date(t).toISOString())}
+                        ariaLabel={`${METRIC_LABELS[metric]} over time`}
+                      />
+                    </CardBody>
+                  </Card>
+                ))}
+              </div>
+
+              <Card>
+                <CardHeader title="Raw snapshots" description="Every engagement snapshot polled for this post in this range." />
+                <CardBody className="overflow-x-auto">
+                  <table className="w-full text-left text-sm">
+                    <thead>
+                      <tr className="border-b border-slate-200 text-xs uppercase tracking-wide text-slate-400">
+                        <th scope="col" className="py-2 pr-4 font-medium">
+                          Polled at
+                        </th>
+                        <th scope="col" className="py-2 pr-4 font-medium">
+                          Platform
+                        </th>
+                        <th scope="col" className="py-2 pr-4 font-medium">
+                          Likes
+                        </th>
+                        <th scope="col" className="py-2 pr-4 font-medium">
+                          Comments
+                        </th>
+                        <th scope="col" className="py-2 pr-4 font-medium">
+                          Shares
+                        </th>
+                        <th scope="col" className="py-2 font-medium">
+                          Impressions
+                        </th>
+                      </tr>
+                    </thead>
+                    <tbody className="[font-variant-numeric:tabular-nums]">
+                      {postTrend.points.map((point, i) => (
+                        <tr key={`${point.platform}-${point.polled_at}-${i}`} className="border-b border-slate-100 last:border-0">
+                          <td className="py-2 pr-4 text-slate-600">{formatDateLabel(point.polled_at)}</td>
+                          <td className="py-2 pr-4 capitalize text-slate-900">{point.platform}</td>
+                          <td className="py-2 pr-4 text-slate-600">{point.likes.toLocaleString("en-US")}</td>
+                          <td className="py-2 pr-4 text-slate-600">{point.comments.toLocaleString("en-US")}</td>
+                          <td className="py-2 pr-4 text-slate-600">{point.shares.toLocaleString("en-US")}</td>
+                          <td className="py-2 text-slate-600">{point.impressions.toLocaleString("en-US")}</td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </CardBody>
+              </Card>
+            </>
+          )
+        ) : null}
+      </section>
+    </div>
   );
 }

--- a/apps/web/app/analytics/platform-table.tsx
+++ b/apps/web/app/analytics/platform-table.tsx
@@ -1,0 +1,60 @@
+import type { PlatformAggregate } from "@/lib/api";
+import { formatAverage, formatCompactNumber } from "./format";
+
+// The accessible, WCAG-clean twin of the bar chart above it (dataviz
+// skill, anti-patterns.md: "No table view / color-only encoding on a
+// continuous scale" is a failure mode) — every number the chart can show
+// is reachable here too, plus the averages the single-metric chart
+// doesn't have room for.
+export function PlatformTable({ platforms }: { platforms: PlatformAggregate[] }) {
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full text-left text-sm">
+        <thead>
+          <tr className="border-b border-slate-200 text-xs uppercase tracking-wide text-slate-400">
+            <th scope="col" className="py-2 pr-4 font-medium">
+              Platform
+            </th>
+            <th scope="col" className="py-2 pr-4 font-medium">
+              Snapshots
+            </th>
+            <th scope="col" className="py-2 pr-4 font-medium">
+              Likes
+            </th>
+            <th scope="col" className="py-2 pr-4 font-medium">
+              Comments
+            </th>
+            <th scope="col" className="py-2 pr-4 font-medium">
+              Shares
+            </th>
+            <th scope="col" className="py-2 font-medium">
+              Impressions
+            </th>
+          </tr>
+        </thead>
+        <tbody className="[font-variant-numeric:tabular-nums]">
+          {platforms.map((platform) => (
+            <tr key={platform.platform} className="border-b border-slate-100 last:border-0">
+              <th scope="row" className="py-2 pr-4 font-medium capitalize text-slate-900">
+                {platform.platform}
+              </th>
+              <td className="py-2 pr-4 text-slate-600">{platform.snapshot_count.toLocaleString("en-US")}</td>
+              <Cell total={platform.total_likes} average={platform.average_likes} />
+              <Cell total={platform.total_comments} average={platform.average_comments} />
+              <Cell total={platform.total_shares} average={platform.average_shares} />
+              <Cell total={platform.total_impressions} average={platform.average_impressions} last />
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function Cell({ total, average, last }: { total: number; average: number; last?: boolean }) {
+  return (
+    <td className={last ? "py-2 text-slate-600" : "py-2 pr-4 text-slate-600"}>
+      {formatCompactNumber(total)} <span className="text-slate-400">(avg {formatAverage(average)})</span>
+    </td>
+  );
+}

--- a/apps/web/app/analytics/stat-tile.tsx
+++ b/apps/web/app/analytics/stat-tile.tsx
@@ -1,0 +1,24 @@
+import { Card } from "@/components/ui/Card";
+
+// Stat tile contract from the dataviz skill (marks-and-anatomy.md):
+// label (sentence case, no trailing colon) + value (semibold, auto-compact)
+// + an optional secondary line. No delta/sparkline here — the analytics
+// endpoints only expose one aggregate window at a time, so there's no
+// second period to compare against without fabricating one.
+export function StatTile({
+  label,
+  value,
+  secondary,
+}: {
+  label: string;
+  value: string;
+  secondary?: string;
+}) {
+  return (
+    <Card className="p-4">
+      <p className="text-sm text-slate-500">{label}</p>
+      <p className="mt-1 text-2xl font-semibold text-slate-900">{value}</p>
+      {secondary ? <p className="mt-0.5 text-xs text-slate-400">{secondary}</p> : null}
+    </Card>
+  );
+}

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -338,3 +338,141 @@ export async function rescheduleReviewPost(
 
   return res.json();
 }
+
+// --- Analytics (Issue #92) ---
+
+// Mirrors apps/api/schemas/analytics.py::PlatformAggregate. total_*/
+// average_* are real SQL SUM()/AVG() computed server-side, not
+// accumulated client-side.
+export interface PlatformAggregate {
+  platform: string;
+  snapshot_count: number;
+  total_likes: number;
+  total_comments: number;
+  total_shares: number;
+  total_impressions: number;
+  average_likes: number;
+  average_comments: number;
+  average_shares: number;
+  average_impressions: number;
+}
+
+// Mirrors apps/api/schemas/analytics.py::BrandAnalyticsSummary.
+export interface BrandAnalyticsSummary {
+  brand_id: string;
+  start_date: string;
+  end_date: string;
+  post_count: number;
+  platforms: PlatformAggregate[];
+  overall: PlatformAggregate;
+}
+
+// Mirrors apps/api/schemas/analytics.py::PostAnalyticsAggregate.
+export interface PostAnalyticsAggregate {
+  post_id: string;
+  start_date: string;
+  end_date: string;
+  platforms: PlatformAggregate[];
+  overall: PlatformAggregate;
+}
+
+// Mirrors apps/api/schemas/analytics.py::EngagementSnapshotPoint.
+export interface EngagementSnapshotPoint {
+  platform: string;
+  likes: number;
+  comments: number;
+  shares: number;
+  impressions: number;
+  polled_at: string;
+}
+
+// Mirrors apps/api/schemas/analytics.py::PostAnalyticsTrend — the raw,
+// unaggregated time series for one post, ordered by polled_at ascending.
+export interface PostAnalyticsTrend {
+  post_id: string;
+  start_date: string;
+  end_date: string;
+  points: EngagementSnapshotPoint[];
+}
+
+// start_date/end_date are optional ISO datetimes on every analytics
+// endpoint — apps/api/routers/analytics.py::_resolve_date_range defaults
+// to the last DEFAULT_WINDOW_DAYS (30) days when either is omitted.
+export interface AnalyticsDateRangeInput {
+  startDate?: string;
+  endDate?: string;
+}
+
+// apps/api/routers/analytics.py mounts these under
+// /brands/{brand_id}/analytics, so every call is scoped to a brand — same
+// convention as calendarEventsUrl/reviewQueueUrl above.
+function analyticsUrl(brandId: string, suffix = ""): string {
+  return `${API_URL}/brands/${brandId}/analytics${suffix}`;
+}
+
+function dateRangeSearchParams(range: AnalyticsDateRangeInput): URLSearchParams {
+  const params = new URLSearchParams();
+  if (range.startDate) params.set("start_date", range.startDate);
+  if (range.endDate) params.set("end_date", range.endDate);
+  return params;
+}
+
+export async function fetchAnalyticsSummary(
+  token: string,
+  brandId: string,
+  range: AnalyticsDateRangeInput = {}
+): Promise<BrandAnalyticsSummary> {
+  const query = dateRangeSearchParams(range).toString();
+  const res = await fetch(analyticsUrl(brandId, `/summary${query ? `?${query}` : ""}`), {
+    headers: authHeaders(token),
+  });
+
+  if (!res.ok) {
+    throw new ApiError(await parseErrorDetail(res), res.status);
+  }
+
+  return res.json();
+}
+
+export async function fetchPostAnalyticsAggregate(
+  token: string,
+  brandId: string,
+  postId: string,
+  range: AnalyticsDateRangeInput = {}
+): Promise<PostAnalyticsAggregate> {
+  const query = dateRangeSearchParams(range).toString();
+  const res = await fetch(analyticsUrl(brandId, `/posts/${postId}${query ? `?${query}` : ""}`), {
+    headers: authHeaders(token),
+  });
+
+  if (!res.ok) {
+    throw new ApiError(await parseErrorDetail(res), res.status);
+  }
+
+  return res.json();
+}
+
+export interface PostAnalyticsTrendInput extends AnalyticsDateRangeInput {
+  platform?: string;
+}
+
+export async function fetchPostAnalyticsTrend(
+  token: string,
+  brandId: string,
+  postId: string,
+  range: PostAnalyticsTrendInput = {}
+): Promise<PostAnalyticsTrend> {
+  const params = dateRangeSearchParams(range);
+  if (range.platform) params.set("platform", range.platform);
+  const query = params.toString();
+
+  const res = await fetch(analyticsUrl(brandId, `/posts/${postId}/trend${query ? `?${query}` : ""}`), {
+    headers: authHeaders(token),
+  });
+
+  if (!res.ok) {
+    throw new ApiError(await parseErrorDetail(res), res.status);
+  }
+
+  return res.json();
+}


### PR DESCRIPTION
Closes #92

## Summary
- Replaces the `/analytics` stub with a real dashboard built on the #88 design system.
- **Brand-level summary**: a date-range filter (presets for 7/30/90 days, matching the API's default 30-day window, plus a custom range), KPI stat tiles for the brand's overall totals/averages, a per-platform bar chart (metric-selectable) and a full accessible data table.
- **Per-post trend view**: since there's no post-listing endpoint yet, accepts a Post ID via a text input (plus an optional platform filter), then renders the post's aggregate stat tiles and a real per-metric line/time-series chart (likes/comments/shares/impressions vs. `polled_at`), with a raw-snapshot data table underneath.
- The date-range filter scopes both sections at once (dataviz skill's "filters scope everything below them" rule).
- Empty states (`EmptyState`) for a brand/window with no engagement snapshots and for a post with no snapshots yet, instead of rendering an empty chart.
- Chart colors/marks follow the `dataviz` skill: the validated 8-hue categorical palette (platforms get a pinned, stable color across every chart), single-hue bars for single-series comparisons, 2px lines with 8px+ ringed markers, hairline recessive gridlines, crosshair + tooltip on the line chart, and a table-view twin for every chart.

## API client
- Added `fetchAnalyticsSummary`, `fetchPostAnalyticsAggregate`, `fetchPostAnalyticsTrend` (+ matching types) to `apps/web/lib/api.ts` under a `// --- Analytics (Issue #92) ---` banner, following the file's existing fetch-wrapper conventions.

## Follow-up (out of scope here)
- No post-picker exists yet since the review queue/calendar don't expose a reusable post list. A proper picker (reusing one of those once available) is a reasonable follow-up; a raw Post ID input unblocks this view for now.

## Test plan
- [x] `npm run lint --prefix apps/web`
- [x] `npm run test --prefix apps/web` (35/35 passing, incl. 6 new tests in `__tests__/analytics-page.test.tsx` covering: summary rendering with real numbers, date-range-change re-fetch, brand-level empty state, summary fetch error, post trend lookup flow, per-post empty state)
- [x] `npm run build --prefix apps/web`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012iWB6uxCB3Rsp97RmVgBW6