### PR TITLE
Agent branding: name the 5 pipeline stages (Aarav, Ved, Keshav, Kavi, Neer)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,27 @@ AI-native social media management: brand intelligence, an agent pipeline that
 turns a calendar slot into a reviewed draft, and human-in-the-loop scheduling
 and publishing — built as a modular monolith, not a pile of microservices.
 
-hello i am here
-
 For the full system design, data model, agent pipeline, and issue roadmap,
 see [`raindeer-social-blueprint.md`](./raindeer-social-blueprint.md). This
 README covers what's here and how to get running; the blueprint covers why.
+
+## Meet the agents
+
+The pipeline is five named agents, each a distinct stage a brand's content
+moves through. The names are product/UI branding — the underlying code keeps
+plain, descriptive module names (linked below) rather than the persona names.
+
+| Agent | Role | Code |
+|-------|------|------|
+| **Aarav** — Onboarding | Scrapes the brand's website, asks clarifying questions, captures logo/theme, and produces the brand report every other agent works from. | [`packages/agents/onboarding/`](./packages/agents/onboarding/) |
+| **Ved** — Research | Researches what's working right now in the brand's niche (e.g. what's going viral in food delivery), on demand or on a schedule. | [`packages/agents/pipeline/nodes/research_engine.py`](./packages/agents/pipeline/nodes/research_engine.py) |
+| **Keshav** — Creative | Turns Ved's research into a concrete creative brief — format, angle, hook, CTA. | [`packages/agents/pipeline/nodes/creative_engine.py`](./packages/agents/pipeline/nodes/creative_engine.py) |
+| **Kavi** — Generative | Writes the post copy and generates the accompanying image(s) from Keshav's brief. | [`packages/agents/pipeline/nodes/generation_engine.py`](./packages/agents/pipeline/nodes/generation_engine.py) |
+| **Neer** — Reviewer | Reviews each draft for brand hygiene, logo placement, and platform fit before it reaches a human. | [`packages/agents/pipeline/nodes/reviewer_engine.py`](./packages/agents/pipeline/nodes/reviewer_engine.py) |
+
+See the open issues for in-flight work on this pipeline (autonomous
+scheduling for Ved, batch generation and engagement prediction, and
+Instagram/Threads/Facebook alongside the existing LinkedIn/X support).
 
 ## System overview
 
@@ -17,7 +33,7 @@ Four backend domains, one repo:
 | Path                | Responsibility |
 |----------------------|----------------|
 | `apps/api`           | FastAPI monolith — routers per domain (`/brands`, `/calendar`, `/posts`, `/agents`, `/publishing`, `/analytics`) |
-| `packages/agents`     | LangGraph agent graphs (research, creative, generation, reviewer, onboarding) |
+| `packages/agents`     | LangGraph agent graphs — Aarav, Ved, Keshav, Kavi, Neer (see **Meet the agents** above) |
 | `apps/web`            | Next.js frontend |
 | `packages/schemas`    | Pydantic + Zod schemas, generated from one OpenAPI source of truth |
 | `migrations`          | Alembic migrations for the Postgres schema |

--- a/apps/web/app/onboarding/page.tsx
+++ b/apps/web/app/onboarding/page.tsx
@@ -130,7 +130,7 @@ export default function OnboardingPage() {
     <div>
       <PageHeader
         title="Onboarding"
-        description={`Teach the AI ${selectedBrand.name}'s voice, audience, and goals.`}
+        description={`Meet Aarav, your onboarding agent — teach it ${selectedBrand.name}'s voice, audience, and goals.`}
       />
 
       {isLoading ? (
@@ -178,8 +178,8 @@ export default function OnboardingPage() {
               <CardBody>
                 {isGenerating ? (
                   <p role="status" className="text-sm text-slate-500">
-                    Running research and synthesis — this can take a minute or two. Feel free to
-                    leave this open; the report will appear here as soon as it&rsquo;s ready.
+                    Aarav is running research and synthesis — this can take a minute or two. Feel
+                    free to leave this open; the report will appear here as soon as it&rsquo;s ready.
                   </p>
                 ) : selectedBrand.brand_report ? (
                   <div className="space-y-6">

--- a/apps/web/app/review-queue/page.tsx
+++ b/apps/web/app/review-queue/page.tsx
@@ -129,7 +129,8 @@ export default function ReviewQueuePage() {
         title="Review Queue"
         description={
           <>
-            Showing data for: <strong className="font-medium text-slate-700">{selectedBrand ? selectedBrand.name : "no brand selected"}</strong>
+            Reviewed by <strong className="font-medium text-slate-700">Neer</strong>, your review agent —
+            showing data for: <strong className="font-medium text-slate-700">{selectedBrand ? selectedBrand.name : "no brand selected"}</strong>
           </>
         }
       />


### PR DESCRIPTION
Closes #104

## Summary
- README: adds a "Meet the agents" section naming the 5 pipeline stages, drops a stray leftover line.
- Surfaces the agent names in the two pages where their work is user-visible today: onboarding page (Aarav) and review-queue page (Neer).
- No backend renames — code keeps its existing descriptive module names, per the branding-only scope agreed for this issue.

## Test plan
- [x] `npx vitest run __tests__/onboarding-page.test.tsx __tests__/review-queue-page.test.tsx` — 8/8 pass