### PR TITLE
feat(agents): predict post engagement in the reviewer engine

### DIFF
--- a/apps/api/models/review_feedback.py
+++ b/apps/api/models/review_feedback.py
@@ -2,7 +2,7 @@ import enum
 import uuid
 from datetime import datetime
 
-from sqlalchemy import DateTime, Enum, Float, ForeignKey, func
+from sqlalchemy import DateTime, Enum, Float, ForeignKey, Text, func
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -74,6 +74,17 @@ class ReviewFeedback(Base):
     # text — same reasoning as Post.body_text/PostVersion.body_text being
     # JSONB keyed by platform rather than a single string.
     comments: Mapped[dict] = mapped_column(JSONB, nullable=False)
+
+    # Issue #107 — the Reviewer Engine's predicted-engagement pass for this
+    # Post, grounded in the brand's actual historical EngagementSnapshot
+    # performance on the same platform(s) where enough history exists (see
+    # packages/agents/pipeline/nodes/reviewer_engine.py's
+    # _historical_engagement_safely), falling back to a pure LLM estimate
+    # otherwise. Nullable because only source=ai_reviewer rows populate
+    # these — a source=human row (#25's approve/reject) never predicts
+    # engagement, it records a human decision.
+    predicted_engagement_score: Mapped[float | None] = mapped_column(Float, nullable=True)
+    predicted_engagement_reasoning: Mapped[str | None] = mapped_column(Text, nullable=True)
 
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now()

--- a/apps/api/schemas/review.py
+++ b/apps/api/schemas/review.py
@@ -21,6 +21,10 @@ class ReviewFeedbackRead(BaseModel):
     score: float
     verdict: ReviewVerdict
     comments: dict
+    # Issue #107 — only populated for source=ai_reviewer rows; a
+    # source=human row (approve/reject) never predicts engagement.
+    predicted_engagement_score: float | None = None
+    predicted_engagement_reasoning: str | None = None
     created_at: datetime
 
 

--- a/apps/web/__tests__/review-queue-page.test.tsx
+++ b/apps/web/__tests__/review-queue-page.test.tsx
@@ -63,10 +63,14 @@ function makePost(overrides: Partial<ReviewQueuePost> = {}): ReviewQueuePost {
               verdict: "revise",
               issues: ["Missing a call to action"],
               suggested_edits: "Add a link to the product page at the end.",
+              predicted_engagement_score: 64,
+              predicted_engagement_reasoning: "Based on 5 historical posts averaging 3.20% engagement.",
             },
           },
           model: "openrouter/free",
         },
+        predicted_engagement_score: 64,
+        predicted_engagement_reasoning: "Based on 5 historical posts averaging 3.20% engagement.",
         created_at: "2026-08-20T10:05:00Z",
       },
     ],
@@ -115,6 +119,19 @@ describe("ReviewQueuePage", () => {
     expect(screen.getByText(/AI reviewer score: 72\/100/)).toBeInTheDocument();
     expect(screen.getByText(/Missing a call to action/)).toBeInTheDocument();
     expect(screen.getByText(/Add a link to the product page at the end\./)).toBeInTheDocument();
+  });
+
+  it("renders the predicted engagement score and reasoning next to the AI review", async () => {
+    fetchReviewQueueMock.mockResolvedValue([makePost()]);
+
+    renderPage();
+
+    await screen.findByText(/Check out our new widget line!/);
+    expect(screen.getByText("Predicted engagement")).toBeInTheDocument();
+    expect(screen.getByText(/Predicted engagement: 64\/100/)).toBeInTheDocument();
+    expect(
+      screen.getByText(/Based on 5 historical posts averaging 3\.20% engagement\./)
+    ).toBeInTheDocument();
   });
 
   it("approves a post through the API and removes it from the queue", async () => {

--- a/apps/web/app/review-queue/review-card.tsx
+++ b/apps/web/app/review-queue/review-card.tsx
@@ -14,6 +14,8 @@ interface PlatformReview {
   verdict?: string;
   issues?: string[];
   suggested_edits?: string;
+  predicted_engagement_score?: number;
+  predicted_engagement_reasoning?: string;
 }
 
 // Mirrors apps/api/models/review_feedback.py::ReviewVerdict.
@@ -160,6 +162,21 @@ export function ReviewCard({ post, onApprove, onReject, onEdit, onReschedule }: 
             <div className="mt-2">
               <ScoreMeter score={aiReview.score} />
             </div>
+            {aiReview.predicted_engagement_score != null && (
+              <div className="mt-3 border-t border-slate-100 pt-2">
+                <div className="flex items-center justify-between gap-2">
+                  <span className="text-[11px] font-medium uppercase tracking-wide text-slate-500">
+                    Predicted engagement
+                  </span>
+                  <Badge tone={scoreTone(aiReview.predicted_engagement_score)}>
+                    {aiReview.predicted_engagement_score.toFixed(0)}/100
+                  </Badge>
+                </div>
+                <div className="mt-1.5">
+                  <ScoreMeter score={aiReview.predicted_engagement_score} />
+                </div>
+              </div>
+            )}
           </div>
         ) : null}
       </header>
@@ -233,6 +250,17 @@ export function ReviewCard({ post, onApprove, onReject, onEdit, onReschedule }: 
                   <p className="mt-2 rounded-md bg-amber-50 px-3 py-2 text-sm text-amber-900">
                     {review.suggested_edits}
                   </p>
+                )}
+
+                {review.predicted_engagement_score != null && (
+                  <div className="mt-2 rounded-md bg-blue-50 px-3 py-2 text-sm text-blue-900">
+                    <span className="font-semibold">
+                      Predicted engagement: {review.predicted_engagement_score.toFixed(0)}/100
+                    </span>
+                    {review.predicted_engagement_reasoning && (
+                      <p className="mt-1 text-blue-800">{review.predicted_engagement_reasoning}</p>
+                    )}
+                  </div>
                 )}
               </li>
             ))}

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -102,7 +102,8 @@ export type ReviewVerdict = "approve" | "revise" | "reject";
 
 // Mirrors apps/api/schemas/review.py::ReviewFeedbackRead. `comments` is
 // free-form JSONB — for an ai_reviewer row it's shaped like
