### PR TITLE
feat(agents): add standing Celery job for autonomous research scheduling

### DIFF
--- a/apps/api/config/__init__.py
+++ b/apps/api/config/__init__.py
@@ -87,6 +87,19 @@ class Settings(BaseSettings):
     # so it stays unit-testable without touching Settings.
     pipeline_trigger_lead_minutes: int = 60
 
+    # Issue #105: how often (in hours) Ved's standing research job
+    # (packages/agents/pipeline/nodes/research_engine.py's
+    # run_standalone_brand_research) re-runs research for every active
+    # brand, independent of whether a post happens to be scheduled onto
+    # the calendar — keeps research fresh between calendar slots rather
+    # than only refreshing each time the #29 pipeline trigger above fires
+    # for a due post. Read by apps/api/worker.py's Celery Beat schedule at
+    # process start, same "Settings field feeds a worker.py schedule/
+    # parameter" convention as pipeline_trigger_lead_minutes above.
+    # Default of 4.5h sits in the middle of the "every 4-5 hours" band
+    # the issue asks for.
+    research_refresh_interval_hours: float = 4.5
+
     # --- CORS (Issue #68) ---
     # Comma-separated list of origins allowed to make cross-origin
     # requests to the API (e.g. the Next.js dev server). Kept as a raw

