### PR TITLE
feat(social): add Instagram, Threads, and Facebook publishing providers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -78,6 +78,15 @@ X_REDIRECT_URI=http://localhost:8000/oauth/x/callback
 # App-level key, reserved for X's v1.1 media/upload endpoint (OAuth 1.0a,
 # not the OAuth2 flow used for publishing) — not required today.
 X_API_KEY=
+
+# Instagram, Threads, and Facebook Page publishing are all Meta Graph API
+# products registered under one Meta developer app (developers.facebook.com)
+# — they share one client id/secret pair rather than each getting its own.
+META_APP_ID=
+META_APP_SECRET=
+INSTAGRAM_REDIRECT_URI=http://localhost:8000/oauth/instagram/callback
+THREADS_REDIRECT_URI=http://localhost:8000/oauth/threads/callback
+FACEBOOK_REDIRECT_URI=http://localhost:8000/oauth/facebook/callback
 # --- Pipeline trigger (Celery Beat, apps/api/worker.py) ---
 # Minutes ahead of a calendar event's target_datetime the pipeline trigger
 # job starts its pipeline run.

--- a/apps/api/config/__init__.py
+++ b/apps/api/config/__init__.py
@@ -36,6 +36,17 @@ class Settings(BaseSettings):
     # XProvider uses today.
     x_api_key: str | None = None
 
+    # Instagram, Threads, and Facebook Page publishing are all Meta Graph
+    # API products registered under one Meta developer app — unlike
+    # LinkedIn/X, they share a single client id/secret pair rather than
+    # each getting its own.
+    meta_app_id: str | None = None
+    meta_app_secret: str | None = None
+
+    instagram_redirect_uri: str | None = None
+    threads_redirect_uri: str | None = None
+    facebook_redirect_uri: str | None = None
+
     search_provider: str = "tavily"
     llm_provider: str = "openrouter"
     storage_provider: str = "supabase"

--- a/apps/api/models/content_calendar_event.py
+++ b/apps/api/models/content_calendar_event.py
@@ -8,9 +8,10 @@ from sqlalchemy.orm import Mapped, mapped_column
 
 from apps.api.config.database import Base
 
-# Platforms #30's publishing adapters actually support — kept in sync with
-# that issue's scope so this table can't hold events no adapter can publish.
-SUPPORTED_PLATFORMS = ("linkedin", "x")
+# Platforms #30/#108/#109/#110's publishing adapters actually support —
+# kept in sync with those issues' scope so this table can't hold events no
+# adapter can publish.
+SUPPORTED_PLATFORMS = ("linkedin", "x", "instagram", "threads", "facebook")
 
 
 class CalendarEventStatus(str, enum.Enum):

--- a/apps/api/models/social_account.py
+++ b/apps/api/models/social_account.py
@@ -11,6 +11,9 @@ from apps.api.config.database import Base
 
 class SocialPlatform(str, enum.Enum):
     LINKEDIN = "linkedin"
+    INSTAGRAM = "instagram"
+    THREADS = "threads"
+    FACEBOOK = "facebook"
 
 
 class SocialAccountStatus(str, enum.Enum):

--- a/apps/api/routers/social_accounts.py
+++ b/apps/api/routers/social_accounts.py
@@ -19,7 +19,7 @@ router = APIRouter(tags=["social-accounts"])
 
 WRITE_ROLES = (UserRole.OWNER, UserRole.ADMIN, UserRole.EDITOR)
 
-STATE_PURPOSE = "linkedin_oauth_connect"
+STATE_PURPOSE = "social_oauth_connect"
 STATE_EXPIRES_MINUTES = 10
 
 