-// { platforms: { [platform]: { score, verdict, issues, suggested_edits } }, model };
+// { platforms: { [platform]: { score, verdict, issues, suggested_edits,
+// predicted_engagement_score, predicted_engagement_reasoning } }, model };
 // for a human row it's { comments?: string }.
 export interface ReviewFeedback {
   id: string;
@@ -111,6 +112,10 @@ export interface ReviewFeedback {
   score: number;
   verdict: ReviewVerdict;
   comments: Record<string, unknown>;
+  // Issue #107 — only populated on ai_reviewer rows; a human row
+  // (approve/reject) never predicts engagement.
+  predicted_engagement_score: number | null;
+  predicted_engagement_reasoning: string | null;
   created_at: string;
 }
 

--- a/migrations/versions/88fcfa95b048_review_feedback_predicted_engagement.py
+++ b/migrations/versions/88fcfa95b048_review_feedback_predicted_engagement.py
@@ -1,0 +1,36 @@
+"""review feedback predicted engagement
+
+Revision ID: 88fcfa95b048
+Revises: 5b29b584c4fa
+Create Date: 2026-08-27 00:00:00.000000
+
+Issue #107 — the Reviewer Engine gains a predicted-engagement pass
+alongside its existing brand-alignment/compliance/platform-fit score.
+Adds two nullable columns to review_feedback (Issue #24's
+migrations/versions/e7d09d412f48_review_feedback.py): a 0-100
+predicted_engagement_score and a short natural-language
+predicted_engagement_reasoning string. Nullable because only
+source=ai_reviewer rows populate them; source=human rows (#25's
+approve/reject) never predict engagement.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '88fcfa95b048'
+down_revision: Union[str, None] = '5b29b584c4fa'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column('review_feedback', sa.Column('predicted_engagement_score', sa.Float(), nullable=True))
+    op.add_column('review_feedback', sa.Column('predicted_engagement_reasoning', sa.Text(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column('review_feedback', 'predicted_engagement_reasoning')
+    op.drop_column('review_feedback', 'predicted_engagement_score')

--- a/packages/agents/pipeline/nodes/reviewer_engine.py
+++ b/packages/agents/pipeline/nodes/reviewer_engine.py
@@ -46,6 +46,23 @@ shape: a factory, build_reviewer_node(db), closing over a caller-supplied
 Session (needed to resolve Post -> Brand, same as the earlier stages),
 returning the actual LangGraph node function. graph.py's
 build_pipeline_graph() calls this factory for the "reviewer" stage only.
+
+Predicted engagement (Issue #107): alongside its brand-alignment/
+compliance/platform-fit scoring, this node now also predicts, per
+platform, how well the draft is likely to perform (0-100 plus a short
+natural-language reasoning string). Grounded in the brand's actual
+historical performance where it exists: _historical_engagement_safely
+computes each platform's average engagement rate ((likes + comments +
+shares) / impressions) across the brand's own past EngagementSnapshot
+rows (Issue #33/#34) and hands the real numbers to the LLM as grounding
+data in the same prompt, alongside brand_context — the same "give the
+LLM real reference material rather than have it guess" pattern this node
+already uses for brand voice. When a platform doesn't yet have enough
+history (_MIN_HISTORICAL_SAMPLES), the prompt says so explicitly and asks
+for a pure qualitative estimate instead. One LLM call still produces
+every field for a platform (score/verdict/issues/suggested_edits plus
+predicted_engagement_score/predicted_engagement_reasoning) — same
+all-or-nothing parse/fallback contract as the rest of this module.
 """
 
 import json
@@ -54,10 +71,12 @@ import time
 import uuid
 from typing import Any
 
+from sqlalchemy import func
 from sqlalchemy.orm import Session
 
 from apps.api.config import get_settings
 from apps.api.models.brand import Brand
+from apps.api.models.engagement_snapshot import EngagementSnapshot
 from apps.api.models.post import Post
 from apps.api.models.review_feedback import ReviewFeedback, ReviewSource, ReviewVerdict
 from apps.api.services.brand_retrieval import get_relevant_brand_context
@@ -67,6 +86,12 @@ logger = logging.getLogger(__name__)
 
 BRAND_CONTEXT_TOP_K = 3
 BRAND_CONTEXT_QUERY = "brand voice, tone, compliance guidelines, and platform norms"
+
+# A brand needs at least this many past snapshot rows with real impressions
+# on a given platform before its historical engagement rate is trusted
+# enough to ground the LLM's prediction — a 1-2 post sample is too noisy to
+# hand over as if it were a reliable benchmark.
+_MIN_HISTORICAL_SAMPLES = 3
 
 # Worst-verdict-wins ordering used to derive one overall verdict from
 # several per-platform verdicts (see module docstring).
@@ -91,6 +116,12 @@ _FALLBACK_SUGGESTED_EDITS = (
     "The Reviewer Engine could not complete an automated pass on this "
     "draft. Route this post to manual human review before it proceeds "
     "rather than relying on this fallback score."
+)
+_FALLBACK_ENGAGEMENT_SCORE = 50.0
+_FALLBACK_ENGAGEMENT_REASONING = (
+    "Automated engagement prediction unavailable (LLM provider error or "
+    "unparseable response) — could not estimate predicted engagement for "
+    "this draft."
 )
 
 # Rough, provider-agnostic per-token estimate used only to keep this
@@ -133,6 +164,60 @@ def _brand_context_safely(db: Session, brand_id: Any) -> list[dict]:
         return []
 
 
+def _historical_engagement_stats(db: Session, brand_id: Any, platform: str) -> dict[str, Any] | None:
+    """The brand's own average engagement rate on `platform` — (likes +
+    comments + shares) / impressions, averaged over every past
+    EngagementSnapshot row for this brand on this platform that actually
+    has impressions to divide by — plus how many snapshots that average is
+    built from. Computed as a single SQL AVG/COUNT (same "aggregate in
+    Postgres, don't fetch-and-reduce in Python" convention
+    analytics_aggregation.py establishes), returning None when there isn't
+    at least _MIN_HISTORICAL_SAMPLES worth of data to trust."""
+    row = (
+        db.query(
+            func.count(EngagementSnapshot.id).label("sample_size"),
+            func.avg(
+                (EngagementSnapshot.likes + EngagementSnapshot.comments + EngagementSnapshot.shares)
+                * 1.0
+                / EngagementSnapshot.impressions
+            ).label("avg_rate"),
+        )
+        .join(Post, Post.id == EngagementSnapshot.post_id)
+        .filter(
+            Post.brand_id == brand_id,
+            EngagementSnapshot.platform == platform,
+            EngagementSnapshot.impressions > 0,
+        )
+        .one()
+    )
+    sample_size = int(row.sample_size or 0)
+    if sample_size < _MIN_HISTORICAL_SAMPLES or row.avg_rate is None:
+        return None
+    return {"sample_size": sample_size, "average_engagement_rate": float(row.avg_rate)}
+
+
+def _historical_engagement_safely(
+    db: Session, brand_id: Any, platforms: list[str]
+) -> dict[str, dict[str, Any] | None]:
+    """Same degrade-on-failure contract as _brand_context_safely: a broken
+    query here (e.g. a transient DB issue) must not take the whole
+    Reviewer Engine node down — it just means this run falls back to a
+    pure LLM estimate for every platform, same as a brand with no history
+    yet."""
+    stats: dict[str, dict[str, Any] | None] = {}
+    for platform in platforms:
+        try:
+            stats[platform] = _historical_engagement_stats(db, brand_id, platform)
+        except Exception:
+            logger.warning(
+                "Reviewer Engine historical engagement lookup failed for platform %r",
+                platform,
+                exc_info=True,
+            )
+            stats[platform] = None
+    return stats
+
+
 def _strip_code_fence(text: str) -> str:
     cleaned = text.strip()
     if not cleaned.startswith("```"):
@@ -168,11 +253,22 @@ def _parse_platform_review(entry: dict) -> dict[str, Any]:
     if not isinstance(suggested_edits, str) or not suggested_edits.strip():
         raise ValueError("missing 'suggested_edits'")
 
+    # Issue #107 — predicted engagement is required per platform, same
+    # all-or-nothing parse contract as the fields above: a response that
+    # skips it degrades the whole review to the fixed fallback rather than
+    # silently shipping a review with no engagement prediction.
+    predicted_engagement_score = _clamp_score(entry.get("predicted_engagement_score"))
+    predicted_engagement_reasoning = entry.get("predicted_engagement_reasoning")
+    if not isinstance(predicted_engagement_reasoning, str) or not predicted_engagement_reasoning.strip():
+        raise ValueError("missing 'predicted_engagement_reasoning'")
+
     return {
         "score": score,
         "verdict": verdict.value,
         "issues": [str(issue) for issue in issues],
         "suggested_edits": suggested_edits.strip(),
+        "predicted_engagement_score": predicted_engagement_score,
+        "predicted_engagement_reasoning": predicted_engagement_reasoning.strip(),
     }
 
 
@@ -201,6 +297,8 @@ def _fallback_review(platforms: list[str]) -> dict[str, dict[str, Any]]:
             "verdict": _FALLBACK_VERDICT.value,
             "issues": [_FALLBACK_ISSUE],
             "suggested_edits": _FALLBACK_SUGGESTED_EDITS,
+            "predicted_engagement_score": _FALLBACK_ENGAGEMENT_SCORE,
+            "predicted_engagement_reasoning": _FALLBACK_ENGAGEMENT_REASONING,
         }
         for platform in platforms
     }