--- a/apps/api/tests/test_research_scheduler.py
+++ b/apps/api/tests/test_research_scheduler.py
@@ -1,0 +1,174 @@
+"""Issue #105 — Ved's standing research job.
+
+Adds a standing Celery Beat schedule on top of the existing #29 per-post
+pipeline trigger: research now also runs on a fixed interval for every
+brand, independent of whether a post happens to be scheduled onto the
+calendar, so research stays fresh between calendar slots.
+
+The actual research logic (search-provider calls, brand-context
+retrieval, degrade-on-failure behavior) is exercised in
+packages/agents/tests/test_research_engine.py against
+run_standalone_brand_research directly — same "unit-testable without
+Celery machinery" split every other worker.py job already uses (see e.g.
+apps/api/tests/test_pipeline_trigger.py for #29, apps/api/tests/
+test_weekly_report.py for #35). This file only covers what's specific to
+the Celery wiring itself, mirroring test_engagement_polling.py's
+"worker.py: Celery task wiring" section:
+
+  1. Settings.research_refresh_interval_hours (an env var, per #105's
+     "configurable" acceptance criterion) is what the beat_schedule entry's
+     interval is actually built from.
+  2. The beat_schedule registers "refresh-brand-research" on that interval.
+  3. The sweep task fans out one research_brand_task per brand — every
+     Brand row, since this schema has no archived/deleted flag yet (same
+     "every brand is active" reasoning generate_weekly_reports_task
+     already relies on for #35).
+  4. The per-brand task's own db-session/commit/rollback handling works,
+     exercised via `.run()` (the task body directly, not `.delay`/`.apply`)
+     — same approach test_engagement_polling.py's
+     test_poll_post_engagement_task_run_success uses.
+"""
+
+import uuid
+from unittest.mock import patch
+
+import pytest
+
+from apps.api.config import Settings
+from apps.api.models import AgentRun, AgentType, Brand, Organization
+from packages.integrations.search.base import SearchResult
+
+SEARCH_PATCH_TARGET = "packages.agents.pipeline.nodes.research_engine.get_search_provider"
+EMBED_PATCH_TARGET = "apps.api.services.brand_retrieval.get_embedding_provider"
+
+
+def _setup_brand(db_session, name: str = "Acme Widgets") -> Brand:
+    org = Organization(name=f"{name} Org")
+    db_session.add(org)
+    db_session.flush()
+
+    brand = Brand(organization_id=org.id, name=name)
+    db_session.add(brand)
+    db_session.flush()
+    return brand
+
+
+def _fake_embed(text: str) -> list[float]:
+    return [0.0] * 1536
+
+
+# --- Settings: the configurable interval (#105's acceptance criterion) -----
+
+
+def test_research_refresh_interval_hours_defaults_within_the_4_to_5_hour_band() -> None:
+    settings = Settings()
+    assert 4.0 <= settings.research_refresh_interval_hours <= 5.0
+
+
+def test_research_refresh_interval_hours_is_overridable_via_env_var(monkeypatch) -> None:
+    monkeypatch.setenv("RESEARCH_REFRESH_INTERVAL_HOURS", "6")
+    settings = Settings()
+    assert settings.research_refresh_interval_hours == 6.0
+
+
+# --- worker.py: Celery task wiring -----------------------------------------
+
+
+def test_beat_schedule_registers_refresh_brand_research() -> None:
+    from apps.api import worker
+
+    entry = worker.celery_app.conf.beat_schedule["refresh-brand-research"]
+    assert entry["task"] == "worker.refresh_brand_research"
+    assert entry["schedule"] == worker.RESEARCH_REFRESH_INTERVAL_SECONDS
+    assert entry["schedule"] == pytest.approx(
+        worker.settings.research_refresh_interval_hours * 60 * 60
+    )
+
+
+def test_refresh_brand_research_task_fans_out_one_task_per_brand(db_session, monkeypatch) -> None:
+    """Same "every brand is active" sweep shape as
+    generate_weekly_reports_task — asserted against the actual row count
+    at fan-out time (rather than a fixed literal) so this isn't coupled
+    to whatever else the test database happens to already contain."""
+    from apps.api import worker
+
+    brand_a = _setup_brand(db_session, "Brand A")
+    brand_b = _setup_brand(db_session, "Brand B")
+
+    monkeypatch.setattr(worker, "SessionLocal", lambda: db_session)
+    monkeypatch.setattr(db_session, "close", lambda: None)
+
+    expected_ids = {str(brand_id) for (brand_id,) in db_session.query(Brand.id).all()}
+    assert {str(brand_a.id), str(brand_b.id)} <= expected_ids
+
+    with patch.object(worker, "research_brand_task") as mock_task:
+        result = worker.refresh_brand_research_task.run()
+
+    assert result == len(expected_ids)
+    called_ids = {call.args[0] for call in mock_task.delay.call_args_list}
+    assert called_ids == expected_ids
+
+
+def test_refresh_brand_research_task_enqueues_nothing_beyond_existing_brands(
+    db_session, monkeypatch
+) -> None:
+    """Without creating any new brand, the sweep still fans out exactly
+    one task per brand actually present — never more, never fewer."""
+    from apps.api import worker
+
+    monkeypatch.setattr(worker, "SessionLocal", lambda: db_session)
+    monkeypatch.setattr(db_session, "close", lambda: None)
+
+    expected_count = db_session.query(Brand.id).count()
+
+    with patch.object(worker, "research_brand_task") as mock_task:
+        result = worker.refresh_brand_research_task.run()
+
+    assert result == expected_count
+    assert mock_task.delay.call_count == expected_count
+
+
+def test_research_brand_task_run_success(db_session, monkeypatch) -> None:
+    """Runs the task's underlying function body directly (`.run`, not
+    `.delay`/`.apply`) so this exercises apps/api/worker.py's own
+    db-session/commit handling without needing Celery/Redis machinery —
+    same approach test_poll_post_engagement_task_run_success uses."""
+    from apps.api import worker
+
+    brand = _setup_brand(db_session)
+
+    monkeypatch.setattr(worker, "SessionLocal", lambda: db_session)
+    monkeypatch.setattr(db_session, "close", lambda: None)
+
+    trend_results = [
+        SearchResult(title="AI content trends 2026", url="https://x.test/a", content="...")
+    ]
+
+    with patch(SEARCH_PATCH_TARGET) as mock_search, patch(EMBED_PATCH_TARGET) as mock_embed:
+        mock_search.return_value.search.return_value = trend_results
+        mock_embed.return_value.embed.return_value = _fake_embed("query")
+
+        worker.research_brand_task.run(str(brand.id))
+
+    run = (
+        db_session.query(AgentRun)
+        .filter(AgentRun.agent_type == AgentType.RESEARCH, AgentRun.post_id.is_(None))
+        .order_by(AgentRun.created_at.desc())
+        .first()
+    )
+    assert run is not None
+    assert run.input == {"brand_id": str(brand.id)}
+    assert run.output["research_brief"]["timing_signal"]["trending_topics"] == [
+        "AI content trends 2026"
+    ]
+
+
+def test_research_brand_task_rolls_back_when_brand_not_found(db_session, monkeypatch) -> None:
+    from apps.api import worker
+    from packages.agents.pipeline.nodes.research_engine import ResearchEngineError
+
+    monkeypatch.setattr(worker, "SessionLocal", lambda: db_session)
+    monkeypatch.setattr(db_session, "close", lambda: None)
+
+    with pytest.raises(ResearchEngineError):
+        worker.research_brand_task.run(str(uuid.uuid4()))