@@ -160,6 +160,142 @@ def linkedin_callback(
     db.flush()
     db.refresh(account)
     return account
+
+
+def _connect_platform(
+    db: Session,
+    brand_id: uuid.UUID,
+    current_user: CurrentUser,
+    platform: str,
+    redirect_uri: str | None,
+) -> AuthorizeUrlRead:
+    """Shared body for the Instagram/Threads/Facebook /connect endpoints
+    below — identical in shape to connect_linkedin above, just
+    parameterized by platform since all three are wired the same way."""
+    _get_org_brand(db, brand_id, current_user.org_id)
+    if not redirect_uri:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=f"{platform.capitalize()} OAuth is not configured",
+        )
+
+    provider = get_social_oauth_provider(platform)
+    state = _create_state(brand_id)
+    url = provider.authorize_url(state=state, redirect_uri=redirect_uri)
+    return AuthorizeUrlRead(authorize_url=url)
+
+
+def _platform_callback(
+    db: Session,
+    code: str,
+    state: str,
+    platform: str,
+    redirect_uri: str | None,
+    social_platform: SocialPlatform,
+) -> SocialAccount:
+    """Shared body for the Instagram/Threads/Facebook OAuth callbacks below
+    — identical in shape to linkedin_callback above, just parameterized by
+    platform since all three are wired the same way."""
+    brand_id = _verify_state(state)
+    provider = get_social_oauth_provider(platform)
+    tokens = provider.exchange_code(code=code, redirect_uri=redirect_uri or "")
+
+    account = (
+        db.query(SocialAccount)
+        .filter(SocialAccount.brand_id == brand_id, SocialAccount.platform == social_platform)
+        .first()
+    )
+    if account is None:
+        account = SocialAccount(brand_id=brand_id, platform=social_platform)
+        db.add(account)
+
+    account.external_account_id = tokens.external_account_id
+    account.access_token_encrypted = encrypt_token(tokens.access_token)
+    account.refresh_token_encrypted = (
+        encrypt_token(tokens.refresh_token) if tokens.refresh_token else None
+    )
+    account.token_expires_at = tokens.expires_at
+    account.scopes = tokens.scopes
+    account.status = SocialAccountStatus.ACTIVE
+
+    db.flush()
+    db.refresh(account)
+    return account
+
+
+@router.post(
+    "/brands/{brand_id}/social-accounts/instagram/connect",
+    response_model=AuthorizeUrlRead,
+)
+def connect_instagram(
+    brand_id: uuid.UUID,
+    db: Session = Depends(get_db),
+    current_user: CurrentUser = Depends(require_role(*WRITE_ROLES)),
+) -> AuthorizeUrlRead:
+    settings = get_settings()
+    return _connect_platform(db, brand_id, current_user, "instagram", settings.instagram_redirect_uri)
+
+
+@router.get("/oauth/instagram/callback", response_model=SocialAccountRead)
+def instagram_callback(
+    code: str = Query(...),
+    state: str = Query(...),
+    db: Session = Depends(get_db),
+) -> SocialAccount:
+    settings = get_settings()
+    return _platform_callback(
+        db, code, state, "instagram", settings.instagram_redirect_uri, SocialPlatform.INSTAGRAM
+    )
+
+
+@router.post(
+    "/brands/{brand_id}/social-accounts/threads/connect",
+    response_model=AuthorizeUrlRead,
+)
+def connect_threads(
+    brand_id: uuid.UUID,
+    db: Session = Depends(get_db),
+    current_user: CurrentUser = Depends(require_role(*WRITE_ROLES)),
+) -> AuthorizeUrlRead:
+    settings = get_settings()
+    return _connect_platform(db, brand_id, current_user, "threads", settings.threads_redirect_uri)
+
+
+@router.get("/oauth/threads/callback", response_model=SocialAccountRead)
+def threads_callback(
+    code: str = Query(...),
+    state: str = Query(...),
+    db: Session = Depends(get_db),
+) -> SocialAccount:
+    settings = get_settings()
+    return _platform_callback(
+        db, code, state, "threads", settings.threads_redirect_uri, SocialPlatform.THREADS
+    )
+
+
+@router.post(
+    "/brands/{brand_id}/social-accounts/facebook/connect",
+    response_model=AuthorizeUrlRead,
+)
+def connect_facebook(
+    brand_id: uuid.UUID,
+    db: Session = Depends(get_db),
+    current_user: CurrentUser = Depends(require_role(*WRITE_ROLES)),
+) -> AuthorizeUrlRead:
+    settings = get_settings()
+    return _connect_platform(db, brand_id, current_user, "facebook", settings.facebook_redirect_uri)
+
+
+@router.get("/oauth/facebook/callback", response_model=SocialAccountRead)
+def facebook_callback(
+    code: str = Query(...),
+    state: str = Query(...),
+    db: Session = Depends(get_db),
+) -> SocialAccount:
+    settings = get_settings()
+    return _platform_callback(
+        db, code, state, "facebook", settings.facebook_redirect_uri, SocialPlatform.FACEBOOK
+    )
 
 
 @router.post(

--- a/apps/api/tests/test_image_gen.py
+++ b/apps/api/tests/test_image_gen.py
@@ -15,12 +15,20 @@ Per the issue's acceptance criteria:
 
 import pathlib
 import uuid
+from datetime import datetime, timezone
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from apps.api.config import get_settings
-from apps.api.models import AgentType, Brand, IntegrationCall, Organization, Post
+from apps.api.models import (
+    AgentType,
+    Brand,
+    ContentCalendarEvent,
+    IntegrationCall,
+    Organization,
+    Post,
+)
 from packages.agents.pipeline.checkpointer import get_postgres_checkpointer
 from packages.agents.pipeline.graph import run_pipeline
 from packages.agents.pipeline.nodes.generation_engine import (
@@ -361,9 +369,26 @@ def test_image_generation_failure_does_not_crash_run_pipeline(db_session, thread
     post = _setup_post(db_session)
     thread_cleanup.append(str(post.id))
 
-    # No calendar_event_id on this Post, so Creative Engine falls back to
-    # SUPPORTED_PLATFORMS ("linkedin", "x") — both platform briefs must be
-    # mocked or Creative Engine's own parse-failure fallback kicks in.
+    # Issues #108/#109/#110 grew SUPPORTED_PLATFORMS beyond ("linkedin",
+    # "x") to also cover Instagram/Threads/Facebook — pin this post's
+    # target_platforms explicitly via a calendar event (same as a real
+    # scheduled post would have) so Research/Creative Engine's "no
+    # calendar event" -> "all SUPPORTED_PLATFORMS" fallback doesn't pull
+    # in platforms this test's LLM mocks don't cover, which would
+    # otherwise fall through to Creative/Generation Engine's own
+    # parse-failure fallback for those extra platforms.
+    calendar_event = ContentCalendarEvent(
+        brand_id=post.brand_id,
+        title="Test event",
+        target_platforms=["linkedin", "x"],
+        desired_format="image",
+        target_datetime=datetime.now(timezone.utc),
+    )
+    db_session.add(calendar_event)
+    db_session.flush()
+    post.calendar_event_id = calendar_event.id
+    db_session.flush()
+
     with (
         patch(SEARCH_PATCH_TARGET) as mock_search,
         patch(EMBED_PATCH_TARGET) as mock_embed,

--- a/apps/api/tests/test_integrations_registry.py
+++ b/apps/api/tests/test_integrations_registry.py
@@ -11,7 +11,10 @@ from packages.integrations.registry import (
     get_social_oauth_provider,
 )
 from packages.integrations.search.tavily import TavilyProvider
+from packages.integrations.social.facebook_provider import FacebookProvider
+from packages.integrations.social.instagram_provider import InstagramProvider
 from packages.integrations.social.linkedin_provider import LinkedInProvider
+from packages.integrations.social.threads_provider import ThreadsProvider
 
 
 @pytest.fixture(autouse=True)
@@ -53,6 +56,32 @@ def test_get_social_oauth_provider_resolves_linkedin() -> None:
 def test_unknown_social_platform_raises() -> None:
     with pytest.raises(ValueError, match="Unknown social platform"):
         get_social_oauth_provider("tiktok")
+
+
+def test_get_social_oauth_provider_resolves_instagram() -> None:
+    assert isinstance(get_social_oauth_provider("instagram"), InstagramProvider)
+
+
+def test_get_social_oauth_provider_resolves_threads() -> None:
+    assert isinstance(get_social_oauth_provider("threads"), ThreadsProvider)
+
+
+def test_get_social_oauth_provider_resolves_facebook() -> None:
+    assert isinstance(get_social_oauth_provider("facebook"), FacebookProvider)
+
+
+def test_meta_oauth_providers_share_meta_app_credentials(monkeypatch) -> None:
+    # Issue #108/#109/#110: Instagram/Threads/Facebook are all Meta Graph
+    # API products registered under one Meta developer app, so they read
+    # META_APP_ID/META_APP_SECRET rather than each getting a dedicated
+    # client id/secret pair the way LinkedIn/X do.
+    monkeypatch.setenv("META_APP_ID", "shared-app-id")
+    monkeypatch.setenv("META_APP_SECRET", "shared-app-secret")
+
+    for platform in ("instagram", "threads", "facebook"):
+        provider = get_social_oauth_provider(platform)
+        assert provider.client_id == "shared-app-id"
+        assert provider.client_secret == "shared-app-secret"
 
 
 def test_get_embedding_provider_defaults_to_openai() -> None:

--- a/apps/api/tests/test_publishing_adapters.py
+++ b/apps/api/tests/test_publishing_adapters.py
@@ -7,20 +7,33 @@ import pytest
 from apps.api.models import IntegrationCall
 from packages.integrations.registry import get_social_publisher
 from packages.integrations.social.base import PublishResult, SocialPublisher
+from packages.integrations.social.facebook_provider import FacebookProvider
+from packages.integrations.social.instagram_provider import InstagramProvider
 from packages.integrations.social.linkedin_provider import LinkedInProvider
+from packages.integrations.social.threads_provider import ThreadsProvider
 from packages.integrations.social.x_provider import XProvider
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 
-# Domains only linkedin_provider.py / x_provider.py are allowed to
-# reference — everything else must go through SocialPublisher /
-# SocialOAuthProvider instead of talking to the vendor directly.
+# Domains only the matching provider file is allowed to reference —
+# everything else must go through SocialPublisher / SocialOAuthProvider
+# instead of talking to the vendor directly. Instagram/Facebook share
+# facebook.com/graph.facebook.com (same Meta Graph API host), so both
+# provider files are listed for that marker.
 VENDOR_MARKERS = {
-    "linkedin.com": "linkedin_provider.py",
-    "twitter.com": "x_provider.py",
+    "linkedin.com": ("linkedin_provider.py",),
+    "twitter.com": ("x_provider.py",),
+    "facebook.com": ("facebook_provider.py", "instagram_provider.py"),
+    "threads.net": ("threads_provider.py",),
 }
 
-ALLOWED_FILES = {"linkedin_provider.py", "x_provider.py"}
+ALLOWED_FILES = {
+    "linkedin_provider.py",
+    "x_provider.py",
+    "facebook_provider.py",
+    "instagram_provider.py",
+    "threads_provider.py",
+}
 
 
 def _mock_response(json_data: dict | None = None, status_code: int = 200, headers=None) -> MagicMock:
@@ -63,6 +76,33 @@ def test_registry_resolves_x_publisher() -> None:
     assert isinstance(get_social_publisher("x"), XProvider)
 
 
+def test_facebook_provider_implements_social_publisher() -> None:
+    provider = FacebookProvider(client_id="cid", client_secret="secret")
+    assert isinstance(provider, SocialPublisher)
+
+
+def test_instagram_provider_implements_social_publisher() -> None:
+    provider = InstagramProvider(client_id="cid", client_secret="secret")
+    assert isinstance(provider, SocialPublisher)
+
+
+def test_threads_provider_implements_social_publisher() -> None:
+    provider = ThreadsProvider(client_id="cid", client_secret="secret")
+    assert isinstance(provider, SocialPublisher)
+
+
+def test_registry_resolves_facebook_publisher() -> None:
+    assert isinstance(get_social_publisher("facebook"), FacebookProvider)
+
+
+def test_registry_resolves_instagram_publisher() -> None:
+    assert isinstance(get_social_publisher("instagram"), InstagramProvider)
+
+
+def test_registry_resolves_threads_publisher() -> None:
+    assert isinstance(get_social_publisher("threads"), ThreadsProvider)
+
+
 def test_registry_unknown_platform_raises() -> None:
     with pytest.raises(ValueError, match="Unknown social platform"):
         get_social_publisher("tiktok")
@@ -84,7 +124,7 @@ def test_no_other_file_references_linkedin_or_x_vendor_urls() -> None:
             text = py_file.read_text()
         except (UnicodeDecodeError, OSError):
             continue
-        for marker in ("linkedin.com", "twitter.com", "api.x.com", "://x.com"):
+        for marker in (*VENDOR_MARKERS, "api.x.com", "://x.com"):
             if marker in text:
                 offenders.append(f"{py_file.relative_to(REPO_ROOT)} references {marker!r}")
     assert offenders == [], "\n".join(offenders)
@@ -695,6 +735,835 @@ def test_x_get_engagement_logs_integration_call(db_session) -> None:
     logged = (
         db_session.query(IntegrationCall)
         .filter_by(provider="x", capability="get_engagement")
+        .order_by(IntegrationCall.created_at.desc())
+        .first()
+    )
+    assert logged is not None
+    assert logged.success is True
+
+
+# ---------------------------------------------------------------------
+# Facebook: OAuth-connection interface, same shape as LinkedIn/X's above —
+# exercised here for coverage since #110 is what introduces FacebookProvider.
+# ---------------------------------------------------------------------
+
+
+def test_facebook_authorize_url_includes_state_and_scopes() -> None:
+    provider = FacebookProvider(client_id="cid", client_secret="secret")
+    url = provider.authorize_url(state="signed-state", redirect_uri="https://app.test/callback")
+
+    assert url.startswith(FacebookProvider.AUTHORIZE_URL)
+    assert "client_id=cid" in url
+    assert "state=signed-state" in url
+    assert "pages_manage_posts" in url
+
+
+def test_facebook_exchange_code_returns_tokens_and_fetches_page_id() -> None:
+    provider = FacebookProvider(client_id="cid", client_secret="secret")
+    token_response = _mock_response({"access_token": "at-123", "expires_in": 5184000})
+    page_response = _mock_response({"id": "page-42", "name": "Acme Page"})
+
+    with patch("httpx.post", return_value=token_response), patch(
+        "httpx.get", return_value=page_response
+    ):
+        tokens = provider.exchange_code(code="auth-code", redirect_uri="https://app.test/callback")
+
+    assert tokens.access_token == "at-123"
+    assert tokens.refresh_token is None
+    assert tokens.external_account_id == "page-42"
+    assert tokens.expires_at is not None
+
+
+def test_facebook_is_token_valid_true_on_200() -> None:
+    provider = FacebookProvider(client_id="cid", client_secret="secret")
+    with patch("httpx.get", return_value=_mock_response({"id": "page-42"}, status_code=200)):
+        assert provider.is_token_valid("some-token") is True
+
+
+def test_facebook_is_token_valid_false_when_platform_rejects_it() -> None:
+    provider = FacebookProvider(client_id="cid", client_secret="secret")
+    with patch("httpx.get", return_value=_mock_response(status_code=401)):
+        assert provider.is_token_valid("revoked-token") is False
+
+
+# ---------------------------------------------------------------------
+# Facebook: successful publish
+# ---------------------------------------------------------------------
+
+
+def test_facebook_publish_success_returns_populated_result(db_session) -> None:
+    provider = FacebookProvider(client_id="cid", client_secret="secret")
+    page_response = _mock_response({"id": "page-42"})
+    post_response = _mock_response({"id": "page-42_999"})
+
+    with patch("httpx.get", return_value=page_response), patch(
+        "httpx.post", return_value=post_response
+    ):
+        result = provider.publish(access_token="good-token", content="hello world")
+
+    assert isinstance(result, PublishResult)
+    assert result.success is True
+    assert result.platform_post_id == "page-42_999"
+    assert result.platform_post_url is not None
+    assert result.error is None
+    assert result.refreshed_tokens is None
+
+
+def test_facebook_publish_success_logs_integration_call(db_session) -> None:
+    provider = FacebookProvider(client_id="cid", client_secret="secret")
+    page_response = _mock_response({"id": "page-42"})
+    post_response = _mock_response({"id": "page-42_999"})
+
+    with patch("httpx.get", return_value=page_response), patch(
+        "httpx.post", return_value=post_response
+    ):
+        provider.publish(access_token="good-token", content="hello world")
+
+    logged = (
+        db_session.query(IntegrationCall)
+        .filter_by(provider="facebook", capability="publish")
+        .order_by(IntegrationCall.created_at.desc())
+        .first()
+    )
+    assert logged is not None
+    assert logged.success is True
+
+
+def test_facebook_publish_includes_link_when_media_urls_given(db_session) -> None:
+    provider = FacebookProvider(client_id="cid", client_secret="secret")
+    page_response = _mock_response({"id": "page-42"})
+    post_response = _mock_response({"id": "page-42_999"})
+
+    with patch("httpx.get", return_value=page_response), patch(
+        "httpx.post", return_value=post_response
+    ) as mock_post:
+        result = provider.publish(
+            access_token="good-token",
+            content="hello world",
+            media_urls=["https://cdn.test/image.png"],
+        )
+
+    assert result.success is True
+    assert mock_post.call_args.kwargs["json"]["link"] == "https://cdn.test/image.png"
+
+
+# ---------------------------------------------------------------------
+# Facebook: expired token -> transparent refresh + retry
+# ---------------------------------------------------------------------
+
+
+def test_facebook_publish_refreshes_and_retries_once_on_expired_token(db_session) -> None:
+    provider = FacebookProvider(client_id="cid", client_secret="secret")
+
+    expired_page_response = _mock_response(status_code=401)
+    refresh_response = _mock_response({"access_token": "new-token", "expires_in": 5184000})
+    retry_page_response = _mock_response({"id": "page-42"})
+    retry_post_response = _mock_response({"id": "page-42_777"})
+
+    get_calls = [expired_page_response, retry_page_response]
+    post_calls = [refresh_response, retry_post_response]
+
+    with patch("httpx.get", side_effect=get_calls) as mock_get, patch(
+        "httpx.post", side_effect=post_calls
+    ) as mock_post:
+        result = provider.publish(
+            access_token="stale-token", content="hello world", refresh_token="prior-long-lived-token"
+        )
+
+    assert result.success is True
+    assert result.platform_post_id == "page-42_777"
+    assert result.refreshed_tokens is not None
+    assert result.refreshed_tokens.access_token == "new-token"
+    assert mock_get.call_count == 2
+    assert mock_post.call_count == 2
+
+
+def test_facebook_publish_expired_token_not_surfaced_as_failure(db_session) -> None:
+    provider = FacebookProvider(client_id="cid", client_secret="secret")
+
+    get_calls = [_mock_response(status_code=401), _mock_response({"id": "page-42"})]
+    post_calls = [
+        _mock_response({"access_token": "new-token"}),
+        _mock_response({"id": "id-1"}),
+    ]
+
+    with patch("httpx.get", side_effect=get_calls), patch("httpx.post", side_effect=post_calls):
+        result = provider.publish(
+            access_token="stale-token", content="hello world", refresh_token="prior-token"
+        )
+
+    assert result.success is True
+    assert result.error is None
+
+
+def test_facebook_publish_expired_token_without_refresh_token_fails(db_session) -> None:
+    provider = FacebookProvider(client_id="cid", client_secret="secret")
+
+    with patch("httpx.get", return_value=_mock_response(status_code=401)):
+        result = provider.publish(access_token="stale-token", content="hello world")
+
+    assert result.success is False
+    assert result.error is not None
+    assert "refresh" in result.error.lower()
+
+
+def test_facebook_publish_refresh_failure_surfaces_as_real_failure(db_session) -> None:
+    provider = FacebookProvider(client_id="cid", client_secret="secret")
+
+    with patch("httpx.get", return_value=_mock_response(status_code=401)), patch(
+        "httpx.post", return_value=_mock_response(status_code=400)
+    ):
+        result = provider.publish(
+            access_token="stale-token", content="hello world", refresh_token="bad-token"
+        )
+
+    assert result.success is False
+    assert result.error is not None
+
+
+# ---------------------------------------------------------------------
+# Facebook: hard (non-token) failures
+# ---------------------------------------------------------------------
+
+
+def test_facebook_publish_hard_http_failure_returns_failed_result(db_session) -> None:
+    provider = FacebookProvider(client_id="cid", client_secret="secret")
+
+    with patch("httpx.get", return_value=_mock_response({"id": "page-42"})), patch(
+        "httpx.post", return_value=_mock_response(status_code=500)
+    ):
+        result = provider.publish(access_token="good-token", content="hello world")
+
+    assert result.success is False
+    assert result.error is not None
+
+
+def test_facebook_publish_hard_failure_logged(db_session) -> None:
+    provider = FacebookProvider(client_id="cid", client_secret="secret")
+
+    with patch("httpx.get", return_value=_mock_response({"id": "page-42"})), patch(
+        "httpx.post", return_value=_mock_response(status_code=500)
+    ):
+        provider.publish(access_token="good-token", content="hello world")
+
+    logged = (
+        db_session.query(IntegrationCall)
+        .filter_by(provider="facebook", capability="publish")
+        .order_by(IntegrationCall.created_at.desc())
+        .first()
+    )
+    assert logged is not None
+    assert logged.success is False
+    assert logged.error_message is not None
+
+
+# ---------------------------------------------------------------------
+# Facebook: get_engagement()
+# ---------------------------------------------------------------------
+
+
+def test_facebook_get_engagement_success_returns_metrics(db_session) -> None:
+    provider = FacebookProvider(client_id="cid", client_secret="secret")
+
+    with patch(
+        "httpx.get",
+        return_value=_mock_response(
+            {
+                "likes": {"summary": {"total_count": 10}},
+                "comments": {"summary": {"total_count": 4}},
+                "shares": {"count": 2},
+            }
+        ),
+    ):
+        result = provider.get_engagement(access_token="good-token", platform_post_id="page-42_999")
+
+    assert result.success is True
+    assert result.rate_limited is False
+    assert result.metrics.likes == 10
+    assert result.metrics.comments == 4
+    assert result.metrics.shares == 2
+    assert result.metrics.impressions == 0
+
+
+def test_facebook_get_engagement_rate_limited_returns_flag_not_raise(db_session) -> None:
+    provider = FacebookProvider(client_id="cid", client_secret="secret")
+
+    with patch("httpx.get", return_value=_mock_response(status_code=429)):
+        result = provider.get_engagement(access_token="good-token", platform_post_id="page-42_999")
+
+    assert result.success is False
+    assert result.rate_limited is True
+    assert result.metrics is None
+
+
+def test_facebook_get_engagement_hard_http_failure_returns_failed_result(db_session) -> None:
+    provider = FacebookProvider(client_id="cid", client_secret="secret")
+
+    with patch("httpx.get", return_value=_mock_response(status_code=500)):
+        result = provider.get_engagement(access_token="good-token", platform_post_id="page-42_999")
+
+    assert result.success is False
+    assert result.rate_limited is False
+    assert result.error is not None
+
+
+def test_facebook_get_engagement_logs_integration_call(db_session) -> None:
+    provider = FacebookProvider(client_id="cid", client_secret="secret")
+
+    with patch(
+        "httpx.get",
+        return_value=_mock_response(
+            {"likes": {"summary": {"total_count": 1}}, "comments": {"summary": {"total_count": 0}}, "shares": {"count": 0}}
+        ),
+    ):
+        provider.get_engagement(access_token="good-token", platform_post_id="page-42_999")
+
+    logged = (
+        db_session.query(IntegrationCall)
+        .filter_by(provider="facebook", capability="get_engagement")
+        .order_by(IntegrationCall.created_at.desc())
+        .first()
+    )
+    assert logged is not None
+    assert logged.success is True
+
+
+# ---------------------------------------------------------------------
+# Instagram: OAuth-connection interface
+# ---------------------------------------------------------------------
+
+
+def test_instagram_authorize_url_includes_state_and_scopes() -> None:
+    provider = InstagramProvider(client_id="cid", client_secret="secret")
+    url = provider.authorize_url(state="signed-state", redirect_uri="https://app.test/callback")
+
+    assert url.startswith(InstagramProvider.AUTHORIZE_URL)
+    assert "client_id=cid" in url
+    assert "state=signed-state" in url
+    assert "instagram_content_publish" in url
+
+
+def test_instagram_exchange_code_returns_tokens_and_fetches_ig_user_id() -> None:
+    provider = InstagramProvider(client_id="cid", client_secret="secret")
+    token_response = _mock_response({"access_token": "at-123", "expires_in": 5184000})
+    accounts_response = _mock_response(
+        {"data": [{"id": "page-1", "instagram_business_account": {"id": "17841400000000000"}}]}
+    )
+
+    with patch("httpx.post", return_value=token_response), patch(
+        "httpx.get", return_value=accounts_response
+    ):
+        tokens = provider.exchange_code(code="auth-code", redirect_uri="https://app.test/callback")
+
+    assert tokens.access_token == "at-123"
+    assert tokens.external_account_id == "17841400000000000"
+
+
+def test_instagram_exchange_code_handles_no_linked_ig_account() -> None:
+    provider = InstagramProvider(client_id="cid", client_secret="secret")
+    token_response = _mock_response({"access_token": "at-123"})
+    accounts_response = _mock_response({"data": [{"id": "page-1"}]})
+
+    with patch("httpx.post", return_value=token_response), patch(
+        "httpx.get", return_value=accounts_response
+    ):
+        tokens = provider.exchange_code(code="auth-code", redirect_uri="https://app.test/callback")
+
+    assert tokens.external_account_id is None
+
+
+def test_instagram_is_token_valid_true_on_200() -> None:
+    provider = InstagramProvider(client_id="cid", client_secret="secret")
+    with patch("httpx.get", return_value=_mock_response({"data": []}, status_code=200)):
+        assert provider.is_token_valid("some-token") is True
+
+
+def test_instagram_is_token_valid_false_when_platform_rejects_it() -> None:
+    provider = InstagramProvider(client_id="cid", client_secret="secret")
+    with patch("httpx.get", return_value=_mock_response(status_code=401)):
+        assert provider.is_token_valid("revoked-token") is False
+
+
+# ---------------------------------------------------------------------
+# Instagram: publish requires media
+# ---------------------------------------------------------------------
+
+
+def test_instagram_publish_without_media_fails_without_any_http_call() -> None:
+    provider = InstagramProvider(client_id="cid", client_secret="secret")
+
+    with patch("httpx.get") as mock_get, patch("httpx.post") as mock_post:
+        result = provider.publish(access_token="good-token", content="hello world")
+
+    assert result.success is False
+    assert "media" in result.error.lower()
+    mock_get.assert_not_called()
+    mock_post.assert_not_called()
+
+
+# ---------------------------------------------------------------------
+# Instagram: successful publish (two-step container -> publish)
+# ---------------------------------------------------------------------
+
+
+def test_instagram_publish_success_returns_populated_result(db_session) -> None:
+    provider = InstagramProvider(client_id="cid", client_secret="secret")
+    accounts_response = _mock_response(
+        {"data": [{"id": "page-1", "instagram_business_account": {"id": "ig-user-1"}}]}
+    )
+    container_response = _mock_response({"id": "container-1"})
+    publish_response = _mock_response({"id": "ig-post-1"})
+
+    with patch("httpx.get", return_value=accounts_response), patch(
+        "httpx.post", side_effect=[container_response, publish_response]
+    ):
+        result = provider.publish(
+            access_token="good-token",
+            content="hello world",
+            media_urls=["https://cdn.test/photo.png"],
+        )
+
+    assert isinstance(result, PublishResult)
+    assert result.success is True
+    assert result.platform_post_id == "ig-post-1"
+    assert result.platform_post_url is not None
+    assert result.error is None
+
+
+def test_instagram_publish_success_logs_integration_call(db_session) -> None:
+    provider = InstagramProvider(client_id="cid", client_secret="secret")
+    accounts_response = _mock_response(
+        {"data": [{"id": "page-1", "instagram_business_account": {"id": "ig-user-1"}}]}
+    )
+    container_response = _mock_response({"id": "container-1"})
+    publish_response = _mock_response({"id": "ig-post-1"})
+
+    with patch("httpx.get", return_value=accounts_response), patch(
+        "httpx.post", side_effect=[container_response, publish_response]
+    ):
+        provider.publish(
+            access_token="good-token",
+            content="hello world",
+            media_urls=["https://cdn.test/photo.png"],
+        )
+
+    logged = (
+        db_session.query(IntegrationCall)
+        .filter_by(provider="instagram", capability="publish")
+        .order_by(IntegrationCall.created_at.desc())
+        .first()
+    )
+    assert logged is not None
+    assert logged.success is True
+
+
+def test_instagram_publish_fails_when_no_ig_account_linked(db_session) -> None:
+    provider = InstagramProvider(client_id="cid", client_secret="secret")
+    accounts_response = _mock_response({"data": [{"id": "page-1"}]})
+
+    with patch("httpx.get", return_value=accounts_response), patch("httpx.post") as mock_post:
+        result = provider.publish(
+            access_token="good-token",
+            content="hello world",
+            media_urls=["https://cdn.test/photo.png"],
+        )
+
+    assert result.success is False
+    assert "instagram" in result.error.lower()
+    mock_post.assert_not_called()
+
+
+# ---------------------------------------------------------------------
+# Instagram: expired token -> transparent refresh + retry
+# ---------------------------------------------------------------------
+
+
+def test_instagram_publish_refreshes_and_retries_once_on_expired_token(db_session) -> None:
+    provider = InstagramProvider(client_id="cid", client_secret="secret")
+
+    expired_accounts_response = _mock_response(status_code=401)
+    retry_accounts_response = _mock_response(
+        {"data": [{"id": "page-1", "instagram_business_account": {"id": "ig-user-1"}}]}
+    )
+    refresh_response = _mock_response({"access_token": "new-token", "expires_in": 5184000})
+    container_response = _mock_response({"id": "container-1"})
+    publish_response = _mock_response({"id": "ig-post-9"})
+
+    get_calls = [expired_accounts_response, retry_accounts_response]
+    post_calls = [refresh_response, container_response, publish_response]
+
+    with patch("httpx.get", side_effect=get_calls) as mock_get, patch(
+        "httpx.post", side_effect=post_calls
+    ) as mock_post:
+        result = provider.publish(
+            access_token="stale-token",
+            content="hello world",
+            media_urls=["https://cdn.test/photo.png"],
+            refresh_token="prior-long-lived-token",
+        )
+
+    assert result.success is True
+    assert result.platform_post_id == "ig-post-9"
+    assert result.refreshed_tokens is not None
+    assert result.refreshed_tokens.access_token == "new-token"
+    assert mock_get.call_count == 2
+    assert mock_post.call_count == 3
+
+
+def test_instagram_publish_expired_token_without_refresh_token_fails(db_session) -> None:
+    provider = InstagramProvider(client_id="cid", client_secret="secret")
+
+    with patch("httpx.get", return_value=_mock_response(status_code=401)):
+        result = provider.publish(
+            access_token="stale-token",
+            content="hello world",
+            media_urls=["https://cdn.test/photo.png"],
+        )
+
+    assert result.success is False
+    assert "refresh" in result.error.lower()
+
+
+def test_instagram_publish_refresh_failure_surfaces_as_real_failure(db_session) -> None:
+    provider = InstagramProvider(client_id="cid", client_secret="secret")
+
+    with patch("httpx.get", return_value=_mock_response(status_code=401)), patch(
+        "httpx.post", return_value=_mock_response(status_code=400)
+    ):
+        result = provider.publish(
+            access_token="stale-token",
+            content="hello world",
+            media_urls=["https://cdn.test/photo.png"],
+            refresh_token="bad-token",
+        )
+
+    assert result.success is False
+    assert result.error is not None
+
+
+# ---------------------------------------------------------------------
+# Instagram: hard (non-token) failures
+# ---------------------------------------------------------------------
+
+
+def test_instagram_publish_hard_http_failure_returns_failed_result(db_session) -> None:
+    provider = InstagramProvider(client_id="cid", client_secret="secret")
+    accounts_response = _mock_response(
+        {"data": [{"id": "page-1", "instagram_business_account": {"id": "ig-user-1"}}]}
+    )
+
+    with patch("httpx.get", return_value=accounts_response), patch(
+        "httpx.post", return_value=_mock_response(status_code=500)
+    ):
+        result = provider.publish(
+            access_token="good-token",
+            content="hello world",
+            media_urls=["https://cdn.test/photo.png"],
+        )
+
+    assert result.success is False
+    assert result.error is not None
+
+
+# ---------------------------------------------------------------------
+# Instagram: get_engagement()
+# ---------------------------------------------------------------------
+
+
+def test_instagram_get_engagement_success_returns_metrics(db_session) -> None:
+    provider = InstagramProvider(client_id="cid", client_secret="secret")
+
+    with patch(
+        "httpx.get",
+        return_value=_mock_response(
+            {
+                "data": [
+                    {"name": "likes", "values": [{"value": 12}]},
+                    {"name": "comments", "values": [{"value": 3}]},
+                    {"name": "saved", "values": [{"value": 5}]},
+                    {"name": "impressions", "values": [{"value": 400}]},
+                ]
+            }
+        ),
+    ):
+        result = provider.get_engagement(access_token="good-token", platform_post_id="ig-post-1")
+
+    assert result.success is True
+    assert result.metrics.likes == 12
+    assert result.metrics.comments == 3
+    assert result.metrics.shares == 5
+    assert result.metrics.impressions == 400
+
+
+def test_instagram_get_engagement_rate_limited_returns_flag_not_raise(db_session) -> None:
+    provider = InstagramProvider(client_id="cid", client_secret="secret")
+
+    with patch("httpx.get", return_value=_mock_response(status_code=429)):
+        result = provider.get_engagement(access_token="good-token", platform_post_id="ig-post-1")
+
+    assert result.success is False
+    assert result.rate_limited is True
+    assert result.metrics is None
+
+
+def test_instagram_get_engagement_logs_integration_call(db_session) -> None:
+    provider = InstagramProvider(client_id="cid", client_secret="secret")
+
+    with patch(
+        "httpx.get",
+        return_value=_mock_response({"data": [{"name": "likes", "values": [{"value": 1}]}]}),
+    ):
+        provider.get_engagement(access_token="good-token", platform_post_id="ig-post-1")
+
+    logged = (
+        db_session.query(IntegrationCall)
+        .filter_by(provider="instagram", capability="get_engagement")
+        .order_by(IntegrationCall.created_at.desc())
+        .first()
+    )
+    assert logged is not None
+    assert logged.success is True
+
+
+# ---------------------------------------------------------------------
+# Threads: OAuth-connection interface
+# ---------------------------------------------------------------------
+
+
+def test_threads_authorize_url_includes_state_and_scopes() -> None:
+    provider = ThreadsProvider(client_id="cid", client_secret="secret")
+    url = provider.authorize_url(state="signed-state", redirect_uri="https://app.test/callback")
+
+    assert url.startswith(ThreadsProvider.AUTHORIZE_URL)
+    assert "client_id=cid" in url
+    assert "state=signed-state" in url
+    assert "threads_content_publish" in url
+
+
+def test_threads_exchange_code_returns_tokens_from_response_directly() -> None:
+    # Unlike LinkedIn/X/Facebook/Instagram, Threads' token-exchange response
+    # includes user_id directly — no separate userinfo call is needed.
+    provider = ThreadsProvider(client_id="cid", client_secret="secret")
+    token_response = _mock_response(
+        {"access_token": "at-123", "user_id": 999888777, "expires_in": 3600}
+    )
+
+    with patch("httpx.post", return_value=token_response) as mock_post, patch(
+        "httpx.get"
+    ) as mock_get:
+        tokens = provider.exchange_code(code="auth-code", redirect_uri="https://app.test/callback")
+
+    assert tokens.access_token == "at-123"
+    assert tokens.external_account_id == "999888777"
+    assert tokens.expires_at is not None
+    mock_get.assert_not_called()
+    mock_post.assert_called_once()
+
+
+def test_threads_is_token_valid_true_on_200() -> None:
+    provider = ThreadsProvider(client_id="cid", client_secret="secret")
+    with patch("httpx.get", return_value=_mock_response({"id": "user-1"}, status_code=200)):
+        assert provider.is_token_valid("some-token") is True
+
+
+def test_threads_is_token_valid_false_when_platform_rejects_it() -> None:
+    provider = ThreadsProvider(client_id="cid", client_secret="secret")
+    with patch("httpx.get", return_value=_mock_response(status_code=401)):
+        assert provider.is_token_valid("revoked-token") is False
+
+
+# ---------------------------------------------------------------------
+# Threads: successful publish (two-step container -> publish, text-only ok)
+# ---------------------------------------------------------------------
+
+
+def test_threads_publish_success_returns_populated_result(db_session) -> None:
+    provider = ThreadsProvider(client_id="cid", client_secret="secret")
+    me_response = _mock_response({"id": "user-1"})
+    container_response = _mock_response({"id": "container-1"})
+    publish_response = _mock_response({"id": "thread-1"})
+
+    with patch("httpx.get", return_value=me_response), patch(
+        "httpx.post", side_effect=[container_response, publish_response]
+    ):
+        result = provider.publish(access_token="good-token", content="hello world")
+
+    assert isinstance(result, PublishResult)
+    assert result.success is True
+    assert result.platform_post_id == "thread-1"
+    assert result.platform_post_url is not None
+    assert result.error is None
+
+
+def test_threads_publish_success_logs_integration_call(db_session) -> None:
+    provider = ThreadsProvider(client_id="cid", client_secret="secret")
+    me_response = _mock_response({"id": "user-1"})
+    container_response = _mock_response({"id": "container-1"})
+    publish_response = _mock_response({"id": "thread-1"})
+
+    with patch("httpx.get", return_value=me_response), patch(
+        "httpx.post", side_effect=[container_response, publish_response]
+    ):
+        provider.publish(access_token="good-token", content="hello world")
+
+    logged = (
+        db_session.query(IntegrationCall)
+        .filter_by(provider="threads", capability="publish")
+        .order_by(IntegrationCall.created_at.desc())
+        .first()
+    )
+    assert logged is not None
+    assert logged.success is True
+
+
+def test_threads_publish_with_media_sets_image_body(db_session) -> None:
+    provider = ThreadsProvider(client_id="cid", client_secret="secret")
+    me_response = _mock_response({"id": "user-1"})
+    container_response = _mock_response({"id": "container-1"})
+    publish_response = _mock_response({"id": "thread-1"})
+
+    with patch("httpx.get", return_value=me_response), patch(
+        "httpx.post", side_effect=[container_response, publish_response]
+    ) as mock_post:
+        result = provider.publish(
+            access_token="good-token",
+            content="hello world",
+            media_urls=["https://cdn.test/image.png"],
+        )
+
+    assert result.success is True
+    first_call_body = mock_post.call_args_list[0].kwargs["json"]
+    assert first_call_body["media_type"] == "IMAGE"
+    assert first_call_body["image_url"] == "https://cdn.test/image.png"
+
+
+# ---------------------------------------------------------------------
+# Threads: expired token -> transparent refresh + retry
+# ---------------------------------------------------------------------
+
+
+def test_threads_publish_refreshes_and_retries_once_on_expired_token(db_session) -> None:
+    provider = ThreadsProvider(client_id="cid", client_secret="secret")
+
+    expired_me_response = _mock_response(status_code=401)
+    refresh_response = _mock_response({"access_token": "new-token", "expires_in": 5184000})
+    retry_me_response = _mock_response({"id": "user-1"})
+    container_response = _mock_response({"id": "container-1"})
+    publish_response = _mock_response({"id": "thread-9"})
+
+    get_calls = [expired_me_response, refresh_response, retry_me_response]
+    post_calls = [container_response, publish_response]
+
+    with patch("httpx.get", side_effect=get_calls) as mock_get, patch(
+        "httpx.post", side_effect=post_calls
+    ) as mock_post:
+        result = provider.publish(
+            access_token="stale-token", content="hello world", refresh_token="prior-token"
+        )
+
+    assert result.success is True
+    assert result.platform_post_id == "thread-9"
+    assert result.refreshed_tokens is not None
+    assert result.refreshed_tokens.access_token == "new-token"
+    assert mock_get.call_count == 3
+    assert mock_post.call_count == 2
+
+
+def test_threads_publish_expired_token_without_refresh_token_fails(db_session) -> None:
+    provider = ThreadsProvider(client_id="cid", client_secret="secret")
+
+    with patch("httpx.get", return_value=_mock_response(status_code=401)):
+        result = provider.publish(access_token="stale-token", content="hello world")
+
+    assert result.success is False
+    assert "refresh" in result.error.lower()
+
+
+def test_threads_publish_refresh_failure_surfaces_as_real_failure(db_session) -> None:
+    provider = ThreadsProvider(client_id="cid", client_secret="secret")
+
+    get_calls = [_mock_response(status_code=401), _mock_response(status_code=400)]
+
+    with patch("httpx.get", side_effect=get_calls):
+        result = provider.publish(
+            access_token="stale-token", content="hello world", refresh_token="bad-token"
+        )
+
+    assert result.success is False
+    assert result.error is not None
+
+
+# ---------------------------------------------------------------------
+# Threads: hard (non-token) failures
+# ---------------------------------------------------------------------
+
+
+def test_threads_publish_hard_http_failure_returns_failed_result(db_session) -> None:
+    provider = ThreadsProvider(client_id="cid", client_secret="secret")
+    me_response = _mock_response({"id": "user-1"})
+
+    with patch("httpx.get", return_value=me_response), patch(
+        "httpx.post", return_value=_mock_response(status_code=500)
+    ):
+        result = provider.publish(access_token="good-token", content="hello world")
+
+    assert result.success is False
+    assert result.error is not None
+
+
+# ---------------------------------------------------------------------
+# Threads: get_engagement()
+# ---------------------------------------------------------------------
+
+
+def test_threads_get_engagement_success_returns_metrics(db_session) -> None:
+    provider = ThreadsProvider(client_id="cid", client_secret="secret")
+
+    with patch(
+        "httpx.get",
+        return_value=_mock_response(
+            {
+                "data": [
+                    {"name": "likes", "values": [{"value": 7}]},
+                    {"name": "replies", "values": [{"value": 1}]},
+                    {"name": "reposts", "values": [{"value": 2}]},
+                    {"name": "views", "values": [{"value": 50}]},
+                ]
+            }
+        ),
+    ):
+        result = provider.get_engagement(access_token="good-token", platform_post_id="thread-1")
+
+    assert result.success is True
+    assert result.metrics.likes == 7
+    assert result.metrics.comments == 1
+    assert result.metrics.shares == 2
+    assert result.metrics.impressions == 50
+
+
+def test_threads_get_engagement_rate_limited_returns_flag_not_raise(db_session) -> None:
+    provider = ThreadsProvider(client_id="cid", client_secret="secret")
+
+    with patch("httpx.get", return_value=_mock_response(status_code=429)):
+        result = provider.get_engagement(access_token="good-token", platform_post_id="thread-1")
+
+    assert result.success is False
+    assert result.rate_limited is True
+    assert result.metrics is None
+
+
+def test_threads_get_engagement_logs_integration_call(db_session) -> None:
+    provider = ThreadsProvider(client_id="cid", client_secret="secret")
+
+    with patch(
+        "httpx.get",
+        return_value=_mock_response({"data": [{"name": "likes", "values": [{"value": 1}]}]}),
+    ):
+        provider.get_engagement(access_token="good-token", platform_post_id="thread-1")
+
+    logged = (
+        db_session.query(IntegrationCall)
+        .filter_by(provider="threads", capability="get_engagement")
         .order_by(IntegrationCall.created_at.desc())
         .first()
     )

--- a/apps/api/tests/test_social_accounts.py
+++ b/apps/api/tests/test_social_accounts.py
@@ -226,6 +226,141 @@ def test_disconnect_wipes_tokens_and_marks_revoked(db_session) -> None:
     assert account.refresh_token_encrypted is None
 
 
+@pytest.mark.parametrize(
+    ("platform", "env_var", "authorize_host"),
+    [
+        ("instagram", "INSTAGRAM_REDIRECT_URI", "https://www.facebook.com"),
+        ("threads", "THREADS_REDIRECT_URI", "https://threads.net"),
+        ("facebook", "FACEBOOK_REDIRECT_URI", "https://www.facebook.com"),
+    ],
+)
+@uses_test_session
+def test_meta_platform_connect_returns_authorize_url_with_signed_state(
+    db_session, monkeypatch, platform, env_var, authorize_host
+) -> None:
+    # Issues #108/#109/#110: Instagram/Threads/Facebook are wired the same
+    # way test_connect_returns_authorize_url_with_signed_state above proves
+    # LinkedIn is — one parametrized test rather than three near-identical
+    # copies.
+    from apps.api.config import get_settings
+
+    monkeypatch.setenv(env_var, f"http://localhost:8000/oauth/{platform}/callback")
+    get_settings.cache_clear()
+    brand, user = _setup_brand(db_session, suffix=f"-{platform}")
+
+    response = client.post(
+        f"/brands/{brand.id}/social-accounts/{platform}/connect", headers=_auth_headers(user)
+    )
+    get_settings.cache_clear()
+
+    assert response.status_code == 200
+    url = response.json()["authorize_url"]
+    assert url.startswith(authorize_host)
+    assert "state=" in url
+
+
+@pytest.mark.parametrize(
+    ("platform", "env_var"),
+    [
+        ("instagram", "INSTAGRAM_REDIRECT_URI"),
+        ("threads", "THREADS_REDIRECT_URI"),
+        ("facebook", "FACEBOOK_REDIRECT_URI"),
+    ],
+)
+@uses_test_session
+def test_meta_platform_connect_503_when_not_configured(
+    db_session, monkeypatch, platform, env_var
+) -> None:
+    from apps.api.config import get_settings
+
+    monkeypatch.delenv(env_var, raising=False)
+    get_settings.cache_clear()
+    brand, user = _setup_brand(db_session, suffix=f"-{platform}")
+
+    response = client.post(
+        f"/brands/{brand.id}/social-accounts/{platform}/connect", headers=_auth_headers(user)
+    )
+    get_settings.cache_clear()
+
+    assert response.status_code == 503
+
+
+@pytest.mark.parametrize(
+    "platform",
+    ["instagram", "threads", "facebook"],
+)
+@uses_test_session
+def test_meta_platform_viewer_cannot_connect(db_session, platform) -> None:
+    brand, viewer = _setup_brand(db_session, UserRole.VIEWER, suffix=f"-{platform}")
+
+    response = client.post(
+        f"/brands/{brand.id}/social-accounts/{platform}/connect", headers=_auth_headers(viewer)
+    )
+
+    assert response.status_code == 403
+
+
+@pytest.mark.parametrize(
+    "platform",
+    ["instagram", "threads", "facebook"],
+)
+@uses_test_session
+def test_meta_platform_callback_rejects_invalid_state(db_session, platform) -> None:
+    response = client.get(
+        f"/oauth/{platform}/callback", params={"code": "abc", "state": "not-a-valid-jwt"}
+    )
+
+    assert response.status_code == 400
+
+
+@pytest.mark.parametrize(
+    ("platform", "social_platform"),
+    [
+        ("instagram", SocialPlatform.INSTAGRAM),
+        ("threads", SocialPlatform.THREADS),
+        ("facebook", SocialPlatform.FACEBOOK),
+    ],
+)
+@uses_test_session
+def test_meta_platform_callback_stores_tokens_encrypted_not_plaintext(
+    db_session, platform, social_platform
+) -> None:
+    from apps.api.routers.social_accounts import _create_state
+
+    brand, _user = _setup_brand(db_session, suffix=f"-{platform}")
+    state = _create_state(brand.id)
+
+    fake_tokens = SocialTokens(
+        access_token="super-secret-access-token",
+        refresh_token=None,
+        expires_at=datetime.now(timezone.utc) + timedelta(days=60),
+        scopes=["basic"],
+        external_account_id=f"{platform}-account-123",
+    )
+
+    with patch(
+        "apps.api.routers.social_accounts.get_social_oauth_provider"
+    ) as mock_get_provider:
+        mock_get_provider.return_value.exchange_code.return_value = fake_tokens
+        response = client.get(
+            f"/oauth/{platform}/callback", params={"code": "auth-code", "state": state}
+        )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["external_account_id"] == f"{platform}-account-123"
+    assert body["status"] == "active"
+    assert "access_token" not in body
+
+    account = (
+        db_session.query(SocialAccount)
+        .filter(SocialAccount.brand_id == brand.id, SocialAccount.platform == social_platform)
+        .one()
+    )
+    assert account.access_token_encrypted != "super-secret-access-token"
+    assert "super-secret-access-token" not in account.access_token_encrypted
+
+
 @uses_test_session
 def test_cross_org_social_account_access_returns_404(db_session) -> None:
     brand, _owner = _setup_brand(db_session, UserRole.EDITOR, suffix="-1")

--- a/apps/api/tests/test_video_gen.py
+++ b/apps/api/tests/test_video_gen.py
@@ -27,6 +27,7 @@ llm.py / test_generation_engine.py's conventions:
 
 import pathlib
 import uuid
+from datetime import datetime, timezone
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -36,6 +37,7 @@ from apps.api.models import (
     AgentRun,
     AgentType,
     Brand,
+    ContentCalendarEvent,
     IntegrationCall,
     Organization,
     Post,
@@ -494,6 +496,26 @@ def test_pipeline_run_does_not_crash_when_video_provider_fails(db_session, threa
     post = _setup_post(db_session)
     thread_cleanup.append(str(post.id))
     brief = _creative_brief(linkedin_format="short_video", x_format="text_post")
+
+    # Issues #108/#109/#110 grew SUPPORTED_PLATFORMS beyond ("linkedin",
+    # "x") to also cover Instagram/Threads/Facebook — pin this post's
+    # target_platforms explicitly via a calendar event (same as a real
+    # scheduled post would have) so Research/Creative Engine's "no
+    # calendar event" -> "all SUPPORTED_PLATFORMS" fallback doesn't pull
+    # in platforms this test's LLM mocks don't cover, which would
+    # otherwise fall through to Creative/Generation Engine's own
+    # parse-failure fallback for those extra platforms.
+    calendar_event = ContentCalendarEvent(
+        brand_id=post.brand_id,
+        title="Test event",
+        target_platforms=["linkedin", "x"],
+        desired_format="short_video",
+        target_datetime=datetime.now(timezone.utc),
+    )
+    db_session.add(calendar_event)
+    db_session.flush()
+    post.calendar_event_id = calendar_event.id
+    db_session.flush()
 
     with (
         patch(SEARCH_PATCH_TARGET) as mock_search,

--- a/apps/web/__tests__/social-accounts-page.test.tsx
+++ b/apps/web/__tests__/social-accounts-page.test.tsx
@@ -118,6 +118,11 @@ describe("SocialAccountsPage", () => {
   it("shows an empty state when nothing is connected for the brand", async () => {
     renderPage();
 
+    // Wait for the actual fetch chain (AuthProvider -> BrandProvider ->
+    // this page's own fetchSocialAccounts) to settle before asserting —
+    // see the identical fix in onboarding-page.test.tsx for why a bare
+    // findByText can occasionally race a still-loading intermediate render.
+    await waitFor(() => expect(fetchSocialAccountsMock).toHaveBeenCalled());
     expect(await screen.findByText("No accounts connected")).toBeInTheDocument();
   });
 

--- a/apps/web/__tests__/social-accounts-page.test.tsx
+++ b/apps/web/__tests__/social-accounts-page.test.tsx
@@ -11,6 +11,9 @@ import type { SocialAccount } from "@/lib/api";
 const fetchBrandsMock = vi.fn();
 const fetchSocialAccountsMock = vi.fn();
 const connectLinkedInMock = vi.fn();
+const connectInstagramMock = vi.fn();
+const connectThreadsMock = vi.fn();
+const connectFacebookMock = vi.fn();
 const disconnectSocialAccountMock = vi.fn();
 
 vi.mock("@/lib/api", async () => {
@@ -20,6 +23,9 @@ vi.mock("@/lib/api", async () => {
     fetchBrands: (...args: unknown[]) => fetchBrandsMock(...args),
     fetchSocialAccounts: (...args: unknown[]) => fetchSocialAccountsMock(...args),
     connectLinkedIn: (...args: unknown[]) => connectLinkedInMock(...args),
+    connectInstagram: (...args: unknown[]) => connectInstagramMock(...args),
+    connectThreads: (...args: unknown[]) => connectThreadsMock(...args),
+    connectFacebook: (...args: unknown[]) => connectFacebookMock(...args),
     disconnectSocialAccount: (...args: unknown[]) => disconnectSocialAccountMock(...args),
   };
 });
@@ -78,6 +84,9 @@ describe("SocialAccountsPage", () => {
     fetchBrandsMock.mockReset();
     fetchSocialAccountsMock.mockReset();
     connectLinkedInMock.mockReset();
+    connectInstagramMock.mockReset();
+    connectThreadsMock.mockReset();
+    connectFacebookMock.mockReset();
     disconnectSocialAccountMock.mockReset();
     redirectToAuthorizeUrlMock.mockReset();
 
@@ -144,6 +153,59 @@ describe("SocialAccountsPage", () => {
     expect(redirectToAuthorizeUrlMock).not.toHaveBeenCalled();
     // Not a raw/generic backend error message anywhere on the page.
     expect(screen.queryByText("LinkedIn OAuth is not configured")).not.toBeInTheDocument();
+  });
+
+  it.each([
+    ["Instagram", connectInstagramMock, "https://www.facebook.com/v21.0/dialog/oauth?foo=bar"],
+    ["Threads", connectThreadsMock, "https://threads.net/oauth/authorize?foo=bar"],
+    ["Facebook", connectFacebookMock, "https://www.facebook.com/v21.0/dialog/oauth?foo=bar"],
+  ])("starts the %s OAuth flow and redirects to the authorize URL on success", async (label, mock, authorizeUrl) => {
+    mock.mockResolvedValue({ authorize_url: authorizeUrl });
+    const user = userEvent.setup();
+
+    renderPage();
+    await waitFor(() => expect(fetchSocialAccountsMock).toHaveBeenCalled());
+
+    await user.click(screen.getByRole("button", { name: `Connect ${label}` }));
+
+    await waitFor(() => {
+      expect(mock).toHaveBeenCalledWith("test-token", "brand-1");
+      expect(redirectToAuthorizeUrlMock).toHaveBeenCalledWith(authorizeUrl);
+    });
+  });
+
+  it.each([
+    ["Instagram", connectInstagramMock],
+    ["Threads", connectThreadsMock],
+    ["Facebook", connectFacebookMock],
+  ])("shows a friendly message instead of a generic error when %s isn't configured", async (label, mock) => {
+    mock.mockRejectedValue(new ApiError(`${label} OAuth is not configured`, 503));
+    const user = userEvent.setup();
+
+    renderPage();
+    await waitFor(() => expect(fetchSocialAccountsMock).toHaveBeenCalled());
+
+    await user.click(screen.getByRole("button", { name: `Connect ${label}` }));
+
+    expect(await screen.findByText(`${label} isn't configured on this server yet.`)).toBeInTheDocument();
+    expect(redirectToAuthorizeUrlMock).not.toHaveBeenCalled();
+  });
+
+  it("renders a status badge for a connected Instagram/Threads/Facebook account", async () => {
+    fetchSocialAccountsMock.mockResolvedValue([
+      makeAccount({ id: "a1", platform: "instagram", external_account_id: "ig-123" }),
+      makeAccount({ id: "a2", platform: "threads", external_account_id: "th-456" }),
+      makeAccount({ id: "a3", platform: "facebook", external_account_id: "fb-789" }),
+    ]);
+
+    renderPage();
+
+    expect(await screen.findByText("Instagram")).toBeInTheDocument();
+    expect(screen.getByText("Threads")).toBeInTheDocument();
+    expect(screen.getByText("Facebook")).toBeInTheDocument();
+    expect(screen.getByText("Account ID: ig-123")).toBeInTheDocument();
+    expect(screen.getByText("Account ID: th-456")).toBeInTheDocument();
+    expect(screen.getByText("Account ID: fb-789")).toBeInTheDocument();
   });
 
   it("disconnects an account only after the confirmation step is completed", async () => {

--- a/apps/web/app/social-accounts/page.tsx
+++ b/apps/web/app/social-accounts/page.tsx
@@ -1,9 +1,12 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useState, type ReactNode } from "react";
 import {
   ApiError,
+  connectFacebook,
+  connectInstagram,
   connectLinkedIn,
+  connectThreads,
   disconnectSocialAccount,
   fetchSocialAccounts,
   type AuthorizeUrlResponse,
@@ -28,22 +31,90 @@ import { redirectToAuthorizeUrl } from "./redirect";
 // platform still renders instead of breaking.
 const PLATFORM_LABELS: Partial<Record<SocialPlatform, string>> = {
   linkedin: "LinkedIn",
+  instagram: "Instagram",
+  threads: "Threads",
+  facebook: "Facebook",
 };
 
 function platformLabel(platform: SocialPlatform): string {
   return PLATFORM_LABELS[platform] ?? platform;
 }
 
-// Platforms the UI can start a connect flow for. LinkedIn is genuinely the
-// only connectable platform today, but this is a list plus a lookup table
-// (not a single hardcoded button/handler) so a second provider is a data
-// change here rather than a rewrite of this page.
-const CONNECTABLE_PLATFORMS: SocialPlatform[] = ["linkedin"];
+function IconLinkedIn() {
+  return (
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+      <rect x="3" y="3" width="18" height="18" rx="3" stroke="currentColor" strokeWidth="1.8" />
+      <circle cx="8" cy="8.5" r="1.3" fill="currentColor" />
+      <path d="M8 11.5v6" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" />
+      <path
+        d="M12.5 17.5v-3.5c0-1.4 1-2.5 2.4-2.5s2.1 1 2.1 2.5v3.5"
+        stroke="currentColor"
+        strokeWidth="1.8"
+        strokeLinecap="round"
+      />
+      <path d="M12.5 11.5v6" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" />
+    </svg>
+  );
+}
+
+function IconInstagram() {
+  return (
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+      <rect x="3.5" y="3.5" width="17" height="17" rx="5" stroke="currentColor" strokeWidth="1.8" />
+      <circle cx="12" cy="12" r="4" stroke="currentColor" strokeWidth="1.8" />
+      <circle cx="17" cy="7" r="1" fill="currentColor" />
+    </svg>
+  );
+}
+
+function IconThreads() {
+  return (
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+      <circle cx="12" cy="12" r="8.5" stroke="currentColor" strokeWidth="1.8" />
+      <path
+        d="M9.5 9.2c1.6-1 4.4-.9 5.1.9.6 1.6-.3 2.7-1.9 3-1.7.3-3.4-.2-3.6-1.6-.2-1.3 1-2 2.3-2 1.6 0 2.9.9 2.9 2.4 0 2-1.7 3.4-4 3.4"
+        stroke="currentColor"
+        strokeWidth="1.4"
+        strokeLinecap="round"
+      />
+    </svg>
+  );
+}
+
+function IconFacebook() {
+  return (
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+      <circle cx="12" cy="12" r="8.5" stroke="currentColor" strokeWidth="1.8" />
+      <path
+        d="M13.8 9.2h-1.3c-.6 0-1 .5-1 1.1v1.4H13.8l-.3 1.9h-1.9v5.2"
+        stroke="currentColor"
+        strokeWidth="1.6"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+const PLATFORM_ICONS: Partial<Record<SocialPlatform, () => ReactNode>> = {
+  linkedin: IconLinkedIn,
+  instagram: IconInstagram,
+  threads: IconThreads,
+  facebook: IconFacebook,
+};
+
+// Platforms the UI can start a connect flow for, plus a lookup table (not
+// hardcoded per-platform buttons/handlers) so adding one more provider is a
+// data change here rather than a rewrite of this page.
+const CONNECTABLE_PLATFORMS: SocialPlatform[] = ["linkedin", "instagram", "threads", "facebook"];
 
 const CONNECT_HANDLERS: Partial<
   Record<SocialPlatform, (token: string, brandId: string) => Promise<AuthorizeUrlResponse>>
 > = {
   linkedin: connectLinkedIn,
+  instagram: connectInstagram,
+  threads: connectThreads,
+  facebook: connectFacebook,
 };
 
 const STATUS_TONE: Record<SocialAccountStatus, BadgeTone> = {
@@ -173,22 +244,28 @@ export default function SocialAccountsPage() {
               description="Starts the OAuth flow in this tab and brings you back here once it's authorized."
             />
             <CardBody className="flex flex-wrap gap-4">
-              {CONNECTABLE_PLATFORMS.map((platform) => (
-                <div key={platform} className="flex flex-col gap-1.5">
-                  <Button
-                    variant="primary"
-                    isLoading={connectingPlatform === platform}
-                    onClick={() => handleConnect(platform)}
-                  >
-                    Connect {platformLabel(platform)}
-                  </Button>
-                  {notConfiguredPlatform === platform ? (
-                    <p role="alert" className="max-w-xs text-sm text-amber-700">
-                      {platformLabel(platform)} isn&apos;t configured on this server yet.
-                    </p>
-                  ) : null}
-                </div>
-              ))}
+              {CONNECTABLE_PLATFORMS.map((platform) => {
+                const Icon = PLATFORM_ICONS[platform];
+                return (
+                  <div key={platform} className="flex flex-col gap-1.5">
+                    <Button
+                      variant="primary"
+                      isLoading={connectingPlatform === platform}
+                      onClick={() => handleConnect(platform)}
+                    >
+                      <span className="flex items-center gap-2">
+                        {Icon ? <Icon /> : null}
+                        Connect {platformLabel(platform)}
+                      </span>
+                    </Button>
+                    {notConfiguredPlatform === platform ? (
+                      <p role="alert" className="max-w-xs text-sm text-amber-700">
+                        {platformLabel(platform)} isn&apos;t configured on this server yet.
+                      </p>
+                    ) : null}
+                  </div>
+                );
+              })}
             </CardBody>
           </Card>
 
@@ -215,12 +292,18 @@ export default function SocialAccountsPage() {
             <ul className="space-y-3">
               {accounts.map((account) => {
                 const expiry = formatExpiry(account.token_expires_at);
+                const Icon = PLATFORM_ICONS[account.platform];
                 return (
                   <li key={account.id}>
                     <Card>
                       <CardBody className="flex flex-wrap items-center justify-between gap-4">
                         <div>
                           <div className="flex items-center gap-2">
+                            {Icon ? (
+                              <span className="text-slate-500" aria-hidden="true">
+                                <Icon />
+                              </span>
+                            ) : null}
                             <h3 className="text-sm font-semibold text-slate-900">
                               {platformLabel(account.platform)}
                             </h3>

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -358,10 +358,8 @@ export async function rescheduleReviewPost(
 
 // --- Social accounts (Issue #91) ---
 
-// Mirrors apps/api/models/social_account.py::SocialPlatform. "linkedin" is
-// the only value today, but this is kept as a string union (not a literal)
-// so the UI layer can stay written generically as more providers land.
-export type SocialPlatform = "linkedin";
+// Mirrors apps/api/models/social_account.py::SocialPlatform.
+export type SocialPlatform = "linkedin" | "instagram" | "threads" | "facebook";
 
 // Mirrors apps/api/models/social_account.py::SocialAccountStatus.
 export type SocialAccountStatus = "active" | "expired" | "revoked";
@@ -411,6 +409,50 @@ export async function fetchSocialAccounts(token: string, brandId: string): Promi
 // the browser does with it.
 export async function connectLinkedIn(token: string, brandId: string): Promise<AuthorizeUrlResponse> {
   const res = await fetch(socialAccountsUrl(brandId, "/linkedin/connect"), {
+    method: "POST",
+    headers: authHeaders(token),
+  });
+
+  if (!res.ok) {
+    throw new ApiError(await parseErrorDetail(res), res.status);
+  }
+
+  return res.json();
+}
+
+// Starts the Instagram/Threads/Facebook OAuth flows — same shape as
+// connectLinkedIn above (see apps/api/routers/social_accounts.py's
+// connect_instagram/connect_threads/connect_facebook, which are all thin
+// wrappers around the same _connect_platform helper connect_linkedin's
+// logic was generalized into).
+export async function connectInstagram(token: string, brandId: string): Promise<AuthorizeUrlResponse> {
+  const res = await fetch(socialAccountsUrl(brandId, "/instagram/connect"), {
+    method: "POST",
+    headers: authHeaders(token),
+  });
+
+  if (!res.ok) {
+    throw new ApiError(await parseErrorDetail(res), res.status);
+  }
+
+  return res.json();
+}
+
+export async function connectThreads(token: string, brandId: string): Promise<AuthorizeUrlResponse> {
+  const res = await fetch(socialAccountsUrl(brandId, "/threads/connect"), {
+    method: "POST",
+    headers: authHeaders(token),
+  });
+
+  if (!res.ok) {
+    throw new ApiError(await parseErrorDetail(res), res.status);
+  }
+
+  return res.json();
+}
+
+export async function connectFacebook(token: string, brandId: string): Promise<AuthorizeUrlResponse> {
+  const res = await fetch(socialAccountsUrl(brandId, "/facebook/connect"), {
     method: "POST",
     headers: authHeaders(token),
   });

--- a/migrations/versions/a1b2c3d4e5f6_social_platform_meta_values.py
+++ b/migrations/versions/a1b2c3d4e5f6_social_platform_meta_values.py
@@ -1,0 +1,44 @@
+"""social_platform meta values
+
+Revision ID: a1b2c3d4e5f6
+Revises: 5b29b584c4fa
+Create Date: 2026-08-27 00:00:00.000000
+
+Issues #108/#109/#110 add Instagram, Threads, and Facebook Page publishing
+alongside LinkedIn/X — apps/api/models/social_account.py::SocialPlatform
+needs a matching row for each so a SocialAccount can actually be stored for
+the new platforms (same reason ad4c424c0dc8's social_accounts migration
+only defined 'LINKEDIN' for the one platform that existed at the time).
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = 'a1b2c3d4e5f6'
+down_revision: Union[str, None] = '5b29b584c4fa'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+_NEW_VALUES = ('INSTAGRAM', 'THREADS', 'FACEBOOK')
+
+
+def upgrade() -> None:
+    for value in _NEW_VALUES:
+        op.execute(f"ALTER TYPE social_platform ADD VALUE IF NOT EXISTS '{value}'")
+
+
+def downgrade() -> None:
+    # Postgres has no ALTER TYPE ... DROP VALUE, so removing these means
+    # rebuilding the enum from scratch — same lossy-on-downgrade tradeoff
+    # 75d69ba778a0's agent_type downgrade and c41e72b7ec17's pipeline_stage
+    # downgrade already accept, and fails as expected if any social_accounts
+    # row already uses one of these values.
+    op.execute("ALTER TYPE social_platform RENAME TO social_platform_old")
+    op.execute("CREATE TYPE social_platform AS ENUM ('LINKEDIN')")
+    op.execute(
+        "ALTER TABLE social_accounts "
+        "ALTER COLUMN platform TYPE social_platform "
+        "USING platform::text::social_platform"
+    )
+    op.execute("DROP TYPE social_platform_old")

--- a/packages/agents/tests/test_creative_engine.py
+++ b/packages/agents/tests/test_creative_engine.py
@@ -347,7 +347,24 @@ def test_creative_node_appends_to_completed_stages(db_session) -> None:
 
 
 def test_pipeline_logs_agent_run_with_agent_type_creative(db_session, thread_cleanup) -> None:
-    post = _setup_post(db_session)
+    from datetime import datetime, timezone
+
+    # Issues #108/#109/#110 grew SUPPORTED_PLATFORMS beyond ("linkedin",
+    # "x") — pin target_platforms explicitly via a calendar event so
+    # Research/Creative Engine's "no calendar event" -> "all
+    # SUPPORTED_PLATFORMS" fallback doesn't pull in platforms this test's
+    # LLM mock doesn't cover.
+    brand = _setup_brand(db_session)
+    event = ContentCalendarEvent(
+        brand_id=brand.id,
+        title="Test event",
+        target_platforms=["linkedin", "x"],
+        desired_format="text_post",
+        target_datetime=datetime(2026, 9, 1, tzinfo=timezone.utc),
+    )
+    db_session.add(event)
+    db_session.flush()
+    post = _setup_post(db_session, brand=brand, calendar_event=event)
     thread_cleanup.append(str(post.id))
 
     with (

--- a/packages/agents/tests/test_generation_engine.py
+++ b/packages/agents/tests/test_generation_engine.py
@@ -355,7 +355,24 @@ def test_generation_node_appends_to_completed_stages(db_session) -> None:
 def test_pipeline_logs_agent_run_with_agent_type_generation_including_token_and_cost(
     db_session, thread_cleanup
 ) -> None:
-    post = _setup_post(db_session)
+    from datetime import datetime, timezone
+
+    # Issues #108/#109/#110 grew SUPPORTED_PLATFORMS beyond ("linkedin",
+    # "x") — pin target_platforms explicitly via a calendar event so
+    # Research/Creative Engine's "no calendar event" -> "all
+    # SUPPORTED_PLATFORMS" fallback doesn't pull in platforms this test's
+    # LLM mocks don't cover.
+    brand = _setup_brand(db_session)
+    event = ContentCalendarEvent(
+        brand_id=brand.id,
+        title="Test event",
+        target_platforms=["linkedin", "x"],
+        desired_format="text_post",
+        target_datetime=datetime(2026, 9, 1, tzinfo=timezone.utc),
+    )
+    db_session.add(event)
+    db_session.flush()
+    post = _setup_post(db_session, brand=brand, calendar_event=event)
     thread_cleanup.append(str(post.id))
 
     with (

--- a/packages/agents/tests/test_research_engine.py
+++ b/packages/agents/tests/test_research_engine.py
@@ -32,6 +32,7 @@ from apps.api.models import (
     Organization,
     Post,
 )
+from apps.api.models.content_calendar_event import SUPPORTED_PLATFORMS
 from packages.agents.onboarding.embedding import embed_brand_report
 from packages.agents.pipeline.checkpointer import get_postgres_checkpointer
 from packages.agents.pipeline.graph import run_pipeline
@@ -171,7 +172,11 @@ def test_research_brief_includes_timing_trend_signal(db_session) -> None:
     assert "timing_signal" in brief
     signal = brief["timing_signal"]
     assert set(signal.keys()) == {"researched_at", "platforms", "trending_topics", "target_datetime"}
-    assert signal["platforms"] == ["linkedin", "x"]  # SUPPORTED_PLATFORMS fallback
+    # No calendar event on this post, so timing_signal falls back to every
+    # SUPPORTED_PLATFORMS entry — asserted against that tuple directly
+    # (rather than a hardcoded list) so this test doesn't need updating
+    # every time a new platform's publishing adapter lands.
+    assert signal["platforms"] == list(SUPPORTED_PLATFORMS)
     assert "Trending: sustainable camping gear" in signal["trending_topics"]
     assert signal["target_datetime"] is None
     # researched_at is a real, parseable ISO-8601 timestamp, not a placeholder.

--- a/packages/agents/tests/test_reviewer_engine.py
+++ b/packages/agents/tests/test_reviewer_engine.py
@@ -31,6 +31,7 @@ from apps.api.models import (
     AgentRun,
     AgentType,
     Brand,
+    ContentCalendarEvent,
     Organization,
     Post,
     ReviewFeedback,
@@ -422,7 +423,25 @@ def test_reviewer_node_appends_to_completed_stages(db_session) -> None:
 def test_pipeline_logs_agent_run_with_agent_type_reviewer_and_writes_review_feedback(
     db_session, thread_cleanup
 ) -> None:
+    from datetime import datetime, timezone
+
     post = _setup_post(db_session)
+    # Issues #108/#109/#110 grew SUPPORTED_PLATFORMS beyond ("linkedin",
+    # "x") — pin target_platforms explicitly via a calendar event so
+    # Research/Creative Engine's "no calendar event" -> "all
+    # SUPPORTED_PLATFORMS" fallback doesn't pull in platforms this test's
+    # LLM mocks below don't cover.
+    event = ContentCalendarEvent(
+        brand_id=post.brand_id,
+        title="Test event",
+        target_platforms=["linkedin", "x"],
+        desired_format="text_post",
+        target_datetime=datetime(2026, 9, 1, tzinfo=timezone.utc),
+    )
+    db_session.add(event)
+    db_session.flush()
+    post.calendar_event_id = event.id
+    db_session.flush()
     thread_cleanup.append(str(post.id))
 
     creative_brief_payload = {

--- a/packages/integrations/registry.py
+++ b/packages/integrations/registry.py
@@ -9,7 +9,10 @@ from packages.integrations.llm.openrouter_provider import OpenRouterProvider
 from packages.integrations.search.base import SearchProvider
 from packages.integrations.search.tavily import TavilyProvider
 from packages.integrations.social.base import SocialOAuthProvider, SocialPublisher
+from packages.integrations.social.facebook_provider import FacebookProvider
+from packages.integrations.social.instagram_provider import InstagramProvider
 from packages.integrations.social.linkedin_provider import LinkedInProvider
+from packages.integrations.social.threads_provider import ThreadsProvider
 from packages.integrations.social.x_provider import XProvider
 from packages.integrations.storage.base import StorageProvider
 from packages.integrations.storage.supabase_provider import SupabaseStorageProvider
@@ -40,6 +43,22 @@ _SOCIAL_OAUTH_PROVIDERS = {
         client_id=settings.x_client_id or "",
         client_secret=settings.x_client_secret or "",
     ),
+    # Instagram, Threads, and Facebook are all Meta Graph API products
+    # registered under one Meta developer app, so they share
+    # META_APP_ID/META_APP_SECRET rather than each getting its own
+    # client_id/secret pair the way LinkedIn/X do.
+    "instagram": lambda settings: InstagramProvider(
+        client_id=settings.meta_app_id or "",
+        client_secret=settings.meta_app_secret or "",
+    ),
+    "threads": lambda settings: ThreadsProvider(
+        client_id=settings.meta_app_id or "",
+        client_secret=settings.meta_app_secret or "",
+    ),
+    "facebook": lambda settings: FacebookProvider(
+        client_id=settings.meta_app_id or "",
+        client_secret=settings.meta_app_secret or "",
+    ),
 }
 
 # Every publisher is currently the same adapter instance that also
@@ -55,6 +74,18 @@ _SOCIAL_PUBLISHERS = {
     "x": lambda settings: XProvider(
         client_id=settings.x_client_id or "",
         client_secret=settings.x_client_secret or "",
+    ),
+    "instagram": lambda settings: InstagramProvider(
+        client_id=settings.meta_app_id or "",
+        client_secret=settings.meta_app_secret or "",
+    ),
+    "threads": lambda settings: ThreadsProvider(
+        client_id=settings.meta_app_id or "",
+        client_secret=settings.meta_app_secret or "",
+    ),
+    "facebook": lambda settings: FacebookProvider(
+        client_id=settings.meta_app_id or "",
+        client_secret=settings.meta_app_secret or "",
     ),
 }
 

--- a/packages/integrations/social/facebook_provider.py
+++ b/packages/integrations/social/facebook_provider.py
@@ -1,0 +1,263 @@
+from datetime import datetime, timedelta, timezone
+from urllib.parse import urlencode
+
+import httpx
+
+from packages.integrations.observability import track_integration_call
+from packages.integrations.social.base import (
+    EngagementMetrics,
+    EngagementResult,
+    PublishResult,
+    SocialOAuthProvider,
+    SocialPublisher,
+    SocialTokens,
+)
+
+
+class _TokenExpiredError(Exception):
+    """Internal signal that Facebook rejected access_token as
+    expired/invalid — distinct from other HTTP failures because it's the
+    one case publish() retries after a refresh, rather than surfacing
+    immediately."""
+
+
+class FacebookProvider(SocialOAuthProvider, SocialPublisher):
+    """The only file in this codebase allowed to call Facebook Graph API's
+    OAuth and Page-publishing endpoints directly.
+
+    Publishes to a Facebook Page, not a personal profile — the Graph API
+    has no endpoint for posting to a personal profile at all. `access_token`
+    throughout this adapter is therefore expected to be a Page access token
+    (not the user access token OAuth first hands back): `_fetch_page_id`
+    resolves which Page it belongs to by calling `/me` — called with a Page
+    token, `/me` identifies the Page itself, the same "ask the token who it
+    belongs to" trick LinkedInProvider._fetch_member_id uses.
+
+    Meta has no `refresh_token` concept like LinkedIn/X's OAuth2 refresh
+    grant — a long-lived token is "refreshed" by re-exchanging *itself*
+    (grant_type=fb_exchange_token) while still valid, not via a separate
+    refresh credential, and that re-exchange stops working the moment the
+    token is actually expired/revoked. `_refresh_access_token` models that:
+    it treats whatever is passed as `refresh_token` as the prior long-lived
+    access token to re-exchange, and the resulting SocialTokens.refresh_token
+    is the new access_token itself (so a caller can chain another refresh
+    later, same shape LinkedIn/X give their refresh_token).
+    """
+
+    GRAPH_VERSION = "v21.0"
+    AUTHORIZE_URL = f"https://www.facebook.com/{GRAPH_VERSION}/dialog/oauth"
+    TOKEN_URL = f"https://graph.facebook.com/{GRAPH_VERSION}/oauth/access_token"
+    ME_URL = f"https://graph.facebook.com/{GRAPH_VERSION}/me"
+
+    SCOPES = ("pages_show_list", "pages_read_engagement", "pages_manage_posts")
+
+    def __init__(self, client_id: str, client_secret: str, timeout: float = 15.0) -> None:
+        self.client_id = client_id
+        self.client_secret = client_secret
+        self.timeout = timeout
+
+    # -- SocialOAuthProvider -----------------------------------------------
+
+    def authorize_url(self, state: str, redirect_uri: str) -> str:
+        params = {
+            "response_type": "code",
+            "client_id": self.client_id,
+            "redirect_uri": redirect_uri,
+            "state": state,
+            "scope": ",".join(self.SCOPES),
+        }
+        return f"{self.AUTHORIZE_URL}?{urlencode(params)}"
+
+    def exchange_code(self, code: str, redirect_uri: str) -> SocialTokens:
+        with track_integration_call("facebook", "oauth_exchange"):
+            response = httpx.post(
+                self.TOKEN_URL,
+                data={
+                    "grant_type": "authorization_code",
+                    "code": code,
+                    "redirect_uri": redirect_uri,
+                    "client_id": self.client_id,
+                    "client_secret": self.client_secret,
+                },
+                timeout=self.timeout,
+            )
+            response.raise_for_status()
+            data = response.json()
+
+        expires_in = data.get("expires_in")
+        expires_at = (
+            datetime.now(timezone.utc) + timedelta(seconds=expires_in)
+            if expires_in is not None
+            else None
+        )
+        external_account_id = self._fetch_page_id(data["access_token"])
+
+        return SocialTokens(
+            access_token=data["access_token"],
+            # No standalone refresh_token — see class docstring.
+            refresh_token=None,
+            expires_at=expires_at,
+            scopes=list(self.SCOPES),
+            external_account_id=external_account_id,
+        )
+
+    def is_token_valid(self, access_token: str) -> bool:
+        with track_integration_call("facebook", "oauth_status_check"):
+            response = httpx.get(
+                self.ME_URL,
+                headers={"Authorization": f"Bearer {access_token}"},
+                timeout=self.timeout,
+            )
+        return response.status_code == 200
+
+    def _fetch_page_id(self, access_token: str) -> str | None:
+        with track_integration_call("facebook", "oauth_userinfo"):
+            response = httpx.get(
+                self.ME_URL,
+                headers={"Authorization": f"Bearer {access_token}"},
+                timeout=self.timeout,
+            )
+            response.raise_for_status()
+            return response.json().get("id")
+
+    # -- SocialPublisher -----------------------------------------------
+
+    def publish(
+        self,
+        access_token: str,
+        content: str,
+        media_urls: list[str] | None = None,
+        refresh_token: str | None = None,
+    ) -> PublishResult:
+        try:
+            return self._attempt_publish(access_token, content, media_urls)
+        except _TokenExpiredError:
+            if not refresh_token:
+                return PublishResult(
+                    success=False,
+                    error="Facebook access token expired/invalid and no refresh token is stored",
+                )
+            try:
+                new_tokens = self._refresh_access_token(refresh_token)
+            except Exception as exc:  # noqa: BLE001 - surfaced as PublishResult, not raised
+                return PublishResult(success=False, error=f"Facebook token refresh failed: {exc}")
+
+            try:
+                result = self._attempt_publish(new_tokens.access_token, content, media_urls)
+            except Exception as exc:  # noqa: BLE001
+                return PublishResult(
+                    success=False,
+                    error=f"Facebook publish failed after token refresh: {exc}",
+                )
+            result.refreshed_tokens = new_tokens
+            return result
+        except Exception as exc:  # noqa: BLE001 - vendor/network errors become failures, not raises
+            return PublishResult(success=False, error=str(exc))
+
+    def _attempt_publish(
+        self, access_token: str, content: str, media_urls: list[str] | None
+    ) -> PublishResult:
+        with track_integration_call("facebook", "publish"):
+            page_response = httpx.get(
+                self.ME_URL,
+                headers={"Authorization": f"Bearer {access_token}"},
+                timeout=self.timeout,
+            )
+            if page_response.status_code == 401:
+                raise _TokenExpiredError("Facebook rejected the access token")
+            page_response.raise_for_status()
+            page_id = page_response.json()["id"]
+
+            body: dict[str, object] = {"message": content}
+            if media_urls:
+                # A single link attachment — a multi-photo post needs the
+                # separate /{page-id}/photos endpoint (attach_to_object_id
+                # workflow), which no caller in this codebase produces yet.
+                body["link"] = media_urls[0]
+
+            response = httpx.post(
+                f"https://graph.facebook.com/{self.GRAPH_VERSION}/{page_id}/feed",
+                headers={"Authorization": f"Bearer {access_token}"},
+                json=body,
+                timeout=self.timeout,
+            )
+            if response.status_code == 401:
+                raise _TokenExpiredError("Facebook rejected the access token")
+            response.raise_for_status()
+            post_id = response.json().get("id")
+
+        return PublishResult(
+            success=True,
+            platform_post_id=post_id,
+            platform_post_url=f"https://www.facebook.com/{post_id}" if post_id else None,
+        )
+
+    # -- SocialPublisher: engagement -------------------------------------
+
+    def get_engagement(self, access_token: str, platform_post_id: str) -> EngagementResult:
+        try:
+            with track_integration_call("facebook", "get_engagement"):
+                response = httpx.get(
+                    f"https://graph.facebook.com/{self.GRAPH_VERSION}/{platform_post_id}",
+                    headers={"Authorization": f"Bearer {access_token}"},
+                    params={"fields": "likes.summary(true),comments.summary(true),shares"},
+                    timeout=self.timeout,
+                )
+                if response.status_code == 429:
+                    return EngagementResult(
+                        success=False,
+                        error="Facebook rate-limited this engagement request",
+                        rate_limited=True,
+                    )
+                response.raise_for_status()
+                data = response.json()
+        except Exception as exc:  # noqa: BLE001 - vendor/network errors become failures, not raises
+            return EngagementResult(success=False, error=str(exc))
+
+        # Post-level impressions require the separate Page Insights API
+        # (a different permission this adapter doesn't request today) —
+        # left at 0 rather than raised as a failure, same "unsupported
+        # metric reads 0, not unknown" convention EngagementSnapshot's
+        # model docstring establishes.
+        return EngagementResult(
+            success=True,
+            metrics=EngagementMetrics(
+                likes=data.get("likes", {}).get("summary", {}).get("total_count", 0),
+                comments=data.get("comments", {}).get("summary", {}).get("total_count", 0),
+                shares=data.get("shares", {}).get("count", 0),
+                impressions=0,
+            ),
+        )
+
+    def _refresh_access_token(self, refresh_token: str) -> SocialTokens:
+        with track_integration_call("facebook", "oauth_refresh"):
+            response = httpx.post(
+                self.TOKEN_URL,
+                data={
+                    "grant_type": "fb_exchange_token",
+                    "client_id": self.client_id,
+                    "client_secret": self.client_secret,
+                    "fb_exchange_token": refresh_token,
+                },
+                timeout=self.timeout,
+            )
+            response.raise_for_status()
+            data = response.json()
+
+        expires_in = data.get("expires_in")
+        expires_at = (
+            datetime.now(timezone.utc) + timedelta(seconds=expires_in)
+            if expires_in is not None
+            else None
+        )
+
+        return SocialTokens(
+            access_token=data["access_token"],
+            # See class docstring: Meta "refresh" re-exchanges the token
+            # itself, so the new access_token doubles as the next
+            # refresh_token a caller would pass in.
+            refresh_token=data.get("access_token"),
+            expires_at=expires_at,
+            scopes=list(self.SCOPES),
+            external_account_id=None,
+        )

--- a/packages/integrations/social/instagram_provider.py
+++ b/packages/integrations/social/instagram_provider.py
@@ -1,0 +1,292 @@
+from datetime import datetime, timedelta, timezone
+from urllib.parse import urlencode
+
+import httpx
+
+from packages.integrations.observability import track_integration_call
+from packages.integrations.social.base import (
+    EngagementMetrics,
+    EngagementResult,
+    PublishResult,
+    SocialOAuthProvider,
+    SocialPublisher,
+    SocialTokens,
+)
+
+
+class _TokenExpiredError(Exception):
+    """Internal signal that Instagram (Meta Graph API) rejected
+    access_token as expired/invalid — distinct from other HTTP failures
+    because it's the one case publish() retries after a refresh, rather
+    than surfacing immediately."""
+
+
+class _NoInstagramAccountError(Exception):
+    """Raised when the Facebook Page behind this token has no linked
+    Instagram professional account — a real, expected state (not every
+    Page has one converted), not a transport failure, so it's a distinct
+    class from _TokenExpiredError even though both fall back to the same
+    generic PublishResult(success=False, ...) in publish()."""
+
+
+class InstagramProvider(SocialOAuthProvider, SocialPublisher):
+    """The only file in this codebase allowed to call the Instagram Graph
+    API's OAuth and content-publishing endpoints directly.
+
+    Instagram's Content Publishing API rides on Facebook Login and the same
+    graph.facebook.com host FacebookProvider uses (same Meta developer app,
+    same reason META_APP_ID/META_APP_SECRET are shared config) — an IG
+    professional account is only reachable through the Facebook Page it's
+    linked to, never directly. `access_token` is a Page-scoped user access
+    token; `_fetch_ig_user_id` resolves the linked IG business account id
+    fresh on every call (via /me/accounts) rather than accepting it as a
+    parameter, the same "ask the token, don't thread an extra id through
+    the interface" choice LinkedInProvider/XProvider make for their own
+    account ids.
+
+    Instagram has no text-only post — every publish() call requires at
+    least one media URL; a caller that omits media_urls gets a normal
+    PublishResult(success=False, ...) rather than a raised error, same as
+    any other rejected-content failure.
+
+    Like FacebookProvider, Meta has no standalone refresh_token — see that
+    class's docstring for how _refresh_access_token models re-exchange
+    instead.
+    """
+
+    GRAPH_VERSION = "v21.0"
+    AUTHORIZE_URL = f"https://www.facebook.com/{GRAPH_VERSION}/dialog/oauth"
+    TOKEN_URL = f"https://graph.facebook.com/{GRAPH_VERSION}/oauth/access_token"
+    ACCOUNTS_URL = f"https://graph.facebook.com/{GRAPH_VERSION}/me/accounts"
+
+    SCOPES = (
+        "instagram_basic",
+        "instagram_content_publish",
+        "pages_show_list",
+        "pages_read_engagement",
+    )
+
+    def __init__(self, client_id: str, client_secret: str, timeout: float = 15.0) -> None:
+        self.client_id = client_id
+        self.client_secret = client_secret
+        self.timeout = timeout
+
+    # -- SocialOAuthProvider -----------------------------------------------
+
+    def authorize_url(self, state: str, redirect_uri: str) -> str:
+        params = {
+            "response_type": "code",
+            "client_id": self.client_id,
+            "redirect_uri": redirect_uri,
+            "state": state,
+            "scope": ",".join(self.SCOPES),
+        }
+        return f"{self.AUTHORIZE_URL}?{urlencode(params)}"
+
+    def exchange_code(self, code: str, redirect_uri: str) -> SocialTokens:
+        with track_integration_call("instagram", "oauth_exchange"):
+            response = httpx.post(
+                self.TOKEN_URL,
+                data={
+                    "grant_type": "authorization_code",
+                    "code": code,
+                    "redirect_uri": redirect_uri,
+                    "client_id": self.client_id,
+                    "client_secret": self.client_secret,
+                },
+                timeout=self.timeout,
+            )
+            response.raise_for_status()
+            data = response.json()
+
+        expires_in = data.get("expires_in")
+        expires_at = (
+            datetime.now(timezone.utc) + timedelta(seconds=expires_in)
+            if expires_in is not None
+            else None
+        )
+
+        try:
+            external_account_id = self._fetch_ig_user_id(data["access_token"])
+        except _NoInstagramAccountError:
+            external_account_id = None
+
+        return SocialTokens(
+            access_token=data["access_token"],
+            refresh_token=None,
+            expires_at=expires_at,
+            scopes=list(self.SCOPES),
+            external_account_id=external_account_id,
+        )
+
+    def is_token_valid(self, access_token: str) -> bool:
+        with track_integration_call("instagram", "oauth_status_check"):
+            response = httpx.get(
+                self.ACCOUNTS_URL,
+                headers={"Authorization": f"Bearer {access_token}"},
+                timeout=self.timeout,
+            )
+        return response.status_code == 200
+
+    def _fetch_ig_user_id(self, access_token: str) -> str:
+        with track_integration_call("instagram", "oauth_userinfo"):
+            response = httpx.get(
+                self.ACCOUNTS_URL,
+                headers={"Authorization": f"Bearer {access_token}"},
+                params={"fields": "instagram_business_account"},
+                timeout=self.timeout,
+            )
+            if response.status_code == 401:
+                raise _TokenExpiredError("Instagram rejected the access token")
+            response.raise_for_status()
+            pages = response.json().get("data", [])
+
+        for page in pages:
+            ig_account = page.get("instagram_business_account")
+            if ig_account and ig_account.get("id"):
+                return ig_account["id"]
+        raise _NoInstagramAccountError(
+            "No Instagram professional account is linked to this Facebook Page"
+        )
+
+    # -- SocialPublisher -----------------------------------------------
+
+    def publish(
+        self,
+        access_token: str,
+        content: str,
+        media_urls: list[str] | None = None,
+        refresh_token: str | None = None,
+    ) -> PublishResult:
+        if not media_urls:
+            return PublishResult(
+                success=False,
+                error="Instagram requires at least one media URL to publish a post",
+            )
+        try:
+            return self._attempt_publish(access_token, content, media_urls)
+        except _TokenExpiredError:
+            if not refresh_token:
+                return PublishResult(
+                    success=False,
+                    error="Instagram access token expired/invalid and no refresh token is stored",
+                )
+            try:
+                new_tokens = self._refresh_access_token(refresh_token)
+            except Exception as exc:  # noqa: BLE001 - surfaced as PublishResult, not raised
+                return PublishResult(success=False, error=f"Instagram token refresh failed: {exc}")
+
+            try:
+                result = self._attempt_publish(new_tokens.access_token, content, media_urls)
+            except Exception as exc:  # noqa: BLE001
+                return PublishResult(
+                    success=False,
+                    error=f"Instagram publish failed after token refresh: {exc}",
+                )
+            result.refreshed_tokens = new_tokens
+            return result
+        except Exception as exc:  # noqa: BLE001 - vendor/network errors become failures, not raises
+            return PublishResult(success=False, error=str(exc))
+
+    def _attempt_publish(
+        self, access_token: str, content: str, media_urls: list[str]
+    ) -> PublishResult:
+        with track_integration_call("instagram", "publish"):
+            ig_user_id = self._fetch_ig_user_id(access_token)
+
+            container_response = httpx.post(
+                f"https://graph.facebook.com/{self.GRAPH_VERSION}/{ig_user_id}/media",
+                headers={"Authorization": f"Bearer {access_token}"},
+                json={"image_url": media_urls[0], "caption": content},
+                timeout=self.timeout,
+            )
+            if container_response.status_code == 401:
+                raise _TokenExpiredError("Instagram rejected the access token")
+            container_response.raise_for_status()
+            creation_id = container_response.json()["id"]
+
+            publish_response = httpx.post(
+                f"https://graph.facebook.com/{self.GRAPH_VERSION}/{ig_user_id}/media_publish",
+                headers={"Authorization": f"Bearer {access_token}"},
+                json={"creation_id": creation_id},
+                timeout=self.timeout,
+            )
+            if publish_response.status_code == 401:
+                raise _TokenExpiredError("Instagram rejected the access token")
+            publish_response.raise_for_status()
+            post_id = publish_response.json().get("id")
+
+        return PublishResult(
+            success=True,
+            platform_post_id=post_id,
+            platform_post_url=f"https://www.instagram.com/p/{post_id}/" if post_id else None,
+        )
+
+    # -- SocialPublisher: engagement -------------------------------------
+
+    def get_engagement(self, access_token: str, platform_post_id: str) -> EngagementResult:
+        try:
+            with track_integration_call("instagram", "get_engagement"):
+                response = httpx.get(
+                    f"https://graph.facebook.com/{self.GRAPH_VERSION}/{platform_post_id}/insights",
+                    headers={"Authorization": f"Bearer {access_token}"},
+                    params={"metric": "impressions,reach,likes,comments,saved"},
+                    timeout=self.timeout,
+                )
+                if response.status_code == 429:
+                    return EngagementResult(
+                        success=False,
+                        error="Instagram rate-limited this engagement request",
+                        rate_limited=True,
+                    )
+                response.raise_for_status()
+                metric_rows = response.json().get("data", [])
+        except Exception as exc:  # noqa: BLE001 - vendor/network errors become failures, not raises
+            return EngagementResult(success=False, error=str(exc))
+
+        values = {
+            row["name"]: row.get("values", [{}])[0].get("value", 0)
+            for row in metric_rows
+            if row.get("name")
+        }
+        return EngagementResult(
+            success=True,
+            metrics=EngagementMetrics(
+                likes=values.get("likes", 0),
+                comments=values.get("comments", 0),
+                # Instagram has no public "share" count — "saved" is the
+                # closest amplification-style signal it exposes.
+                shares=values.get("saved", 0),
+                impressions=values.get("impressions", 0),
+            ),
+        )
+
+    def _refresh_access_token(self, refresh_token: str) -> SocialTokens:
+        with track_integration_call("instagram", "oauth_refresh"):
+            response = httpx.post(
+                self.TOKEN_URL,
+                data={
+                    "grant_type": "fb_exchange_token",
+                    "client_id": self.client_id,
+                    "client_secret": self.client_secret,
+                    "fb_exchange_token": refresh_token,
+                },
+                timeout=self.timeout,
+            )
+            response.raise_for_status()
+            data = response.json()
+
+        expires_in = data.get("expires_in")
+        expires_at = (
+            datetime.now(timezone.utc) + timedelta(seconds=expires_in)
+            if expires_in is not None
+            else None
+        )
+
+        return SocialTokens(
+            access_token=data["access_token"],
+            refresh_token=data.get("access_token"),
+            expires_at=expires_at,
+            scopes=list(self.SCOPES),
+            external_account_id=None,
+        )

--- a/packages/integrations/social/threads_provider.py
+++ b/packages/integrations/social/threads_provider.py
@@ -1,0 +1,264 @@
+from datetime import datetime, timedelta, timezone
+from urllib.parse import urlencode
+
+import httpx
+
+from packages.integrations.observability import track_integration_call
+from packages.integrations.social.base import (
+    EngagementMetrics,
+    EngagementResult,
+    PublishResult,
+    SocialOAuthProvider,
+    SocialPublisher,
+    SocialTokens,
+)
+
+
+class _TokenExpiredError(Exception):
+    """Internal signal that Threads rejected access_token as
+    expired/invalid — distinct from other HTTP failures because it's the
+    one case publish() retries after a refresh, rather than surfacing
+    immediately."""
+
+
+class ThreadsProvider(SocialOAuthProvider, SocialPublisher):
+    """The only file in this codebase allowed to call the Threads API's
+    OAuth and publishing endpoints directly.
+
+    Threads is a separate Meta product from the Facebook Graph API proper —
+    its own OAuth dialog (threads.net) and its own API host
+    (graph.threads.net) — but still registered under the same Meta
+    developer app as Facebook/Instagram, hence sharing META_APP_ID/
+    META_APP_SECRET with FacebookProvider/InstagramProvider even though the
+    endpoints themselves differ.
+
+    The authorization-code exchange response includes the Threads user id
+    directly (`user_id`), so unlike LinkedIn/X/Facebook/Instagram this
+    adapter doesn't need a separate userinfo call during exchange_code —
+    only publish()/is_token_valid(), which don't have that response handy,
+    re-fetch it from `/me`.
+
+    Threads publishing is two-step like Instagram's (create a media
+    container, then publish it) and supports text-only posts, unlike
+    Instagram.
+
+    Meta has no standalone refresh_token here either — see
+    FacebookProvider's docstring for the same "re-exchange the token
+    itself" shape, using Threads' own `th_refresh_token` grant.
+    """
+
+    AUTHORIZE_URL = "https://threads.net/oauth/authorize"
+    TOKEN_URL = "https://graph.threads.net/oauth/access_token"
+    REFRESH_URL = "https://graph.threads.net/refresh_access_token"
+    ME_URL = "https://graph.threads.net/v1.0/me"
+
+    SCOPES = ("threads_basic", "threads_content_publish")
+
+    def __init__(self, client_id: str, client_secret: str, timeout: float = 15.0) -> None:
+        self.client_id = client_id
+        self.client_secret = client_secret
+        self.timeout = timeout
+
+    # -- SocialOAuthProvider -----------------------------------------------
+
+    def authorize_url(self, state: str, redirect_uri: str) -> str:
+        params = {
+            "response_type": "code",
+            "client_id": self.client_id,
+            "redirect_uri": redirect_uri,
+            "state": state,
+            "scope": ",".join(self.SCOPES),
+        }
+        return f"{self.AUTHORIZE_URL}?{urlencode(params)}"
+
+    def exchange_code(self, code: str, redirect_uri: str) -> SocialTokens:
+        with track_integration_call("threads", "oauth_exchange"):
+            response = httpx.post(
+                self.TOKEN_URL,
+                data={
+                    "grant_type": "authorization_code",
+                    "code": code,
+                    "redirect_uri": redirect_uri,
+                    "client_id": self.client_id,
+                    "client_secret": self.client_secret,
+                },
+                timeout=self.timeout,
+            )
+            response.raise_for_status()
+            data = response.json()
+
+        expires_in = data.get("expires_in")
+        expires_at = (
+            datetime.now(timezone.utc) + timedelta(seconds=expires_in)
+            if expires_in is not None
+            else None
+        )
+
+        return SocialTokens(
+            access_token=data["access_token"],
+            refresh_token=None,
+            expires_at=expires_at,
+            scopes=list(self.SCOPES),
+            external_account_id=str(data["user_id"]) if data.get("user_id") is not None else None,
+        )
+
+    def is_token_valid(self, access_token: str) -> bool:
+        with track_integration_call("threads", "oauth_status_check"):
+            response = httpx.get(
+                self.ME_URL,
+                headers={"Authorization": f"Bearer {access_token}"},
+                timeout=self.timeout,
+            )
+        return response.status_code == 200
+
+    def _fetch_user_id(self, access_token: str) -> str:
+        with track_integration_call("threads", "oauth_userinfo"):
+            response = httpx.get(
+                self.ME_URL,
+                headers={"Authorization": f"Bearer {access_token}"},
+                timeout=self.timeout,
+            )
+            if response.status_code == 401:
+                raise _TokenExpiredError("Threads rejected the access token")
+            response.raise_for_status()
+            return response.json()["id"]
+
+    # -- SocialPublisher -----------------------------------------------
+
+    def publish(
+        self,
+        access_token: str,
+        content: str,
+        media_urls: list[str] | None = None,
+        refresh_token: str | None = None,
+    ) -> PublishResult:
+        try:
+            return self._attempt_publish(access_token, content, media_urls)
+        except _TokenExpiredError:
+            if not refresh_token:
+                return PublishResult(
+                    success=False,
+                    error="Threads access token expired/invalid and no refresh token is stored",
+                )
+            try:
+                new_tokens = self._refresh_access_token(refresh_token)
+            except Exception as exc:  # noqa: BLE001 - surfaced as PublishResult, not raised
+                return PublishResult(success=False, error=f"Threads token refresh failed: {exc}")
+
+            try:
+                result = self._attempt_publish(new_tokens.access_token, content, media_urls)
+            except Exception as exc:  # noqa: BLE001
+                return PublishResult(
+                    success=False,
+                    error=f"Threads publish failed after token refresh: {exc}",
+                )
+            result.refreshed_tokens = new_tokens
+            return result
+        except Exception as exc:  # noqa: BLE001 - vendor/network errors become failures, not raises
+            return PublishResult(success=False, error=str(exc))
+
+    def _attempt_publish(
+        self, access_token: str, content: str, media_urls: list[str] | None
+    ) -> PublishResult:
+        with track_integration_call("threads", "publish"):
+            threads_user_id = self._fetch_user_id(access_token)
+
+            body: dict[str, object] = {"text": content}
+            if media_urls:
+                body["media_type"] = "IMAGE"
+                body["image_url"] = media_urls[0]
+            else:
+                body["media_type"] = "TEXT"
+
+            container_response = httpx.post(
+                f"https://graph.threads.net/v1.0/{threads_user_id}/threads",
+                headers={"Authorization": f"Bearer {access_token}"},
+                json=body,
+                timeout=self.timeout,
+            )
+            if container_response.status_code == 401:
+                raise _TokenExpiredError("Threads rejected the access token")
+            container_response.raise_for_status()
+            creation_id = container_response.json()["id"]
+
+            publish_response = httpx.post(
+                f"https://graph.threads.net/v1.0/{threads_user_id}/threads_publish",
+                headers={"Authorization": f"Bearer {access_token}"},
+                json={"creation_id": creation_id},
+                timeout=self.timeout,
+            )
+            if publish_response.status_code == 401:
+                raise _TokenExpiredError("Threads rejected the access token")
+            publish_response.raise_for_status()
+            post_id = publish_response.json().get("id")
+
+        return PublishResult(
+            success=True,
+            platform_post_id=post_id,
+            platform_post_url=f"https://www.threads.net/t/{post_id}" if post_id else None,
+        )
+
+    # -- SocialPublisher: engagement -------------------------------------
+
+    def get_engagement(self, access_token: str, platform_post_id: str) -> EngagementResult:
+        try:
+            with track_integration_call("threads", "get_engagement"):
+                response = httpx.get(
+                    f"https://graph.threads.net/v1.0/{platform_post_id}/insights",
+                    headers={"Authorization": f"Bearer {access_token}"},
+                    params={"metric": "likes,replies,reposts,views"},
+                    timeout=self.timeout,
+                )
+                if response.status_code == 429:
+                    return EngagementResult(
+                        success=False,
+                        error="Threads rate-limited this engagement request",
+                        rate_limited=True,
+                    )
+                response.raise_for_status()
+                metric_rows = response.json().get("data", [])
+        except Exception as exc:  # noqa: BLE001 - vendor/network errors become failures, not raises
+            return EngagementResult(success=False, error=str(exc))
+
+        values = {
+            row["name"]: row.get("values", [{}])[0].get("value", 0)
+            for row in metric_rows
+            if row.get("name")
+        }
+        return EngagementResult(
+            success=True,
+            metrics=EngagementMetrics(
+                likes=values.get("likes", 0),
+                comments=values.get("replies", 0),
+                shares=values.get("reposts", 0),
+                impressions=values.get("views", 0),
+            ),
+        )
+
+    def _refresh_access_token(self, refresh_token: str) -> SocialTokens:
+        with track_integration_call("threads", "oauth_refresh"):
+            response = httpx.get(
+                self.REFRESH_URL,
+                params={
+                    "grant_type": "th_refresh_token",
+                    "access_token": refresh_token,
+                },
+                timeout=self.timeout,
+            )
+            response.raise_for_status()
+            data = response.json()
+
+        expires_in = data.get("expires_in")
+        expires_at = (
+            datetime.now(timezone.utc) + timedelta(seconds=expires_in)
+            if expires_in is not None
+            else None
+        )
+
+        return SocialTokens(
+            access_token=data["access_token"],
+            refresh_token=data.get("access_token"),
+            expires_at=expires_at,
+            scopes=list(self.SCOPES),
+            external_account_id=None,
+        )


### PR DESCRIPTION
Closes #108
Closes #109
Closes #110

Re-opened from PR #116 as a same-repo branch — that PR was opened from a fork, which causes the `issue-pr-sync` check to fail with a 403 (GitHub restricts the default `GITHUB_TOKEN` to read-only for `pull_request` events from forks). Also fixes a flaky test found while verifying: `social-accounts-page.test.tsx`'s empty-state test raced the same async-provider-chain issue already fixed once in `onboarding-page.test.tsx` — same `waitFor` barrier applied here.

## Summary
- New `instagram_provider.py`, `threads_provider.py`, `facebook_provider.py` implementing `SocialPublisher`, following the LinkedIn/X pattern (OAuth, encrypted token storage, post, get_engagement).
- Registered in `registry.py`, added to `SUPPORTED_PLATFORMS`.
- OAuth connect/callback endpoints in `social_accounts.py` for each platform.
- `META_APP_ID`/`META_APP_SECRET` env vars (shared across the 3 Meta-based platforms), added to `.env.example` with empty placeholder defaults — actual Meta Developer App credentials are the user's to provision.
- Frontend: Instagram/Threads/Facebook connect options in `apps/web/app/social-accounts/page.tsx` with inline SVG icons, plus corresponding `lib/api.ts` functions/types.

## Test plan
- [x] Backend + frontend test suites pass locally
- [x] `npx tsc --noEmit` clean
- [x] Flaky `social-accounts-page.test.tsx` empty-state test fixed and verified across 3 consecutive runs