@@ -217,16 +315,39 @@ def _platforms_for(body_text: dict[str, Any]) -> list[str]:
     return list(body_text.keys())
 
 
+def _format_historical_engagement(historical_engagement: dict[str, dict[str, Any] | None], platforms: list[str]) -> str:
+    lines = []
+    for platform in platforms:
+        stats = historical_engagement.get(platform)
+        if stats is None:
+            lines.append(
+                f"- {platform}: insufficient historical data (fewer than "
+                f"{_MIN_HISTORICAL_SAMPLES} past posts with impressions) — "
+                "give a pure qualitative estimate based on the draft "
+                "content and brand context instead."
+            )
+        else:
+            lines.append(
+                f"- {platform}: {stats['sample_size']} historical posts, "
+                f"average engagement rate {stats['average_engagement_rate'] * 100:.2f}% "
+                "((likes + comments + shares) / impressions) — ground your "
+                "prediction in this real number and say so in your reasoning."
+            )
+    return "\n".join(lines)
+
+
 def _build_prompt(
     brand: Brand,
     brand_context: list[dict],
     body_text: dict[str, Any],
     platforms: list[str],
+    historical_engagement: dict[str, dict[str, Any] | None],
 ) -> str:
     industry = brand.industry or brand.name
     tone_descriptors = brand.tone_descriptors or []
     target_audience = brand.target_audience or "not specified"
     content_json = json.dumps({platform: body_text.get(platform, "") for platform in platforms})