--- a/apps/api/worker.py
+++ b/apps/api/worker.py
@@ -9,6 +9,7 @@ from apps.api.models.brand import Brand
 from apps.api.services import engagement_polling, publish_queue
 from apps.api.models import Post
 from apps.api.services import engagement_polling, notifications, publish_queue
+from packages.agents.pipeline.nodes.research_engine import run_standalone_brand_research
 from packages.agents.pipeline.trigger import trigger_due_pipelines
 from packages.agents.reporting.weekly_report import generate_weekly_report
 
@@ -43,6 +44,20 @@ ENGAGEMENT_POLL_INTERVAL_SECONDS = 900.0
 # unit-testable without any Celery machinery.
 WEEKLY_REPORT_INTERVAL_SECONDS = 7 * 24 * 60 * 60.0
 
+# Issue #105: on a recurring schedule, run Ved's Research Engine
+# (packages/agents/pipeline/nodes/research_engine.py) for every active
+# brand, independent of whether a post happens to be scheduled onto the
+# calendar — the #29 trigger below only researches a brand incidentally,
+# as part of writing a specific post, so without this a brand with a slow
+# calendar could go a long time between fresh research. Same "float
+# seconds" schedule shape as ENGAGEMENT_POLL_INTERVAL_SECONDS/
+# WEEKLY_REPORT_INTERVAL_SECONDS above, but — per #105's acceptance
+# criteria that the interval be configurable via an env var — sourced
+# from Settings.research_refresh_interval_hours rather than a hardcoded
+# literal (see apps/api/config/__init__.py). Read once at process start,
+# same as every other beat_schedule entry here.
+RESEARCH_REFRESH_INTERVAL_SECONDS = settings.research_refresh_interval_hours * 60 * 60.0
+
 # Issue #29: on a recurring schedule, poll ContentCalendarEvent for events
 # approaching their target_datetime and start the #18 pipeline for each.
 # Runs every minute — frequent enough that Settings.pipeline_trigger_lead_
@@ -63,6 +78,10 @@ celery_app.conf.beat_schedule = {
     "generate-weekly-reports": {
         "task": "worker.generate_weekly_reports",
         "schedule": WEEKLY_REPORT_INTERVAL_SECONDS,
+    },
+    "refresh-brand-research": {
+        "task": "worker.refresh_brand_research",
+        "schedule": RESEARCH_REFRESH_INTERVAL_SECONDS,
     },
 }
 
@@ -282,6 +301,57 @@ def generate_weekly_report_task(brand_id: str) -> None:
     db = SessionLocal()
     try:
         generate_weekly_report(db, uuid.UUID(brand_id))
+        db.commit()
+    except Exception:
+        db.rollback()
+        raise
+    finally:
+        db.close()
+
+
+@celery_app.task(name="worker.refresh_brand_research")
+def refresh_brand_research_task() -> int:
+    """Celery Beat entrypoint for Issue #105's standing research job.
+
+    Same fan-out shape as generate_weekly_reports_task above: every brand
+    is "active" (this schema has no archived/deleted flag on Brand yet,
+    same reasoning generate_weekly_reports_task already relies on), so
+    this sweep just resolves every brand and hands each one off to
+    research_brand_task individually, so one brand's search/embedding
+    provider being slow or failing never delays or blocks another
+    brand's research. (run_standalone_brand_research's underlying
+    _brand_research_brief already degrades gracefully on a broken search
+    or embedding provider rather than raising — see research_engine.py —
+    so this per-brand task only needs to handle the "brand vanished
+    mid-sweep" case, not transient provider errors.) Returns the number
+    of brands a research refresh was enqueued for.
+    """
+    db = SessionLocal()
+    try:
+        brand_ids = [row[0] for row in db.query(Brand.id).all()]
+    finally:
+        db.close()
+
+    for brand_id in brand_ids:
+        research_brand_task.delay(str(brand_id))
+    return len(brand_ids)
+
+
+@celery_app.task(name="worker.research_brand")
+def research_brand_task(brand_id: str) -> None:
+    """The actual per-brand standing research Celery task Issue #105 asks
+    for — deliberately thin, same split as generate_weekly_report_task
+    above. All the real logic (the trend/brand-context research itself,
+    plus logging the AgentRun row) lives in
+    packages/agents/pipeline/nodes/research_engine.py's
+    run_standalone_brand_research — the same module (and the same
+    _brand_research_brief core) the on-demand, per-post research node
+    uses — kept import-free of Celery so it stays unit-testable without
+    any Celery/Redis machinery running.
+    """
+    db = SessionLocal()
+    try:
+        run_standalone_brand_research(db, uuid.UUID(brand_id))
         db.commit()
     except Exception:
         db.rollback()

