### PR TITLE
feat(agents): add opt-in batch mode to the Generation Engine

### DIFF
--- a/apps/api/models/post.py
+++ b/apps/api/models/post.py
@@ -2,7 +2,7 @@ import enum
 import uuid
 from datetime import datetime
 
-from sqlalchemy import DateTime, Enum, ForeignKey, func
+from sqlalchemy import DateTime, Enum, ForeignKey, Integer, func
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -63,6 +63,24 @@ class Post(Base):
         nullable=False,
         default=PipelineStage.RESEARCH,
     )
+
+    # Written by the Generation Engine's batch mode (Issue #106) — a shared
+    # id linking every Post produced by the same batch generation run, so a
+    # human can be shown "the other N-1 variants" for a post they're
+    # reviewing. NULL for every Post produced by the (default, unchanged)
+    # single-post generation path — those have no siblings, so there's
+    # nothing to group. Not a ForeignKey to another table: it's a bare
+    # shared value across sibling Post rows, the same "group id with no
+    # row of its own" shape LangGraph's thread_id uses.
+    variant_group_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), nullable=True
+    )
+    # This Post's 1-based position within variant_group_id (1 for the
+    # original post that triggered the run, 2..N for the additional
+    # sibling Posts batch mode creates). Purely presentational ordering —
+    # nothing in the pipeline branches on it. NULL alongside
+    # variant_group_id for non-batch Posts.
+    variant_index: Mapped[int | None] = mapped_column(Integer, nullable=True)
 
     # Written by the Generation Engine (Issue #21) — a dict keyed by
     # platform (e.g. {"linkedin": "...", "x": "..."}), matching

--- a/migrations/versions/8fa8ca323102_post_variant_group.py
+++ b/migrations/versions/8fa8ca323102_post_variant_group.py
@@ -1,0 +1,53 @@
+"""post variant group
+
+Revision ID: 8fa8ca323102
+Revises: 5b29b584c4fa
+Create Date: 2026-08-27 00:35:59.492114
+
+Issue #106 (Kavi batch generation) lets the Generation Engine
+(packages/agents/pipeline/nodes/generation_engine.py) optionally produce
+several distinct post variants (copy + image each) from a single creative
+brief in one run, instead of exactly one Post per pipeline run. Each
+variant is its own Post row (own body_text/media/PostVersion history, so
+existing single-post assumptions elsewhere in the codebase keep holding),
+tied to its siblings from the same generation run via a shared, nullable
+"variant group" id — nothing like this exists yet (this repo's only
+per-post grouping so far is calendar_event_id, which is a 1:1 link to a
+calendar slot, not a sibling-grouping concept). Adds:
+
+  * posts.variant_group_id — nullable UUID, shared by every Post produced
+    by the same batch generation run. NULL for every Post produced by the
+    existing (default, unchanged) single-post generation path, since those
+    have no siblings to group with.
+  * posts.variant_index — nullable integer, this Post's 1-based position
+    within its variant group (1 for the original post that triggered the
+    run, 2..N for the additional sibling Posts batch mode creates). NULL
+    alongside variant_group_id for non-batch Posts.
+
+An index on variant_group_id supports the natural "fetch every variant in
+this batch so a human can pick/edit one" query a future review-queue
+endpoint would run.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '8fa8ca323102'
+down_revision: Union[str, None] = '5b29b584c4fa'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column('posts', sa.Column('variant_group_id', sa.UUID(), nullable=True))
+    op.add_column('posts', sa.Column('variant_index', sa.Integer(), nullable=True))
+    op.create_index('posts_variant_group_id_idx', 'posts', ['variant_group_id'])
+
+
+def downgrade() -> None:
+    op.drop_index('posts_variant_group_id_idx', table_name='posts')
+    op.drop_column('posts', 'variant_index')
+    op.drop_column('posts', 'variant_group_id')

--- a/packages/agents/pipeline/graph.py
+++ b/packages/agents/pipeline/graph.py
@@ -110,6 +110,17 @@ class PipelineState(TypedDict):
     # research_brief's comment above), so this must be listed even though
     # it's only ever set by this one stage.
     generation_output: dict[str, Any] | None
+    # Optional, caller-supplied input (never set by any node) read by the
+    # generation node (#21/#106) to decide whether to run its default
+    # single-Post/PostVersion behavior or #106's opt-in batch mode —
+    # {"batch": True, "variant_count": <int, optional>} — see
+    # nodes/generation_engine.py's module docstring ("Batch mode") for the
+    # full contract. Absent for the calendar-slot-triggered flow
+    # (trigger.py) and apps/api/routers/review.py's resume calls, so their
+    # behavior is unchanged by #106. LangGraph drops any state key not
+    # declared here (see research_brief's comment above), so this must be
+    # listed even though no node ever writes to it.
+    generation_options: dict[str, Any] | None
     # Populated by the reviewer node (#24) — the automated brand-voice/
     # compliance/platform-fit review of Post.body_text: an overall score/
     # verdict plus a per-platform breakdown (score/verdict/issues/
@@ -258,6 +269,7 @@ def run_pipeline(
     checkpointer,
     *,
     resume: Any = None,
+    generation_options: dict[str, Any] | None = None,
 ) -> Iterator[dict]:
     """Advances `post` through the pipeline graph until it either finishes
     or hits the human_review interrupt, updating Post.current_pipeline_stage