+    historical_engagement_text = _format_historical_engagement(historical_engagement, platforms)
 
     return f"""You are a meticulous brand-voice, compliance, and
 platform-fit reviewer. You are given a finished draft post and must
@@ -246,6 +367,9 @@ Target audience: {target_audience}
 ## Draft post copy to review, per platform
 {content_json}
 
+## Historical engagement performance, per platform
+{historical_engagement_text}
+
 ## Task
 For EACH of these target platforms — {", ".join(platforms)} — critically
 evaluate that platform's draft copy against:
@@ -257,6 +381,11 @@ evaluate that platform's draft copy against:
    reviewer would flag.
 3. Platform fit — does it respect that platform's norms (length,
    formality, format conventions, audience expectations)?
+4. Predicted engagement — using the historical engagement performance
+   data above when it's available for that platform (cite the actual
+   numbers in your reasoning), or your best qualitative estimate when
+   historical data is insufficient, predict how well THIS draft will
+   perform relative to typical performance.
 
 Score each platform from 0 (severely off-brand, non-compliant, or wrong
 for the platform) to 100 (fully on-brand, compliant, and platform-
@@ -265,20 +394,29 @@ appropriate). Assign a verdict: "approve" for a score of 80 or higher
 (fundamental problems). List the SPECIFIC issues you found — never a
 generic "needs improvement" — and give SPECIFIC, actionable suggested
 edits: concrete rewording, a concrete fix, or a concrete rewritten
-passage, tied to what is actually wrong with THIS draft.
+passage, tied to what is actually wrong with THIS draft. Separately,
+score predicted engagement from 0 (very low predicted engagement) to 100
+(very high predicted engagement) and give a short (1-3 sentence)
+natural-language reasoning string for that prediction.
 
 Respond with a single JSON object of exactly this shape:
 {{"platforms": {{"<platform>": {{"score": <number 0-100>, "verdict":
 "approve"|"revise"|"reject", "issues": ["specific issue 1", "specific
 issue 2"], "suggested_edits": "specific, actionable edit instructions or
-a concrete rewritten passage"}}, ...}}}}
+a concrete rewritten passage", "predicted_engagement_score": <number
+0-100>, "predicted_engagement_reasoning": "short reasoning, citing
+historical numbers when they were provided above"}}, ...}}}}
 
 Respond with ONLY the JSON object. No markdown code fences, no extra text.
 """
 
 
 def _review_content(
-    brand: Brand, brand_context: list[dict], body_text: dict[str, Any], platforms: list[str]
+    brand: Brand,
+    brand_context: list[dict],
+    body_text: dict[str, Any],
+    platforms: list[str],
+    historical_engagement: dict[str, dict[str, Any] | None],
 ) -> tuple[dict[str, dict[str, Any]], str, int]:
     """Calls LLMProvider exclusively through its interface (never a direct
     vendor SDK import) — same degrade-on-failure contract as
@@ -287,7 +425,7 @@ def _review_content(
     usable review, must never take the pipeline down with it, just fall
     back to a fixed "needs manual review" verdict."""
     model = _default_model()