--- a/packages/agents/pipeline/nodes/research_engine.py
+++ b/packages/agents/pipeline/nodes/research_engine.py
@@ -31,6 +31,24 @@ caller-supplied Session and returns the actual LangGraph node function.
 graph.py's build_pipeline_graph() calls this factory for the "research"
 stage only — the other stages, and the graph's overall wiring/interrupt
 logic, are untouched.
+
+Issue #105 adds a second, standing entrypoint into this same research
+logic: run_standalone_brand_research(db, brand_id), called on a Celery
+Beat schedule (apps/api/worker.py) for every brand rather than only when
+a Post is about to be written. Both entrypoints funnel through the same
+_brand_research_brief() core — the on-demand, per-post path
+(_research_brief) and the standalone path only differ in what identifies
+the request (a Post, with its own calendar-scoped platforms/
+target_datetime, vs. a bare Brand researching every SUPPORTED_PLATFORMS
+with no target_datetime yet) and in how the result is persisted: the
+per-post path's output is returned into PipelineState for run_pipeline()
+to log as an AgentRun row (same as every other stage), while the
+standalone path — like packages/agents/reporting/weekly_report.py's
+per-brand job — isn't reached through run_pipeline at all, so it logs its
+own AgentRun(agent_type=RESEARCH, post_id=None) row directly, with
+brand_id carried in `input` (same "post_id left null, id carried in
+input" convention that module's docstring and apps/api/models/agent_run.py
+already establish for a job that isn't a pipeline node).
 """
 
 import logging
@@ -40,6 +58,7 @@ from typing import Any
 
 from sqlalchemy.orm import Session
 
+from apps.api.models.agent_run import AgentRun, AgentType
 from apps.api.models.brand import Brand
 from apps.api.models.content_calendar_event import ContentCalendarEvent, SUPPORTED_PLATFORMS
 from apps.api.models.post import Post
@@ -130,12 +149,16 @@ def _build_timing_signal(
     }
 
 
-def _research_brief(db: Session, post: Post) -> dict[str, Any]:
-    brand = db.get(Brand, post.brand_id)
-    if brand is None:
-        raise ResearchEngineError(f"Research Engine: no Brand found for post {post.id}")
-
-    platforms = _platforms_for(post, db)
+def _brand_research_brief(
+    db: Session, brand: Brand, *, platforms: list[str], target_datetime: datetime | None
+) -> dict[str, Any]:
+    """The actual research work — platform + industry trend search via
+    SearchProvider, plus the brand's voice/audience/positioning via #16's
+    retrieval helper — shared by both entrypoints below (the per-post
+    _research_brief and the standalone run_standalone_brand_research).
+    Deliberately Post-agnostic: it only needs a Brand, the platforms to
+    research, and an optional already-known target_datetime, so neither
+    caller has to duplicate this logic."""
     industry = brand.industry or brand.name
 
     platform_trend_results = {
@@ -148,24 +171,80 @@ def _research_brief(db: Session, post: Post) -> dict[str, Any]:
         result for results in platform_trend_results.values() for result in results
     ] + industry_trend_results
 
-    calendar_event = _calendar_event_for(post, db)
     brand_context = _brand_context_safely(
         db, brand.id, query=f"{brand.name} brand voice, audience, and positioning"
     )
 
     return {
-        "post_id": str(post.id),
         "brand_context": brand_context,
         "platform_trends": {
             platform: _serialize(results) for platform, results in platform_trend_results.items()
         },
         "industry_trends": _serialize(industry_trend_results),
-        "timing_signal": _build_timing_signal(
-            platforms,
-            all_trend_results,
-            calendar_event.target_datetime if calendar_event else None,
-        ),
+        "timing_signal": _build_timing_signal(platforms, all_trend_results, target_datetime),
     }
+
+
+def _research_brief(db: Session, post: Post) -> dict[str, Any]:
+    brand = db.get(Brand, post.brand_id)
+    if brand is None:
+        raise ResearchEngineError(f"Research Engine: no Brand found for post {post.id}")
+
+    platforms = _platforms_for(post, db)
+    calendar_event = _calendar_event_for(post, db)
+    brief = _brand_research_brief(
+        db,
+        brand,
+        platforms=platforms,
+        target_datetime=calendar_event.target_datetime if calendar_event else None,
+    )
+    return {"post_id": str(post.id), **brief}
+
+
+def run_standalone_brand_research(db: Session, brand_id: uuid.UUID) -> AgentRun:
+    """Issue #105 — Ved's standing research job. Runs the exact same
+    _brand_research_brief() core the on-demand, per-post research node
+    calls, but for a single brand independent of whether a post happens
+    to be scheduled onto the calendar, so a brand's research stays fresh
+    between calendar slots rather than only refreshing each time a post
+    is about to be written.
+
+    Called on a Celery Beat schedule (apps/api/worker.py) once per active
+    brand. There's no ContentCalendarEvent to narrow the platform list or
+    supply a target_datetime here (unlike the per-post path), so this
+    researches every SUPPORTED_PLATFORMS platform with target_datetime=None.
+
+    Unlike the per-post path — whose output is returned into PipelineState
+    for run_pipeline() to log as an AgentRun row alongside every other
+    stage — this path isn't reached through run_pipeline at all, so (same
+    as packages/agents/reporting/weekly_report.py's per-brand job) it logs
+    its own AgentRun(agent_type=RESEARCH, post_id=None) row directly, with
+    brand_id carried in `input` instead. Flushes but does not commit —
+    callers (a Celery task, a test) control the transaction boundary.
+
+    Raises ResearchEngineError if brand_id doesn't resolve to a real
+    Brand — a data/programming error, not a transient provider failure,
+    same as build_research_node's Post-not-found case.
+    """
+    brand = db.get(Brand, brand_id)
+    if brand is None:
+        raise ResearchEngineError(f"Research Engine: no Brand found for brand_id={brand_id}")
+
+    brief = _brand_research_brief(
+        db, brand, platforms=list(SUPPORTED_PLATFORMS), target_datetime=None
+    )
+    brief = {"brand_id": str(brand.id), **brief}
+
+    run = AgentRun(
+        post_id=None,
+        agent_type=AgentType.RESEARCH,
+        input={"brand_id": str(brand_id)},
+        output={"research_brief": brief},
+    )
+    db.add(run)
+    db.flush()
+    db.refresh(run)
+    return run
 
 
 def build_research_node(db: Session | None):

--- a/packages/agents/tests/test_research_engine.py
+++ b/packages/agents/tests/test_research_engine.py
@@ -38,6 +38,7 @@ from packages.agents.pipeline.graph import run_pipeline
 from packages.agents.pipeline.nodes.research_engine import (
     ResearchEngineError,
     build_research_node,
+    run_standalone_brand_research,
 )
 from packages.integrations.search.base import SearchResult
 
@@ -286,6 +287,119 @@ def test_research_node_appends_to_completed_stages(db_session) -> None:
         result = node({"post_id": str(post.id), "completed_stages": ["upstream_stage"]})
 
     assert result["completed_stages"] == ["upstream_stage", "research"]
+
+
+# --- Issue #105: standalone, per-brand research (independent of any Post) --
+
+
+def test_standalone_research_reuses_the_same_search_and_context_logic(db_session) -> None:
+    """Same "SearchProvider only through its interface" + brand-context-
+    reuse contract as the per-post node — proven the same way those tests
+    prove it for build_research_node."""
+    brand = _setup_brand(db_session, industry="Outdoor gear")
+
+    with patch(SEARCH_PATCH_TARGET) as mock_search, patch(EMBED_PATCH_TARGET) as mock_embed:
+        mock_search.return_value.search.return_value = []
+        mock_embed.return_value.embed.return_value = _fake_embed("query")
+
+        run_standalone_brand_research(db_session, brand.id)
+
+    mock_search.assert_called()
+    mock_search.return_value.search.assert_called()
+
+
+def test_standalone_research_degrades_gracefully_on_search_provider_failure(db_session) -> None:
+    brand = _setup_brand(db_session)
+
+    with patch(SEARCH_PATCH_TARGET) as mock_search, patch(EMBED_PATCH_TARGET) as mock_embed:
+        mock_search.return_value.search.side_effect = Exception("Tavily timed out")
+        mock_embed.return_value.embed.return_value = _fake_embed("query")
+
+        run = run_standalone_brand_research(db_session, brand.id)
+
+    brief = run.output["research_brief"]
+    assert brief["industry_trends"] == []
+    assert all(results == [] for results in brief["platform_trends"].values())
+    assert brief["timing_signal"]["trending_topics"] == []
+
+
+def test_standalone_research_covers_every_supported_platform(db_session) -> None:
+    """Unlike the per-post path (which narrows to a ContentCalendarEvent's
+    target_platforms when one exists), there's no calendar event here, so
+    the standalone job always researches every SUPPORTED_PLATFORMS
+    platform and has no target_datetime to report."""
+    brand = _setup_brand(db_session)
+
+    with patch(SEARCH_PATCH_TARGET) as mock_search, patch(EMBED_PATCH_TARGET) as mock_embed:
+        mock_search.return_value.search.return_value = []
+        mock_embed.return_value.embed.return_value = _fake_embed("query")
+
+        run = run_standalone_brand_research(db_session, brand.id)
+
+    brief = run.output["research_brief"]
+    assert brief["brand_id"] == str(brand.id)
+    assert "post_id" not in brief
+    signal = brief["timing_signal"]
+    assert signal["platforms"] == ["linkedin", "x"]
+    assert signal["target_datetime"] is None
+
+
+def test_standalone_research_reuses_brand_context_retrieval_helper(db_session) -> None:
+    brand = _setup_brand(db_session)
+    brand.brand_report = {"audience": "Eco-conscious millennials"}
+    db_session.flush()
+
+    with patch("packages.agents.onboarding.embedding.get_embedding_provider") as mock_embed_onboard:
+        mock_embed_onboard.return_value.embed.side_effect = _fake_embed
+        embed_brand_report(db_session, brand)
+
+    with patch(SEARCH_PATCH_TARGET) as mock_search, patch(EMBED_PATCH_TARGET) as mock_embed:
+        mock_search.return_value.search.return_value = []
+        mock_embed.return_value.embed.side_effect = _fake_embed
+
+        run = run_standalone_brand_research(db_session, brand.id)
+
+    assert run.output["research_brief"]["brand_context"] == [
+        {"section": "audience", "content": "Eco-conscious millennials"}
+    ]
+
+
+def test_standalone_research_raises_when_brand_not_found(db_session) -> None:
+    with pytest.raises(ResearchEngineError):
+        run_standalone_brand_research(db_session, uuid.uuid4())
+
+
+def test_standalone_research_logs_agent_run_with_null_post_id(db_session) -> None:
+    """Not reached through run_pipeline (there's no Post/thread for a
+    standalone brand-level run), so — same convention
+    packages/agents/reporting/weekly_report.py's per-brand job
+    establishes — this path logs its own AgentRun row directly, with
+    post_id left null and brand_id carried in `input` instead."""
+    brand = _setup_brand(db_session)
+
+    trend_results = [
+        SearchResult(title="AI content trends 2026", url="https://x.test/a", content="...")
+    ]
+
+    with patch(SEARCH_PATCH_TARGET) as mock_search, patch(EMBED_PATCH_TARGET) as mock_embed:
+        mock_search.return_value.search.return_value = trend_results
+        mock_embed.return_value.embed.return_value = _fake_embed("query")
+
+        run = run_standalone_brand_research(db_session, brand.id)
+
+    assert run.post_id is None
+    assert run.agent_type == AgentType.RESEARCH
+    assert run.input == {"brand_id": str(brand.id)}
+    assert run.output["research_brief"]["timing_signal"]["trending_topics"] == [
+        "AI content trends 2026"
+    ]
+
+    persisted = (
+        db_session.query(AgentRun)
+        .filter(AgentRun.id == run.id, AgentRun.agent_type == AgentType.RESEARCH)
+        .one()
+    )
+    assert persisted.post_id is None
 
 
 # --- AgentRun logged with agent_type=research, via the real pipeline -------


### PR DESCRIPTION
## Linked issue
Closes #105

## Why
Ved's Research Engine (`packages/agents/pipeline/nodes/research_engine.py`) only ran as part of the per-post pipeline, triggered from `packages/agents/pipeline/trigger.py` when a calendar slot needed content. A brand with a sparse content calendar could therefore go a long time between fresh trend research. Issue #105 asks for a standing job that keeps research fresh independent of whether a post happens to be scheduled.

## What changed
- **`packages/agents/pipeline/nodes/research_engine.py`**: extracted the shared `_brand_research_brief()` core (platform + industry trend search, brand-context retrieval, timing signal) out of the existing per-post `_research_brief()`. Added `run_standalone_brand_research(db, brand_id)`, which reuses that same core for a bare brand (no Post/ContentCalendarEvent — researches every `SUPPORTED_PLATFORMS` platform with `target_datetime=None`) and logs its own `AgentRun(agent_type=RESEARCH, post_id=None, input={"brand_id": ...})` row directly, mirroring the `post_id=null` convention `packages/agents/reporting/weekly_report.py` already established for a job that isn't a pipeline node. No research logic is duplicated between the two entrypoints.
- **`apps/api/config/__init__.py`**: added `Settings.research_refresh_interval_hours` (default `4.5`, i.e. inside the "every 4-5 hours" band the issue asks for), following the same pattern as the existing `pipeline_trigger_lead_minutes` field — overridable via the `RESEARCH_REFRESH_INTERVAL_HOURS` env var.
- **`apps/api/worker.py`**: added a Celery Beat schedule entry (`refresh-brand-research`, interval sourced from `Settings.research_refresh_interval_hours`) plus two tasks, following the exact fan-out shape `generate_weekly_reports_task` / `generate_weekly_report_task` already use for #35's weekly reports:
  - `refresh_brand_research_task` — Beat entrypoint, resolves every Brand (this schema has no archived/deleted flag yet, same "every brand is active" reasoning the weekly-report sweep already relies on) and fans out one `research_brand_task.delay(brand_id)` per brand.
  - `research_brand_task` — thin per-brand wrapper around `run_standalone_brand_research`, with the same open-session/commit-or-rollback/close shape every other worker.py task uses.

## How I tested this
```
pytest apps/api/tests packages/agents/tests -v --cov --cov-fail-under=70
```
412 passed, 0 failed. Total coverage 97.88% (well above the 70% gate). New/updated test files:
- `packages/agents/tests/test_research_engine.py` — new tests for `run_standalone_brand_research`: reuses SearchProvider/brand-context logic, degrades gracefully on search/embedding failures, covers every supported platform with no target_datetime, raises `ResearchEngineError` for an unknown brand, and logs an `AgentRun` row with `post_id=None`.
- `apps/api/tests/test_research_scheduler.py` (new) — Celery wiring tests mirroring `test_engagement_polling.py`'s "worker.py: Celery task wiring" section: the configurable-interval setting (default + env override), the beat_schedule registration, the sweep's per-brand fan-out, and the per-brand task's own db-session/commit/rollback handling via `.run()`.

## Screenshots / recording
N/A — backend-only change (Celery job + config), no API response shape or frontend change.

## Checklist
- [x] Tests added/updated and passing locally
- [x] Migration included if the schema changed — N/A, no schema change
- [x] No secrets, API keys, or `.env` values committed
- [x] Docs/README updated if behavior or setup changed — N/A, no README/behavior-doc changes needed per this issue's scope
- [x] I branched from `main` and am targeting `main`