@@ -267,6 +279,16 @@ def run_pipeline(
 
     Pass `resume=<value>` to continue a previously interrupted run (e.g. a
     human's approve/reject decision) instead of starting a new one.
+
+    Pass `generation_options=<dict>` to opt into the generation node's
+    batch mode (Issue #106) for a fresh run — e.g. {"batch": True,
+    "variant_count": 5} — see nodes/generation_engine.py's module
+    docstring for the full contract. Defaults to None (unchanged, single-
+    Post behavior); ignored when `resume` is set, since generation already
+    ran earlier in the same thread and isn't re-entered on resume. Neither
+    the calendar-slot-triggered flow (trigger.py) nor
+    apps/api/routers/review.py's resume calls pass this, so their
+    behavior is unaffected by #106.
 
     Yields each node's raw update dict as it completes, in case a caller
     wants to observe progress; most callers can just ignore the return
@@ -279,6 +301,8 @@ def run_pipeline(
         graph_input: Any = Command(resume=resume)
     else:
         graph_input = {"post_id": str(post.id), "completed_stages": []}
+        if generation_options is not None:
+            graph_input["generation_options"] = generation_options
 
     for update in graph.stream(graph_input, config=config, stream_mode="updates"):
         for node_name, node_output in update.items():

--- a/packages/agents/pipeline/nodes/generation_engine.py
+++ b/packages/agents/pipeline/nodes/generation_engine.py
@@ -61,6 +61,36 @@ to resolve Post -> Post.body_text/PostVersion, same as the earlier
 stages), returning the actual LangGraph node function. graph.py's
 build_pipeline_graph() calls this factory for the "generation" stage
 only.
+
+Batch mode (Issue #106) — optional, off by default:
+  Everything above describes this node's default behavior, which is
+  completely unchanged: exactly one Post/PostVersion pair per pipeline
+  run, used by the calendar-slot-triggered flow
+  (packages/agents/pipeline/trigger.py) and by
+  apps/api/routers/review.py's resume calls. Batch mode is an additive,
+  explicitly-requested alternative for a human who wants a small batch of
+  distinct drafts to pick/edit from instead of one draft at a time — it is
+  never turned on implicitly.
+
+  A caller opts in by including a "generation_options" entry (see
+  PipelineState in graph.py) shaped like {"batch": True, "variant_count":
+  <int, optional>} in the initial graph input passed to run_pipeline()
+  (graph.py). When present and truthy, this node runs the same
+  copy+media generation pass _generation_output already implements once
+  per variant (default DEFAULT_BATCH_VARIANT_COUNT, clamped to
+  [MIN_BATCH_VARIANT_COUNT, MAX_BATCH_VARIANT_COUNT]) — the post the run
+  was invoked for becomes variant 1, and (variant_count - 1) additional
+  sibling Post rows are created for the rest, each with its own
+  body_text/media/PostVersion history exactly like a normal single-post
+  run would produce. All variants share a freshly generated
+  Post.variant_group_id (apps/api/models/post.py) so they can be queried
+  together later, with Post.variant_index recording each one's 1-based
+  position. Sibling Posts are deliberately created with no
+  calendar_event_id of their own — see _clone_post_for_variant's
+  docstring for why. Exactly one AgentRun row is still logged for the
+  generation stage either way (see the AgentRun paragraph above) — batch
+  mode's token/cost/latency figures on that row are summed across every
+  variant it produced.
 """
 
 import json
@@ -73,7 +103,7 @@ import httpx
 from sqlalchemy.orm import Session
 
 from apps.api.config import get_settings
-from apps.api.models.post import Post
+from apps.api.models.post import PipelineStage, Post
 from apps.api.models.post_version import PostVersion
 from packages.integrations.registry import (
     get_image_provider,
@@ -100,6 +130,17 @@ VIDEO_FORMAT_KEYWORDS = ("video", "carousel")
 # until a real pricing/billing feed exists — not tied to any specific
 # model's actual price.
 _COST_PER_1K_TOKENS = 0.002
+
+# Batch mode (Issue #106) defaults/bounds for "generation_options":
+# {"variant_count": N} — the issue asks for "4-5" variants, so 5 is the
+# default when a caller opts into batch mode without naming a count; the
+# clamp keeps a bad/unbounded caller-supplied value (too small to be a
+# meaningful batch, or large enough to hammer the LLM/image providers)
+# from turning into a runaway loop of LLM/image-gen calls rather than
+# raising and failing the whole pipeline run over it.
+DEFAULT_BATCH_VARIANT_COUNT = 5
+MIN_BATCH_VARIANT_COUNT = 2
+MAX_BATCH_VARIANT_COUNT = 8
 
 
 class GenerationEngineError(Exception):
@@ -428,6 +469,85 @@ def _generation_output(db: Session, post: Post, creative_brief: dict[str, Any]) 
     }
 
 
+def _resolve_variant_count(generation_options: dict[str, Any]) -> int:
+    """Reads "variant_count" out of the caller-supplied generation_options
+    dict (see module docstring's Batch mode section), defaulting to
+    DEFAULT_BATCH_VARIANT_COUNT and clamping to
+    [MIN_BATCH_VARIANT_COUNT, MAX_BATCH_VARIANT_COUNT]. Degrades to the
+    default on a missing/non-numeric value rather than raising — same
+    degrade-on-failure spirit as the rest of this module: a malformed
+    option shouldn't take the whole pipeline run down."""
+    requested = generation_options.get("variant_count", DEFAULT_BATCH_VARIANT_COUNT)
+    try:
+        count = int(requested)
+    except (TypeError, ValueError):
+        count = DEFAULT_BATCH_VARIANT_COUNT
+    return max(MIN_BATCH_VARIANT_COUNT, min(MAX_BATCH_VARIANT_COUNT, count))
+
+
+def _clone_post_for_variant(db: Session, post: Post) -> Post:
+    """Creates one additional sibling Post row for batch mode (Issue #106)
+    — same brand as the triggering post, but deliberately with no
+    calendar_event_id of its own. packages/agents/pipeline/trigger.py's
+    _get_or_create_post() looks up "the Post for this calendar event" with
+    a plain .first() query, assuming exactly one Post per calendar event;
+    giving every sibling variant the same calendar_event_id as the
+    original would silently break that assumption for a flow batch mode
+    isn't even wired into yet (the calendar-triggered flow never sets
+    generation_options — see module docstring). current_pipeline_stage is
+    set explicitly to GENERATION since this row is created mid-node,
+    outside run_pipeline's normal "set current_pipeline_stage after each
+    node completes" bookkeeping (graph.py) — it never runs through this
+    graph itself, so nothing else would ever set it."""
+    clone = Post(brand_id=post.brand_id, current_pipeline_stage=PipelineStage.GENERATION)
+    db.add(clone)
+    db.flush()
+    db.refresh(clone)
+    return clone
+
+
+def _generate_batch_output(
+    db: Session, post: Post, creative_brief: dict[str, Any], variant_count: int
+) -> dict[str, Any]:
+    """Batch mode's entry point (Issue #106): runs _generation_output's
+    exact same single-variant copy+media generation pass once per variant
+    — the post this run was invoked for becomes variant 1, and
+    (variant_count - 1) additional sibling Posts (_clone_post_for_variant)
+    supply the rest — tagging every variant with a shared, freshly
+    generated variant_group_id and a 1-based variant_index (see
+    apps/api/models/post.py) so they can be queried together later.
+
+    Returns the same generation_output shape build_generation_node's
+    caller already relies on for the default path — "model"/"tokens"/
+    "cost"/"latency_ms" (summed/aggregated across every variant, since
+    graph.py's run_pipeline still logs exactly one AgentRun row for the
+    generation stage regardless of variant count) plus "post_id" — with
+    "batch"/"variant_group_id"/"variant_count"/"variants" added on top so
+    a caller can tell this was a batch run and see every variant it
+    produced.
+    """
+    variant_group_id = uuid.uuid4()
+    variant_posts = [post] + [_clone_post_for_variant(db, post) for _ in range(variant_count - 1)]
+
+    variants: list[dict[str, Any]] = []
+    for index, variant_post in enumerate(variant_posts, start=1):
+        variant_post.variant_group_id = variant_group_id
+        variant_post.variant_index = index
+        variants.append(_generation_output(db, variant_post, creative_brief))
+
+    return {
+        "post_id": str(post.id),
+        "batch": True,
+        "variant_group_id": str(variant_group_id),
+        "variant_count": len(variants),
+        "variants": variants,
+        "model": variants[0]["model"],
+        "tokens": sum(variant["tokens"] for variant in variants),
+        "cost": round(sum(variant["cost"] for variant in variants), 6),
+        "latency_ms": sum(variant["latency_ms"] for variant in variants),
+    }
+
+
 def build_generation_node(db: Session | None):
     """Builds the real "generation" stage node function, closing over
     `db`. Mirrors research_engine.py/creative_engine.py's factory shape
@@ -455,7 +575,21 @@ def build_generation_node(db: Session | None):
             )
 
         creative_brief = state.get("creative_brief") or {}
-        output = _generation_output(db, post, creative_brief)
+        generation_options = state.get("generation_options") or {}
+
+        # Batch mode (Issue #106) is opt-in only — see module docstring's
+        # "Batch mode" section. Absent (or falsy) generation_options.batch,
+        # this is the exact same single-Post/PostVersion call as before
+        # #106, unchanged, so the calendar-slot-triggered flow
+        # (packages/agents/pipeline/trigger.py) and
+        # apps/api/routers/review.py's resume calls keep behaving
+        # identically.
+        if generation_options.get("batch"):
+            variant_count = _resolve_variant_count(generation_options)
+            output = _generate_batch_output(db, post, creative_brief, variant_count)
+        else:
+            output = _generation_output(db, post, creative_brief)
+
         return {
             "completed_stages": [*state.get("completed_stages", []), "generation"],
             "generation_output": output,

--- a/packages/agents/tests/test_generation_engine.py
+++ b/packages/agents/tests/test_generation_engine.py
@@ -113,15 +113,21 @@ def _copy_payload() -> dict:
     }
 
 
-def _run_node(db_session, post: Post, creative_brief: dict | None = None) -> dict:
+def _run_node(
+    db_session,
+    post: Post,
+    creative_brief: dict | None = None,
+    generation_options: dict | None = None,
+) -> dict:
     node = build_generation_node(db_session)
-    return node(
-        {
-            "post_id": str(post.id),
-            "completed_stages": [],
-            "creative_brief": creative_brief if creative_brief is not None else {},
-        }
-    )
+    state = {
+        "post_id": str(post.id),
+        "completed_stages": [],
+        "creative_brief": creative_brief if creative_brief is not None else {},
+    }
+    if generation_options is not None:
+        state["generation_options"] = generation_options
+    return node(state)
 
 
 @pytest.fixture()
@@ -392,3 +398,266 @@ def test_pipeline_logs_agent_run_with_agent_type_generation_including_token_and_
 
     db_session.refresh(post)
     assert post.body_text == _copy_payload()
+
+
+# --- batch mode (Issue #106) — additive, explicitly-requested only --------
+
+
+def test_batch_mode_off_by_default_leaves_variant_columns_null(db_session) -> None:
+    """The default path (no "generation_options" in state at all — the
+    calendar-slot-triggered flow's exact shape) must behave identically to
+    before #106: a single Post, no variant_group_id/variant_index set."""
+    post = _setup_post(db_session)
+
+    with patch(LLM_PATCH_TARGET) as mock_llm:
+        mock_llm.return_value.complete.return_value = _llm_response(_copy_payload())
+        result = _run_node(db_session, post, _creative_brief())
+
+    assert "batch" not in result["generation_output"]
+    db_session.refresh(post)
+    assert post.variant_group_id is None
+    assert post.variant_index is None
+
+
+def test_batch_mode_false_behaves_identically_to_default(db_session) -> None:
+    """generation_options present but batch falsy is still the single-Post
+    path — batch mode only activates when explicitly truthy."""
+    post = _setup_post(db_session)
+
+    with patch(LLM_PATCH_TARGET) as mock_llm:
+        mock_llm.return_value.complete.return_value = _llm_response(_copy_payload())
+        result = _run_node(
+            db_session, post, _creative_brief(), generation_options={"batch": False}
+        )
+
+    assert "batch" not in result["generation_output"]
+    db_session.refresh(post)
+    assert post.variant_group_id is None
+
+
+def test_batch_mode_produces_default_variant_count_sibling_posts(db_session) -> None:
+    from packages.agents.pipeline.nodes.generation_engine import DEFAULT_BATCH_VARIANT_COUNT
+
+    post = _setup_post(db_session)
+
+    with patch(LLM_PATCH_TARGET) as mock_llm:
+        mock_llm.return_value.complete.return_value = _llm_response(_copy_payload())
+        result = _run_node(db_session, post, _creative_brief(), generation_options={"batch": True})
+
+    output = result["generation_output"]
+    assert output["batch"] is True
+    assert output["variant_count"] == DEFAULT_BATCH_VARIANT_COUNT
+    assert len(output["variants"]) == DEFAULT_BATCH_VARIANT_COUNT
+    assert mock_llm.return_value.complete.call_count == DEFAULT_BATCH_VARIANT_COUNT
+
+    db_session.refresh(post)
+    group_id = post.variant_group_id
+    assert group_id is not None
+    assert post.variant_index == 1
+
+    siblings = (
+        db_session.query(Post)
+        .filter(Post.variant_group_id == group_id)
+        .order_by(Post.variant_index)
+        .all()
+    )
+    assert len(siblings) == DEFAULT_BATCH_VARIANT_COUNT
+    assert [sibling.variant_index for sibling in siblings] == list(
+        range(1, DEFAULT_BATCH_VARIANT_COUNT + 1)
+    )
+    # The original post is variant 1; every variant has its own body_text.
+    assert siblings[0].id == post.id
+    for sibling in siblings:
+        assert sibling.body_text == _copy_payload()
+        assert sibling.brand_id == post.brand_id
+        # Sibling variants must never inherit a calendar_event_id — see
+        # _clone_post_for_variant's docstring for why.
+        if sibling.id != post.id:
+            assert sibling.calendar_event_id is None
+
+
+def test_batch_mode_respects_custom_variant_count(db_session) -> None:
+    post = _setup_post(db_session)
+
+    with patch(LLM_PATCH_TARGET) as mock_llm:
+        mock_llm.return_value.complete.return_value = _llm_response(_copy_payload())
+        result = _run_node(
+            db_session,
+            post,
+            _creative_brief(),
+            generation_options={"batch": True, "variant_count": 3},
+        )
+
+    assert result["generation_output"]["variant_count"] == 3
+    assert mock_llm.return_value.complete.call_count == 3
+
+
+def test_batch_mode_clamps_variant_count_below_minimum(db_session) -> None:
+    from packages.agents.pipeline.nodes.generation_engine import MIN_BATCH_VARIANT_COUNT
+
+    post = _setup_post(db_session)
+
+    with patch(LLM_PATCH_TARGET) as mock_llm:
+        mock_llm.return_value.complete.return_value = _llm_response(_copy_payload())
+        result = _run_node(
+            db_session,
+            post,
+            _creative_brief(),
+            generation_options={"batch": True, "variant_count": 1},
+        )
+
+    assert result["generation_output"]["variant_count"] == MIN_BATCH_VARIANT_COUNT
+
+
+def test_batch_mode_clamps_variant_count_above_maximum(db_session) -> None:
+    from packages.agents.pipeline.nodes.generation_engine import MAX_BATCH_VARIANT_COUNT
+
+    post = _setup_post(db_session)
+
+    with patch(LLM_PATCH_TARGET) as mock_llm:
+        mock_llm.return_value.complete.return_value = _llm_response(_copy_payload())
+        result = _run_node(
+            db_session,
+            post,
+            _creative_brief(),
+            generation_options={"batch": True, "variant_count": 999},
+        )
+
+    assert result["generation_output"]["variant_count"] == MAX_BATCH_VARIANT_COUNT
+
+
+def test_batch_mode_degrades_to_default_count_on_non_numeric_variant_count(db_session) -> None:
+    from packages.agents.pipeline.nodes.generation_engine import DEFAULT_BATCH_VARIANT_COUNT
+
+    post = _setup_post(db_session)
+
+    with patch(LLM_PATCH_TARGET) as mock_llm:
+        mock_llm.return_value.complete.return_value = _llm_response(_copy_payload())
+        result = _run_node(
+            db_session,
+            post,
+            _creative_brief(),
+            generation_options={"batch": True, "variant_count": "not-a-number"},
+        )
+
+    assert result["generation_output"]["variant_count"] == DEFAULT_BATCH_VARIANT_COUNT
+
+
+def test_batch_mode_creates_a_post_version_row_per_variant(db_session) -> None:
+    post = _setup_post(db_session)
+
+    with patch(LLM_PATCH_TARGET) as mock_llm:
+        mock_llm.return_value.complete.return_value = _llm_response(_copy_payload())
+        result = _run_node(
+            db_session,
+            post,
+            _creative_brief(),
+            generation_options={"batch": True, "variant_count": 3},
+        )
+
+    variant_post_ids = [uuid.UUID(variant["post_id"]) for variant in result["generation_output"]["variants"]]
+    assert len(set(variant_post_ids)) == 3
+
+    versions = (
+        db_session.query(PostVersion).filter(PostVersion.post_id.in_(variant_post_ids)).all()
+    )
+    assert len(versions) == 3
+
+
+def test_batch_mode_invokes_media_hook_once_per_variant_per_platform(db_session) -> None:
+    post = _setup_post(db_session)
+    brief = _creative_brief(linkedin_format="image", x_format="short_thread")
+
+    with patch(LLM_PATCH_TARGET) as mock_llm, patch(MEDIA_PATCH_TARGET) as mock_media:
+        mock_llm.return_value.complete.return_value = _llm_response(_copy_payload())
+        mock_media.return_value = {"status": "stubbed"}
+        _run_node(db_session, post, brief, generation_options={"batch": True, "variant_count": 3})
+
+    # linkedin needs media on every one of the 3 variants; x never does.
+    assert mock_media.call_count == 3
+    called_platforms = {call.args[1] for call in mock_media.call_args_list}
+    assert called_platforms == {"linkedin"}
+
+
+def test_batch_mode_still_logs_exactly_one_agent_run_row_for_generation(
+    db_session, thread_cleanup
+) -> None:
+    """graph.py's run_pipeline logs a single AgentRun row per stage
+    regardless of how many variants batch mode produced — see
+    generation_engine.py's module docstring and _generate_batch_output's."""
+    post = _setup_post(db_session)
+    thread_cleanup.append(str(post.id))
+
+    with (
+        patch(SEARCH_PATCH_TARGET) as mock_search,
+        patch(EMBED_PATCH_TARGET) as mock_embed,
+        patch(CREATIVE_LLM_PATCH_TARGET) as mock_creative_llm,
+        patch(LLM_PATCH_TARGET) as mock_generation_llm,
+    ):
+        mock_search.return_value.search.return_value = []
+        mock_embed.return_value.embed.return_value = [0.0] * 1536
+        mock_creative_llm.return_value.complete.return_value = _llm_response(
+            {
+                "linkedin": _creative_brief()["platforms"]["linkedin"],
+                "x": _creative_brief()["platforms"]["x"],
+            }
+        )
+        mock_generation_llm.return_value.complete.return_value = _llm_response(_copy_payload())
+
+        with get_postgres_checkpointer() as checkpointer:
+            list(
+                run_pipeline(
+                    db_session,
+                    post,
+                    checkpointer,
+                    generation_options={"batch": True, "variant_count": 3},
+                )
+            )
+
+    runs = (
+        db_session.query(AgentRun)
+        .filter(AgentRun.post_id == post.id, AgentRun.agent_type == AgentType.GENERATION)
+        .all()
+    )
+    assert len(runs) == 1
+    run = runs[0]
+    # tokens/cost are aggregated (summed) across all 3 variants, not just
+    # the triggering post's own generation call.
+    assert run.tokens == 200 * 3
+    assert run.cost is not None
+    assert run.cost > 0
+
+
+def test_calendar_triggered_run_pipeline_default_ignores_batch_entirely(
+    db_session, thread_cleanup
+) -> None:
+    """run_pipeline's default call shape — no generation_options kwarg at
+    all — is exactly what trigger.py uses; this pins that it still
+    produces a single, non-variant Post, unaffected by #106."""
+    post = _setup_post(db_session)
+    thread_cleanup.append(str(post.id))
+
+    with (
+        patch(SEARCH_PATCH_TARGET) as mock_search,
+        patch(EMBED_PATCH_TARGET) as mock_embed,
+        patch(CREATIVE_LLM_PATCH_TARGET) as mock_creative_llm,
+        patch(LLM_PATCH_TARGET) as mock_generation_llm,
+    ):
+        mock_search.return_value.search.return_value = []
+        mock_embed.return_value.embed.return_value = [0.0] * 1536
+        mock_creative_llm.return_value.complete.return_value = _llm_response(
+            {
+                "linkedin": _creative_brief()["platforms"]["linkedin"],
+                "x": _creative_brief()["platforms"]["x"],
+            }
+        )
+        mock_generation_llm.return_value.complete.return_value = _llm_response(_copy_payload())
+
+        with get_postgres_checkpointer() as checkpointer:
+            list(run_pipeline(db_session, post, checkpointer))
+
+    db_session.refresh(post)
+    assert post.variant_group_id is None
+    assert (
+        db_session.query(Post).filter(Post.brand_id == post.brand_id).count() == 1
+    )


### PR DESCRIPTION
Closes #106

Re-opened from PR #113 as a same-repo branch — that PR was opened from a fork, which caused the `issue-pr-sync` check to fail with a 403 (`Resource not accessible by integration`): GitHub restricts the default `GITHUB_TOKEN` to read-only for `pull_request` events from forks, so the sync workflow's issue-comment call gets rejected. Same commit, no code changes.

## Summary
- Opt-in batch mode: pass `generation_options={"batch": True, "variant_count": N}` into `run_pipeline()` to produce 4-5 (default 5, clamped 2-8) distinct copy+image post variants from one creative brief in a single run. Default single-post behavior (calendar-triggered flow) is unchanged.
- Each variant is its own `Post`/`PostVersion` row, linked via a new nullable `posts.variant_group_id` + `variant_index` (migration `8fa8ca323102_post_variant_group.py`, single alembic head before/after).
- One `AgentRun` row per generation stage, tokens/cost/latency summed across variants.

## Test plan
- [x] `alembic heads` — single head before and after
- [x] `pytest apps/api/tests packages/agents/tests --cov=apps/api --cov=packages --cov-fail-under=70` — 407 passed, 97.79% coverage (3 pre-existing unrelated `test_rate_limit.py` flakes, pass individually)