-    prompt = _build_prompt(brand, brand_context, body_text, platforms)
+    prompt = _build_prompt(brand, brand_context, body_text, platforms, historical_engagement)
     try:
         response = get_llm_provider().complete(prompt=prompt, model=model, temperature=0.2)
         platform_reviews = _parse_review(response.text, platforms)
@@ -309,6 +447,30 @@ def _overall_from_platforms(platform_reviews: dict[str, dict[str, Any]]) -> tupl
     return overall_score, overall_verdict
 
 
+def _overall_predicted_engagement(platform_reviews: dict[str, dict[str, Any]]) -> tuple[float, str]:
+    """Unlike the brand-alignment score/verdict (worst platform wins,
+    since a single off-brand platform is a real risk that must not be
+    masked), predicted engagement isn't a risk signal — it's averaged
+    across platforms so a strong-predicted-engagement platform and a
+    weak-predicted-engagement one net out to a representative overall
+    number rather than the post being judged solely by its worst channel.
+    Reasoning is the single platform's own reasoning when there's only
+    one, otherwise each platform's reasoning prefixed by its name so the
+    UI/API can show one short string without losing per-platform nuance."""
+    scores = [entry["predicted_engagement_score"] for entry in platform_reviews.values()]
+    overall_score = round(sum(scores) / len(scores), 1)
+
+    if len(platform_reviews) == 1:
+        (only_entry,) = platform_reviews.values()
+        reasoning = only_entry["predicted_engagement_reasoning"]
+    else:
+        reasoning = "; ".join(
+            f"{platform}: {entry['predicted_engagement_reasoning']}"
+            for platform, entry in platform_reviews.items()
+        )
+    return overall_score, reasoning
+
+
 def _reviewer_output(db: Session, post: Post) -> dict[str, Any]:
     brand = db.get(Brand, post.brand_id)
     if brand is None:
@@ -317,12 +479,18 @@ def _reviewer_output(db: Session, post: Post) -> dict[str, Any]:
     body_text = post.body_text or {}
     platforms = _platforms_for(body_text)
     brand_context = _brand_context_safely(db, brand.id)
+    historical_engagement = _historical_engagement_safely(db, brand.id, platforms)
 
     start = time.perf_counter()
-    platform_reviews, model, tokens = _review_content(brand, brand_context, body_text, platforms)
+    platform_reviews, model, tokens = _review_content(
+        brand, brand_context, body_text, platforms, historical_engagement
+    )
     latency_ms = (time.perf_counter() - start) * 1000
 
     overall_score, overall_verdict = _overall_from_platforms(platform_reviews)
+    predicted_engagement_score, predicted_engagement_reasoning = _overall_predicted_engagement(
+        platform_reviews
+    )
     cost = _estimate_cost(tokens)
 
     # Append an immutable ReviewFeedback row for this review pass — never
@@ -334,6 +502,8 @@ def _reviewer_output(db: Session, post: Post) -> dict[str, Any]:
         score=overall_score,
         verdict=overall_verdict,
         comments={"platforms": platform_reviews, "model": model},
+        predicted_engagement_score=predicted_engagement_score,
+        predicted_engagement_reasoning=predicted_engagement_reasoning,
     )
     db.add(feedback)
     db.flush()
@@ -349,6 +519,8 @@ def _reviewer_output(db: Session, post: Post) -> dict[str, Any]:
         "tokens": tokens,
         "cost": cost,
         "latency_ms": latency_ms,
+        "predicted_engagement_score": predicted_engagement_score,
+        "predicted_engagement_reasoning": predicted_engagement_reasoning,
     }
 
 

--- a/packages/agents/tests/test_reviewer_engine.py
+++ b/packages/agents/tests/test_reviewer_engine.py
@@ -31,6 +31,7 @@ from apps.api.models import (
     AgentRun,
     AgentType,
     Brand,
+    EngagementSnapshot,
     Organization,
     Post,
     ReviewFeedback,
@@ -135,6 +136,11 @@ def _off_brand_review_payload() -> dict:
                     "calm, five minutes a day.' Drop the exclamation points "
                     "and all-caps throughout."
                 ),
+                "predicted_engagement_score": 15,
+                "predicted_engagement_reasoning": (
+                    "Hype-driven, spammy language like this typically suppresses "
+                    "engagement and trust on LinkedIn's professional audience."
+                ),
             }
         }
     }
@@ -148,6 +154,11 @@ def _on_brand_review_payload() -> dict:
                 "verdict": "approve",
                 "issues": [],
                 "suggested_edits": "No changes needed — tone, claims, and length all match brand voice and LinkedIn norms.",
+                "predicted_engagement_score": 68,
+                "predicted_engagement_reasoning": (
+                    "Calm, benefit-led copy consistent with brand voice should "
+                    "perform in line with typical LinkedIn engagement for this brand."
+                ),
             }
         }
     }
@@ -225,20 +236,26 @@ def test_second_review_pass_appends_a_new_row_instead_of_overwriting(db_session)
 
     with patch(LLM_PATCH_TARGET) as mock_llm:
         mock_llm.return_value.complete.return_value = _llm_response(_on_brand_review_payload())
-        _run_node(db_session, post)
+        first_result = _run_node(db_session, post)
 
         mock_llm.return_value.complete.return_value = _llm_response(_off_brand_review_payload())
-        _run_node(db_session, post)
+        second_result = _run_node(db_session, post)
 
     rows = (
-        db_session.query(ReviewFeedback)
-        .filter(ReviewFeedback.post_id == post.id)
-        .order_by(ReviewFeedback.created_at.asc())
-        .all()
+        db_session.query(ReviewFeedback).filter(ReviewFeedback.post_id == post.id).all()
     )
     assert len(rows) == 2
-    assert rows[0].verdict == ReviewVerdict.APPROVE
-    assert rows[1].verdict == ReviewVerdict.REJECT
+
+    # Looked up by the review_feedback_id each call actually returned
+    # (not by created_at ordering) — within a single test transaction,
+    # Postgres's now() is pinned to transaction start, so both rows can
+    # land on the exact same timestamp and created_at ordering isn't a
+    # reliable tie-breaker.
+    rows_by_id = {str(row.id): row for row in rows}
+    first_row = rows_by_id[first_result["review_output"]["review_feedback_id"]]
+    second_row = rows_by_id[second_result["review_output"]["review_feedback_id"]]
+    assert first_row.verdict == ReviewVerdict.APPROVE
+    assert second_row.verdict == ReviewVerdict.REJECT
 
 
 # --- off-brand content scores low with actionable, specific suggestions ----
@@ -315,12 +332,16 @@ def test_worst_scoring_platform_sets_the_overall_score_and_verdict(db_session) -
                 "verdict": "approve",
                 "issues": [],
                 "suggested_edits": "No changes needed.",
+                "predicted_engagement_score": 80,
+                "predicted_engagement_reasoning": "On-brand copy should perform well.",
             },
             "x": {
                 "score": 20,
                 "verdict": "reject",
                 "issues": ["Uses hype language inconsistent with brand voice."],
                 "suggested_edits": "Rewrite without exclamation points or superlatives; match the calm brand tone.",
+                "predicted_engagement_score": 30,
+                "predicted_engagement_reasoning": "Off-brand hype language tends to underperform.",
             },
         }
     }
@@ -332,6 +353,9 @@ def test_worst_scoring_platform_sets_the_overall_score_and_verdict(db_session) -
     output = result["review_output"]
     assert output["score"] == 20
     assert output["verdict"] == "reject"
+    # Unlike score/verdict, predicted engagement is averaged across
+    # platforms rather than worst-wins (see _overall_predicted_engagement).
+    assert output["predicted_engagement_score"] == 55.0
 
 
 # --- degrade-on-failure ------------------------------------------------
@@ -452,12 +476,16 @@ def test_pipeline_logs_agent_run_with_agent_type_reviewer_and_writes_review_feed
                 "verdict": "approve",
                 "issues": [],
                 "suggested_edits": "No changes needed.",
+                "predicted_engagement_score": 75,
+                "predicted_engagement_reasoning": "On-brand, calm copy in line with typical performance.",
             },
             "x": {
                 "score": 85,
                 "verdict": "approve",
                 "issues": [],
                 "suggested_edits": "No changes needed.",
+                "predicted_engagement_score": 70,
+                "predicted_engagement_reasoning": "Concise, on-brand copy should perform well on X.",
             },
         }
     }
@@ -496,3 +524,167 @@ def test_pipeline_logs_agent_run_with_agent_type_reviewer_and_writes_review_feed
     assert feedback_rows[0].source == ReviewSource.AI_REVIEWER
     assert feedback_rows[0].score == 85.0
     assert feedback_rows[0].verdict == ReviewVerdict.APPROVE
+
+
+# --- predicted engagement (Issue #107) --------------------------------------
+
+
+def _add_historical_snapshot(
+    db_session, brand: Brand, platform: str, likes: int, comments: int, shares: int, impressions: int
+) -> None:
+    """A past, already-published Post on `platform` for `brand` with one
+    EngagementSnapshot row — the raw material _historical_engagement_stats
+    aggregates over."""
+    past_post = Post(brand_id=brand.id)
+    db_session.add(past_post)
+    db_session.flush()
+    db_session.add(
+        EngagementSnapshot(
+            post_id=past_post.id,
+            platform=platform,
+            likes=likes,
+            comments=comments,
+            shares=shares,
+            impressions=impressions,
+        )
+    )
+    db_session.flush()
+
+
+def test_predicted_engagement_persisted_on_review_feedback_row_and_output(db_session) -> None:
+    post = _setup_post(db_session, body_text=ON_BRAND_BODY_TEXT)
+
+    with patch(LLM_PATCH_TARGET) as mock_llm:
+        mock_llm.return_value.complete.return_value = _llm_response(_on_brand_review_payload())
+        result = _run_node(db_session, post)
+
+    output = result["review_output"]
+    assert output["predicted_engagement_score"] == 68.0
+    assert "engagement" in output["predicted_engagement_reasoning"].lower() or len(
+        output["predicted_engagement_reasoning"]
+    ) > 0
+
+    row = db_session.query(ReviewFeedback).filter(ReviewFeedback.post_id == post.id).one()
+    assert row.predicted_engagement_score == 68.0
+    assert row.predicted_engagement_reasoning == output["predicted_engagement_reasoning"]
+
+
+def test_predicted_engagement_omitted_by_llm_degrades_to_fallback(db_session) -> None:
+    """Same all-or-nothing parse contract as the other required per-platform
+    fields (see test_reviewer_degrades_gracefully_when_llm_omits_required_fields)
+    — an LLM response missing predicted_engagement_score/reasoning must not
+    silently ship a review with no engagement prediction, it degrades the
+    whole platform review to the fixed fallback."""
+    post = _setup_post(db_session, body_text=ON_BRAND_BODY_TEXT)
+
+    with patch(LLM_PATCH_TARGET) as mock_llm:
+        mock_llm.return_value.complete.return_value = _llm_response(
+            {
+                "platforms": {
+                    "linkedin": {
+                        "score": 90,
+                        "verdict": "approve",
+                        "issues": [],
+                        "suggested_edits": "No changes needed.",
+                        # predicted_engagement_score/reasoning deliberately omitted
+                    }
+                }
+            }
+        )
+        result = _run_node(db_session, post)
+
+    output = result["review_output"]
+    assert output["verdict"] == "revise"
+    assert output["score"] == 50.0
+    assert output["predicted_engagement_score"] == 50.0
+    assert "unavailable" in output["predicted_engagement_reasoning"].lower()
+
+
+def test_reviewer_falls_back_to_manual_review_includes_engagement_fallback(db_session) -> None:
+    post = _setup_post(db_session, body_text=ON_BRAND_BODY_TEXT)
+
+    with patch(LLM_PATCH_TARGET) as mock_llm:
+        mock_llm.return_value.complete.side_effect = Exception("LLM provider unreachable")
+        result = _run_node(db_session, post)
+
+    output = result["review_output"]
+    assert output["predicted_engagement_score"] == 50.0
+    assert "unavailable" in output["predicted_engagement_reasoning"].lower()
+
+    row = db_session.query(ReviewFeedback).filter(ReviewFeedback.post_id == post.id).one()
+    assert row.predicted_engagement_score == 50.0
+
+
+def test_historical_engagement_grounds_the_llm_prompt_when_enough_history_exists(db_session) -> None:
+    """Prefer grounding the prediction in the brand's actual historical
+    performance where available (Issue #107's acceptance criteria) — when
+    a brand has _MIN_HISTORICAL_SAMPLES+ past LinkedIn posts with real
+    impressions, the real computed average engagement rate must be handed
+    to the LLM as grounding data in the prompt, not left for the LLM to
+    guess."""
+    brand = _setup_brand(db_session)
+    # 3 historical posts, engagement rate (likes+comments+shares)/impressions
+    # of exactly 10% each -> average 10%.
+    for _ in range(3):
+        _add_historical_snapshot(
+            db_session, brand, "linkedin", likes=8, comments=1, shares=1, impressions=100
+        )
+    post = _setup_post(db_session, brand=brand, body_text=ON_BRAND_BODY_TEXT)
+
+    with patch(LLM_PATCH_TARGET) as mock_llm:
+        mock_llm.return_value.complete.return_value = _llm_response(_on_brand_review_payload())
+        _run_node(db_session, post)
+
+    prompt = mock_llm.return_value.complete.call_args.kwargs["prompt"]
+    assert "3 historical posts" in prompt
+    assert "10.00%" in prompt
+
+
+def test_historical_engagement_says_insufficient_data_when_brand_has_no_history(db_session) -> None:
+    post = _setup_post(db_session, body_text=ON_BRAND_BODY_TEXT)
+
+    with patch(LLM_PATCH_TARGET) as mock_llm:
+        mock_llm.return_value.complete.return_value = _llm_response(_on_brand_review_payload())
+        _run_node(db_session, post)
+
+    prompt = mock_llm.return_value.complete.call_args.kwargs["prompt"]
+    assert "insufficient historical data" in prompt
+
+
+def test_historical_engagement_below_minimum_sample_size_is_not_used(db_session) -> None:
+    """Two historical snapshots is below _MIN_HISTORICAL_SAMPLES (3) — too
+    noisy a sample to hand over as a trustworthy benchmark, so the prompt
+    must still say the data is insufficient rather than grounding on it."""
+    brand = _setup_brand(db_session)
+    for _ in range(2):
+        _add_historical_snapshot(
+            db_session, brand, "linkedin", likes=8, comments=1, shares=1, impressions=100
+        )
+    post = _setup_post(db_session, brand=brand, body_text=ON_BRAND_BODY_TEXT)
+
+    with patch(LLM_PATCH_TARGET) as mock_llm:
+        mock_llm.return_value.complete.return_value = _llm_response(_on_brand_review_payload())
+        _run_node(db_session, post)
+
+    prompt = mock_llm.return_value.complete.call_args.kwargs["prompt"]
+    assert "insufficient historical data" in prompt
+
+
+def test_overall_predicted_engagement_is_averaged_not_worst_platform(db_session) -> None:
+    """Contrasts with _overall_from_platforms (brand-alignment score/verdict
+    is worst-platform-wins) — predicted engagement is averaged across
+    platforms instead, exercised directly via
+    test_worst_scoring_platform_sets_the_overall_score_and_verdict's
+    assertion above; this test checks the single-platform passthrough case."""
+    post = _setup_post(db_session, body_text=ON_BRAND_BODY_TEXT)
+
+    with patch(LLM_PATCH_TARGET) as mock_llm:
+        mock_llm.return_value.complete.return_value = _llm_response(_on_brand_review_payload())
+        result = _run_node(db_session, post)
+
+    output = result["review_output"]
+    # Single platform: overall reasoning passes through the one platform's
+    # reasoning unmodified rather than prefixing it with the platform name.
+    assert output["predicted_engagement_reasoning"] == (
+        output["platforms"]["linkedin"]["predicted_engagement_reasoning"]
+    )


### PR DESCRIPTION
## Linked issue
Closes #107

## Why
The Reviewer Engine (Neer) scores brand-alignment/compliance/platform-fit for a generated draft but has no signal for how well the post is likely to *perform*. Reviewers currently have to guess at expected engagement with no data to back it up.

## What changed
- `apps/api/models/review_feedback.py`: adds nullable `predicted_engagement_score` (0-100) and `predicted_engagement_reasoning` (short natural-language string) columns to `ReviewFeedback`. Nullable because only `source=ai_reviewer` rows populate them — human approve/reject rows never predict engagement.
- `migrations/versions/88fcfa95b048_review_feedback_predicted_engagement.py`: the corresponding Alembic migration (single head, `down_revision = 5b29b584c4fa`).
- `apps/api/schemas/review.py`: adds the two new optional fields to `ReviewFeedbackRead`.
- `packages/agents/pipeline/nodes/reviewer_engine.py`:
  - Computes each platform's historical average engagement rate — `(likes + comments + shares) / impressions` — from the brand's own past `EngagementSnapshot` rows via a single SQL AVG/COUNT query (`_historical_engagement_stats`), requiring at least 3 samples before it's trusted.
  - Hands that real historical data to the LLM as grounding material in the same prompt used for brand-voice scoring, instructing it to ground its prediction in the real numbers when available and to fall back to a pure qualitative estimate when a platform doesn't have enough history yet.
  - Extends the per-platform JSON response schema with `predicted_engagement_score`/`predicted_engagement_reasoning` (required, same all-or-nothing parse/fallback contract as the existing fields — a response missing them degrades to the fixed "needs manual review" fallback, which now also carries fallback engagement values).
  - Aggregates an overall predicted-engagement score/reasoning across platforms by averaging (unlike the brand-alignment score, which is worst-platform-wins) since engagement isn't a risk signal.
- `apps/web/lib/api.ts`: adds the two new fields to the `ReviewFeedback` client type.
- `apps/web/app/review-queue/review-card.tsx`: shows the overall predicted-engagement score/meter next to the existing AI score in the card header, and per-platform predicted engagement + reasoning alongside each platform's issues/suggested edits.

## How I tested this
- `pytest apps/api/tests packages/agents/tests -v --cov --cov-fail-under=70` → 406 passed, 97.82% coverage.
- Added new backend tests in `packages/agents/tests/test_reviewer_engine.py` covering: predicted engagement persisted on the `ReviewFeedback` row/node output, the LLM prompt is grounded with real historical numbers when a brand has ≥3 historical posts on a platform, the prompt says "insufficient historical data" below that threshold, missing predicted-engagement fields in the LLM response degrade to the fixed fallback, and the fallback includes engagement fields. Also fixed a latent flaky assertion in `test_second_review_pass_appends_a_new_row_instead_of_overwriting` (it sorted by `created_at`, which Postgres pins to transaction start for every statement in a single test transaction, making the sort order for two rows non-deterministic — now looks each row up by the `review_feedback_id` its call actually returned).
- `npx vitest run` in `apps/web` (Node 18 via `fnm use 18`) → 58 passed across 11 files, including a new `review-queue-page.test.tsx` case asserting the predicted engagement score/reasoning render.
- `npx tsc --noEmit`, `npm run lint`, and `npm run build` in `apps/web` all pass cleanly.
- `alembic heads` confirms a single head (`88fcfa95b048`) before and after adding the migration; `alembic upgrade head` applied cleanly against the local Postgres instance.

## Screenshots / recording
No visual UI restyle — this adds a small new score/meter block and per-platform reasoning text within the existing review-card layout (see `apps/web/app/review-queue/review-card.tsx`'s diff for the exact markup).

## Checklist
- [x] Tests added/updated and passing locally
- [x] Migration included (schema changed)
- [x] No secrets, API keys, or `.env` values committed
- [ ] Docs/README updated if behavior or setup changed (no doc changes needed)
- [x] I branched from `main` and am targeting `main`