### PR TITLE
UI: n8n-inspired dark shell restyle + global prompt bar

### DIFF
--- a/apps/web/__tests__/auth-gate.test.tsx
+++ b/apps/web/__tests__/auth-gate.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, waitFor } from "@testing-library/react";
 import { AuthGate } from "@/components/auth-gate";
 import { AuthProvider } from "@/lib/auth-context";
 import { BrandProvider } from "@/lib/brand-context";
+import { ToastProvider } from "@/components/ui/Toast";
 
 const replace = vi.fn();
 let mockPathname = "/calendar";
@@ -18,13 +19,15 @@ vi.mock("@/lib/api", () => ({
 
 function renderGate() {
   return render(
-    <AuthProvider>
-      <BrandProvider>
-        <AuthGate>
-          <div>protected content</div>
-        </AuthGate>
-      </BrandProvider>
-    </AuthProvider>
+    <ToastProvider>
+      <AuthProvider>
+        <BrandProvider>
+          <AuthGate>
+            <div>protected content</div>
+          </AuthGate>
+        </BrandProvider>
+      </AuthProvider>
+    </ToastProvider>
   );
 }
 

--- a/apps/web/__tests__/prompt-bar.test.tsx
+++ b/apps/web/__tests__/prompt-bar.test.tsx
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { PromptBar } from "@/components/prompt-bar";
+import { ToastProvider } from "@/components/ui/Toast";
+import { AGENTS, DEFAULT_AGENT } from "@/lib/agents";
+
+function renderPromptBar() {
+  return render(
+    <ToastProvider>
+      <PromptBar />
+    </ToastProvider>,
+  );
+}
+
+describe("PromptBar", () => {
+  it("opens the palette when the floating trigger is clicked", async () => {
+    const user = userEvent.setup();
+    renderPromptBar();
+
+    expect(screen.queryByRole("dialog", { name: "Prompt bar" })).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /ask anything/i }));
+
+    expect(screen.getByRole("dialog", { name: "Prompt bar" })).toBeInTheDocument();
+  });
+
+  it("opens the palette with Cmd/Ctrl+K from anywhere", async () => {
+    const user = userEvent.setup();
+    renderPromptBar();
+
+    await user.keyboard("{Meta>}k{/Meta}");
+
+    expect(screen.getByRole("dialog", { name: "Prompt bar" })).toBeInTheDocument();
+  });
+
+  it("closes on Escape", async () => {
+    const user = userEvent.setup();
+    renderPromptBar();
+
+    await user.click(screen.getByRole("button", { name: /ask anything/i }));
+    expect(screen.getByRole("dialog", { name: "Prompt bar" })).toBeInTheDocument();
+
+    await user.keyboard("{Escape}");
+
+    expect(screen.queryByRole("dialog", { name: "Prompt bar" })).not.toBeInTheDocument();
+  });
+
+  it("renders all five agents", async () => {
+    const user = userEvent.setup();
+    renderPromptBar();
+    await user.click(screen.getByRole("button", { name: /ask anything/i }));
+
+    for (const agent of AGENTS) {
+      expect(screen.getByText(agent.name)).toBeInTheDocument();
+    }
+    expect(screen.getAllByRole("option")).toHaveLength(5);
+  });
+
+  it("moves the active row with arrow keys", async () => {
+    const user = userEvent.setup();
+    renderPromptBar();
+    await user.click(screen.getByRole("button", { name: /ask anything/i }));
+
+    const options = screen.getAllByRole("option");
+    options.forEach((option) => expect(option).toHaveAttribute("aria-selected", "false"));
+
+    await user.keyboard("{ArrowDown}");
+    expect(screen.getAllByRole("option")[0]).toHaveAttribute("aria-selected", "true");
+
+    await user.keyboard("{ArrowDown}");
+    expect(screen.getAllByRole("option")[1]).toHaveAttribute("aria-selected", "true");
+    expect(screen.getAllByRole("option")[0]).toHaveAttribute("aria-selected", "false");
+
+    await user.keyboard("{ArrowUp}");
+    expect(screen.getAllByRole("option")[0]).toHaveAttribute("aria-selected", "true");
+  });
+
+  it("submits the arrow-selected agent on Enter and toasts the routing", async () => {
+    const user = userEvent.setup();
+    renderPromptBar();
+    await user.click(screen.getByRole("button", { name: /ask anything/i }));
+
+    const kaviIndex = AGENTS.findIndex((agent) => agent.id === "kavi");
+    await user.type(screen.getByRole("textbox", { name: "Instruction" }), "make 3 more variants");
+    for (let i = 0; i <= kaviIndex; i += 1) {
+      await user.keyboard("{ArrowDown}");
+    }
+    await user.keyboard("{Enter}");
+
+    expect(screen.queryByRole("dialog", { name: "Prompt bar" })).not.toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByText('Routing to Kavi: "make 3 more variants"')).toBeInTheDocument();
+    });
+  });
+
+  it("routes free text with no explicit selection to a sensible default agent", async () => {
+    const user = userEvent.setup();
+    renderPromptBar();
+    await user.click(screen.getByRole("button", { name: /ask anything/i }));
+
+    await user.type(screen.getByRole("textbox", { name: "Instruction" }), "what's trending in fitness");
+    await user.keyboard("{Enter}");
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(`Routing to ${DEFAULT_AGENT.name}: "what's trending in fitness"`),
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import { Inter } from "next/font/google";
+import { Inter, JetBrains_Mono } from "next/font/google";
 import type { ReactNode } from "react";
 import "./globals.css";
 import { AuthProvider } from "@/lib/auth-context";
@@ -8,6 +8,9 @@ import { AuthGate } from "@/components/auth-gate";
 import { ToastProvider } from "@/components/ui/Toast";
 
 const inter = Inter({ subsets: ["latin"], variable: "--font-inter" });
+// Backs the `font-mono` Tailwind token used for shell chrome — nav section
+// labels, keyboard-shortcut hints, agent tags, the prompt bar's agent rows.
+const jetbrainsMono = JetBrains_Mono({ subsets: ["latin"], variable: "--font-mono" });
 
 export const metadata: Metadata = {
   title: "Raindeer Social",
@@ -20,7 +23,7 @@ export const metadata: Metadata = {
 // is what scopes brand-aware pages to the switcher's current selection.
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
-    <html lang="en" className={inter.variable}>
+    <html lang="en" className={`${inter.variable} ${jetbrainsMono.variable}`}>
       <body className="font-sans">
         <ToastProvider>
           <AuthProvider>

--- a/apps/web/components/auth-gate.tsx
+++ b/apps/web/components/auth-gate.tsx
@@ -5,6 +5,7 @@ import type { ReactNode } from "react";
 import { usePathname, useRouter } from "next/navigation";
 import { useAuth } from "@/lib/auth-context";
 import { Nav } from "@/components/nav";
+import { PromptBar } from "@/components/prompt-bar";
 
 // Routes reachable without a token. Everything else is gated.
 const PUBLIC_PATHS = ["/login"];
@@ -51,6 +52,7 @@ export function AuthGate({ children }: { children: ReactNode }) {
       <main className="min-w-0 flex-1 px-6 py-8 lg:px-10">
         <div className="mx-auto max-w-6xl">{children}</div>
       </main>
+      <PromptBar />
     </div>
   );
 }

--- a/apps/web/components/brand-switcher.tsx
+++ b/apps/web/components/brand-switcher.tsx
@@ -25,14 +25,14 @@ export function BrandSwitcher() {
 
   if (error) {
     return (
-      <p className="px-1 text-xs font-medium text-red-600" role="alert">
+      <p className="px-1 text-xs font-medium text-red-400" role="alert">
         {error}
       </p>
     );
   }
 
   if (brands.length === 0) {
-    return <p className="px-1 text-xs text-slate-500">No brands yet</p>;
+    return <p className="px-1 text-xs text-ink-400">No brands yet</p>;
   }
 
   return (
@@ -44,15 +44,15 @@ export function BrandSwitcher() {
         aria-label="Select brand"
         value={selectedBrandId ?? ""}
         onChange={(event) => setSelectedBrandId(event.target.value)}
-        className="w-full appearance-none rounded-lg border border-slate-200 bg-slate-50 py-2 pl-10 pr-8 text-sm font-medium text-slate-800 hover:bg-slate-100 focus:border-brand-500 focus:outline-none focus:ring-2 focus:ring-brand-500/20"
+        className="w-full appearance-none rounded-lg border border-ink-700 bg-ink-800/60 py-2 pl-10 pr-8 text-sm font-medium text-ink-100 transition-colors hover:bg-ink-800 focus:border-accent-500 focus:outline-none focus:ring-2 focus:ring-accent-500/20"
       >
         {brands.map((brand) => (
-          <option key={brand.id} value={brand.id}>
+          <option key={brand.id} value={brand.id} className="bg-ink-900 text-ink-100">
             {brand.name}
           </option>
         ))}
       </select>
-      <div className="pointer-events-none absolute inset-y-0 right-2.5 flex items-center text-slate-400">
+      <div className="pointer-events-none absolute inset-y-0 right-2.5 flex items-center text-ink-400">
         <svg width="14" height="14" viewBox="0 0 24 24" fill="none" aria-hidden="true">
           <path d="M6 9l6 6 6-6" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
         </svg>

--- a/apps/web/components/nav.tsx
+++ b/apps/web/components/nav.tsx
@@ -103,21 +103,27 @@ export function Nav() {
   const { logout } = useAuth();
 
   return (
-    <aside className="sticky top-0 flex h-screen w-64 shrink-0 flex-col border-r border-slate-200 bg-white">
-      <div className="flex h-16 items-center gap-2 border-b border-slate-100 px-5">
-        <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-brand-600 text-sm font-bold text-white">
+    <aside className="sticky top-0 flex h-screen w-64 shrink-0 flex-col border-r border-ink-800 bg-ink-950 bg-gradient-to-b from-ink-900 via-ink-950 to-ink-950 shadow-chrome">
+      <div className="flex h-16 items-center gap-2.5 border-b border-ink-800 px-5">
+        <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-accent-500 text-sm font-bold text-ink-950">
           R
         </div>
-        <Link href="/" className="text-[15px] font-semibold text-slate-900">
+        <Link href="/" className="text-[15px] font-semibold tracking-tight text-ink-100">
           Raindeer Social
         </Link>
       </div>
 
-      <div className="border-b border-slate-100 px-4 py-3">
+      <div className="border-b border-ink-800 px-4 py-3.5">
+        <p className="mb-2 px-0.5 font-mono text-[10px] font-medium uppercase tracking-widest text-ink-500">
+          Brand
+        </p>
         <BrandSwitcher />
       </div>
 
       <nav aria-label="Main navigation" className="flex-1 overflow-y-auto scrollbar-thin px-3 py-4">
+        <p className="mb-2 px-3 font-mono text-[10px] font-medium uppercase tracking-widest text-ink-500">
+          Workspace
+        </p>
         <ul className="space-y-0.5">
           {NAV_LINKS.map((link) => {
             const isActive = link.href === "/" ? pathname === "/" : pathname.startsWith(link.href);
@@ -128,14 +134,20 @@ export function Nav() {
                   href={link.href}
                   aria-current={isActive ? "page" : undefined}
                   className={cn(
-                    "flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition-colors",
+                    "flex items-center gap-3 rounded-lg border-l-2 px-3 py-2 text-sm font-medium transition-colors",
                     isActive
-                      ? "bg-brand-50 text-brand-700"
-                      : "text-slate-600 hover:bg-slate-100 hover:text-slate-900",
+                      ? "border-accent-500 bg-ink-800/70 text-accent-400"
+                      : "border-transparent text-ink-300 hover:border-ink-600 hover:bg-ink-800/50 hover:text-ink-50",
                   )}
                 >
                   <Icon />
-                  {link.label}
+                  <span className="flex-1">{link.label}</span>
+                  {isActive ? (
+                    <span
+                      aria-hidden="true"
+                      className="h-1.5 w-1.5 shrink-0 animate-pulse-dot rounded-full bg-accent-500"
+                    />
+                  ) : null}
                 </Link>
               </li>
             );
@@ -143,11 +155,14 @@ export function Nav() {
         </ul>
       </nav>
 
-      <div className="border-t border-slate-100 p-3">
+      <div className="border-t border-ink-800 p-3">
+        <p className="mb-2 px-3 font-mono text-[10px] font-medium uppercase tracking-widest text-ink-500">
+          Session
+        </p>
         <button
           type="button"
           onClick={logout}
-          className="flex w-full items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium text-slate-600 hover:bg-slate-100 hover:text-slate-900"
+          className="flex w-full items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium text-ink-300 transition-colors hover:bg-ink-800/70 hover:text-ink-50"
         >
           <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden="true">
             <path

--- a/apps/web/components/prompt-bar.tsx
+++ b/apps/web/components/prompt-bar.tsx
@@ -1,0 +1,199 @@
+"use client";
+
+import type { KeyboardEvent as ReactKeyboardEvent } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { AGENTS, DEFAULT_AGENT, type Agent } from "@/lib/agents";
+import { useToast } from "@/components/ui/Toast";
+import { cn } from "@/components/ui/cn";
+
+type Push = ReturnType<typeof useToast>["push"];
+
+// --- Integration point -----------------------------------------------
+// This is the one seam to swap when a real agent-dispatch endpoint exists:
+// replace the toast below with the API call, keep the same signature.
+function dispatchPrompt(agent: Agent, text: string, push: Push) {
+  push(`Routing to ${agent.name}: "${text.trim()}"`, "info");
+}
+// -----------------------------------------------------------------------
+
+/**
+ * Global, keyboard-first command palette. Floats a trigger pill above the
+ * app shell (mounted once from AuthGate) and opens with Cmd/Ctrl+K from
+ * anywhere. Lets a user type a free-form instruction or jump straight to
+ * one of the five pipeline agents; submitting today only surfaces a toast
+ * (see `dispatchPrompt` above) — the parsing/selection UX is otherwise
+ * exactly what a real dispatch call would need.
+ */
+export function PromptBar() {
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const [activeIndex, setActiveIndex] = useState(-1);
+  const [mounted, setMounted] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const { push } = useToast();
+
+  useEffect(() => setMounted(true), []);
+
+  const close = useCallback(() => {
+    setOpen(false);
+    setQuery("");
+    setActiveIndex(-1);
+  }, []);
+
+  useEffect(() => {
+    function onKeyDown(event: KeyboardEvent) {
+      if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "k") {
+        event.preventDefault();
+        setOpen(true);
+      }
+    }
+    document.addEventListener("keydown", onKeyDown);
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, []);
+
+  useEffect(() => {
+    if (!open) return;
+    inputRef.current?.focus();
+  }, [open]);
+
+  const submit = useCallback(
+    (agent: Agent) => {
+      dispatchPrompt(agent, query, push);
+      close();
+    },
+    [query, push, close],
+  );
+
+  function onPaletteKeyDown(event: ReactKeyboardEvent<HTMLDivElement>) {
+    if (event.key === "Escape") {
+      event.preventDefault();
+      close();
+      return;
+    }
+    if (event.key === "ArrowDown") {
+      event.preventDefault();
+      setActiveIndex((current) => (current + 1) % AGENTS.length);
+      return;
+    }
+    if (event.key === "ArrowUp") {
+      event.preventDefault();
+      setActiveIndex((current) => (current <= 0 ? AGENTS.length - 1 : current - 1));
+      return;
+    }
+    if (event.key === "Enter") {
+      event.preventDefault();
+      if (!query.trim() && activeIndex === -1) return;
+      submit(activeIndex >= 0 ? AGENTS[activeIndex] : DEFAULT_AGENT);
+    }
+  }
+
+  if (!mounted) return null;
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        aria-haspopup="dialog"
+        aria-expanded={open}
+        className={cn(
+          "fixed bottom-6 left-1/2 z-40 flex -translate-x-1/2 items-center gap-2.5 rounded-full",
+          "border border-ink-700 bg-ink-900/90 px-4 py-2.5 text-sm font-medium text-ink-200",
+          "shadow-chrome backdrop-blur transition-all duration-150",
+          "hover:-translate-y-0.5 hover:border-accent-500/60 hover:text-white",
+          "focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent-500",
+        )}
+      >
+        <span aria-hidden="true" className="font-mono text-accent-400">
+          ›_
+        </span>
+        Ask anything
+        <kbd className="rounded border border-ink-600 bg-ink-800 px-1.5 py-0.5 font-mono text-[10px] text-ink-400">
+          {"⌘"}K
+        </kbd>
+      </button>
+
+      {open
+        ? createPortal(
+            <div
+              className="fixed inset-0 z-50 flex items-start justify-center bg-ink-950/70 px-4 pt-[14vh] backdrop-blur-sm animate-fade-in"
+              onClick={close}
+            >
+              <div
+                role="dialog"
+                aria-modal="true"
+                aria-label="Prompt bar"
+                onClick={(event) => event.stopPropagation()}
+                onKeyDown={onPaletteKeyDown}
+                className="w-full max-w-xl animate-slide-up overflow-hidden rounded-2xl border border-ink-700 bg-ink-900 shadow-chrome"
+              >
+                <div className="flex items-center gap-3 border-b border-ink-800 px-4 py-3.5">
+                  <span aria-hidden="true" className="font-mono text-lg text-accent-400">
+                    ›
+                  </span>
+                  <input
+                    ref={inputRef}
+                    value={query}
+                    onChange={(event) => setQuery(event.target.value)}
+                    placeholder="Type an instruction, or jump to an agent…"
+                    aria-label="Instruction"
+                    className="flex-1 bg-transparent text-[15px] text-ink-100 placeholder:text-ink-500 focus:outline-none"
+                  />
+                  <kbd className="shrink-0 rounded border border-ink-700 bg-ink-800 px-1.5 py-0.5 font-mono text-[10px] text-ink-400">
+                    Esc
+                  </kbd>
+                </div>
+
+                <ul role="listbox" aria-label="Agents" className="max-h-80 overflow-y-auto scrollbar-thin py-2">
+                  {AGENTS.map((agent, index) => {
+                    const isActive = index === activeIndex;
+                    return (
+                      <li key={agent.id}>
+                        <button
+                          type="button"
+                          role="option"
+                          aria-selected={isActive}
+                          onMouseEnter={() => setActiveIndex(index)}
+                          onClick={() => submit(agent)}
+                          className={cn(
+                            "flex w-full items-center gap-3 px-4 py-2.5 text-left transition-colors",
+                            isActive ? "bg-ink-800" : "hover:bg-ink-800/60",
+                          )}
+                        >
+                          <span
+                            aria-hidden="true"
+                            className={cn(
+                              "flex h-8 w-8 shrink-0 items-center justify-center rounded-lg font-mono text-xs font-semibold transition-colors",
+                              isActive ? "bg-accent-500 text-ink-950" : "bg-ink-800 text-accent-400",
+                            )}
+                          >
+                            {agent.initial}
+                          </span>
+                          <span className="min-w-0 flex-1">
+                            <span className="flex items-baseline gap-2">
+                              <span className="text-sm font-semibold text-ink-100">{agent.name}</span>
+                              <span className="font-mono text-[10px] uppercase tracking-wider text-ink-500">
+                                {agent.stage}
+                              </span>
+                            </span>
+                            <span className="block truncate text-xs text-ink-400">{agent.role}</span>
+                          </span>
+                          {isActive ? (
+                            <kbd className="hidden shrink-0 rounded border border-ink-600 bg-ink-900 px-1.5 py-0.5 font-mono text-[10px] text-ink-400 sm:block">
+                              Enter
+                            </kbd>
+                          ) : null}
+                        </button>
+                      </li>
+                    );
+                  })}
+                </ul>
+              </div>
+            </div>,
+            document.body,
+          )
+        : null}
+    </>
+  );
+}

--- a/apps/web/lib/agents.ts
+++ b/apps/web/lib/agents.ts
@@ -1,0 +1,57 @@
+// Product-facing names for the five pipeline stages in `packages/agents/`.
+// The backend module names stay plain and descriptive (research_engine.py,
+// creative_engine.py, ...) — these personas are UI branding only, used by
+// the global prompt bar to let a user address a stage by name instead of
+// only interacting with it through a dedicated page.
+export interface Agent {
+  id: string;
+  name: string;
+  stage: string;
+  role: string;
+  /** Single letter shown in the prompt bar's agent badge. */
+  initial: string;
+}
+
+export const AGENTS: Agent[] = [
+  {
+    id: "aarav",
+    name: "Aarav",
+    stage: "Onboarding",
+    role: "Scrapes the brand's website, asks clarifying questions, captures logo/theme, and produces the brand report every other agent works from.",
+    initial: "A",
+  },
+  {
+    id: "ved",
+    name: "Ved",
+    stage: "Research",
+    role: "Researches what's working right now in the brand's niche, on demand or on a schedule.",
+    initial: "V",
+  },
+  {
+    id: "keshav",
+    name: "Keshav",
+    stage: "Creative",
+    role: "Turns Ved's research into a concrete creative brief — format, angle, hook, CTA.",
+    initial: "K",
+  },
+  {
+    id: "kavi",
+    name: "Kavi",
+    stage: "Generative",
+    role: "Writes the post copy and generates the accompanying image(s) from Keshav's brief.",
+    initial: "K",
+  },
+  {
+    id: "neer",
+    name: "Neer",
+    stage: "Reviewer",
+    role: "Reviews each draft for brand hygiene, logo placement, and platform fit before it reaches a human.",
+    initial: "N",
+  },
+];
+
+// Free-form instructions that aren't explicitly routed to one agent (no
+// arrow-key selection made before Enter) fall back to Ved — most ad hoc
+// asks ("what's trending", "research X") start with research, and it's the
+// same agent the issue's own example ("research competitor X") points to.
+export const DEFAULT_AGENT = AGENTS[1];

--- a/apps/web/tailwind.config.ts
+++ b/apps/web/tailwind.config.ts
@@ -17,14 +17,54 @@ const config: Config = {
           800: "#5b21b6",
           900: "#4c1d95",
         },
+        // Dark, near-black "chrome" scale for the app shell (sidebar, the
+        // command palette panel) — this is what gives the app its
+        // n8n-style "workflow tool" feel. Page *content* (cards, forms,
+        // tables) intentionally stays on the light `slate` scale so it
+        // remains as readable as before; only the surrounding shell uses
+        // `ink`.
+        ink: {
+          950: "#0b0b10",
+          900: "#131318",
+          800: "#1b1b22",
+          700: "#26262f",
+          600: "#34343f",
+          500: "#4b4b59",
+          400: "#71717e",
+          300: "#9a9aa6",
+          200: "#c4c4cc",
+          100: "#e6e6ea",
+        },
+        // Coral/amber "signal" accent used sparingly against the dark
+        // chrome (active nav item, palette trigger, keyboard hints) —
+        // distinct from `brand`, which stays the primary action color
+        // used throughout page content.
+        accent: {
+          50: "#fff3f0",
+          100: "#ffe4dc",
+          200: "#ffc4b3",
+          300: "#ff9d84",
+          400: "#ff7a5c",
+          500: "#f9603f",
+          600: "#e6472a",
+          700: "#c13620",
+          800: "#992a19",
+          900: "#7a2415",
+        },
       },
       fontFamily: {
         sans: ["var(--font-inter)", "system-ui", "sans-serif"],
+        // Technical/monospace accent used for shell chrome — nav section
+        // labels, keyboard-shortcut hints, agent-id tags — not for body
+        // copy or form content.
+        mono: ["var(--font-mono)", "ui-monospace", "SFMono-Regular", "Menlo", "monospace"],
       },
       boxShadow: {
         card: "0 1px 2px 0 rgb(0 0 0 / 0.03), 0 1px 3px 0 rgb(0 0 0 / 0.06)",
         "card-hover": "0 4px 6px -1px rgb(0 0 0 / 0.05), 0 2px 4px -2px rgb(0 0 0 / 0.05)",
         popover: "0 10px 15px -3px rgb(0 0 0 / 0.08), 0 4px 6px -4px rgb(0 0 0 / 0.08)",
+        // Denser, flatter shadow for elements sitting on the dark shell.
+        chrome: "0 8px 24px -8px rgb(0 0 0 / 0.5)",
       },
       borderRadius: {
         xl2: "1rem",
@@ -35,10 +75,15 @@ const config: Config = {
           from: { opacity: "0", transform: "translateY(4px)" },
           to: { opacity: "1", transform: "translateY(0)" },
         },
+        "pulse-dot": {
+          "0%, 100%": { opacity: "1" },
+          "50%": { opacity: "0.35" },
+        },
       },
       animation: {
         "fade-in": "fade-in 0.15s ease-out",
         "slide-up": "slide-up 0.2s ease-out",
+        "pulse-dot": "pulse-dot 1.8s ease-in-out infinite",
       },
     },
   },

--- a/apps/web/tailwind.config.ts
+++ b/apps/web/tailwind.config.ts
@@ -59,6 +59,9 @@ const config: Config = {
         // copy or form content.
         mono: ["var(--font-mono)", "ui-monospace", "SFMono-Regular", "Menlo", "monospace"],
       },
+      backdropBlur: {
+        xs: "2px",
+      },
       boxShadow: {
         card: "0 1px 2px 0 rgb(0 0 0 / 0.03), 0 1px 3px 0 rgb(0 0 0 / 0.06)",
         "card-hover": "0 4px 6px -1px rgb(0 0 0 / 0.05), 0 2px 4px -2px rgb(0 0 0 / 0.05)",


### PR DESCRIPTION
## Linked issue
Closes #111

## Why
The dashboard read as a generic light admin panel. This restyles the app shell toward n8n's dark/technical aesthetic and adds a global, keyboard-first prompt bar so a user can address a pipeline agent directly ("research competitor X" -> Ved) instead of only through dedicated pages — without touching the existing sidebar+pages architecture (no canvas/node editor, as scoped).

Builds on the design tokens seeded in a prior commit on this branch (`ink` dark scale, `accent` coral/amber, `mono` font family, `chrome` shadow, `pulse-dot` animation).

## What changed

**Shell / nav (`components/nav.tsx`, `components/brand-switcher.tsx`, `components/auth-gate.tsx`)**
- Sidebar commits fully to the dark `ink` scale: a subtle `ink-900 -> ink-950` gradient for depth, a crisp 1px `ink-800` border seam against the light content area, and `shadow-chrome` for a denser, flatter shadow than the light-theme card shadows.
- Three sections get muted, mono, uppercase labels (`Brand`, `Workspace`, `Session`) — the "technical tool" texture the issue asked for, not body copy.
- The active nav link gets the `accent-500` treatment (text + left border) plus a small `pulse-dot` — a live "you are here" indicator, using the animation token the way it's meant to be used (signal, not decoration).
- `BrandSwitcher` re-themed for the dark shell (same `<select>`/props/DOM — existing tests untouched).
- Page *content* (cards, forms, tables) is deliberately left on the light `slate`/`brand` scale, per the issue's scope.

**Global prompt bar (`components/prompt-bar.tsx`, `lib/agents.ts`) — the centerpiece**
- A floating pill trigger, bottom-center (`Ask anything` + a `⌘K` hint), styled to match the dark shell (ink border/bg, backdrop blur, lifts slightly + accent border on hover).
- `Cmd/Ctrl+K` opens it from anywhere in the app (global `keydown` listener), same as clicking the pill.
- Opening shows a dark, blurred overlay (`bg-ink-950/70` + `backdrop-blur-sm`) with a centered panel: a large borderless instruction input up top, and the 5 pipeline agents below as rows — initial badge, name, mono uppercase stage label, one-line role, keyed by `lib/agents.ts` (`Aarav`/`Ved`/`Keshav`/`Kavi`/`Neer`).
  - The current `main`/README doesn't yet have the "Meet the agents" section (that's a separate, unmerged branch — `feature/issue-104-agent-branding`). I pulled the exact names and one-liners from that branch's introducing commit rather than inventing new copy, so the descriptions here will match once #104 lands.
- Fully keyboard-driven: `ArrowUp`/`ArrowDown` moves the active row (wrapping), `Enter` submits, `Escape` or a backdrop click closes. Hovering a row also sets it active, so mouse and keyboard stay in sync.
- Submit routes to the arrow-selected agent if one is active; otherwise (typed text, no explicit selection) it defaults to **Ved** — most ad hoc asks start with research, and it's the same agent the issue's own example points to. This default is a named constant (`DEFAULT_AGENT` in `lib/agents.ts`) with the reasoning in a comment, so it's easy to change later.
- Submitting calls one function, `dispatchPrompt(agent, text, push)` in `prompt-bar.tsx`, which today only pushes a toast (`Routing to Ved: "…"` via the existing `useToast()`). It's commented as the integration point — swapping in a real dispatch call is a one-function change, no UI rewiring needed.
- Open/close uses the existing `fade-in`/`slide-up` animation tokens so it feels consistent with `Modal`/`Toast` rather than introducing new motion language.

**Bug fix carried along**: the tailwind config seeded in the prior commit pointed `mono` at `var(--font-mono)`, but nothing ever defined that CSS variable — so `font-mono` was silently falling back to the browser default serif, not a monospace face. Wired up `next/font`'s `JetBrains_Mono` in `app/layout.tsx` the same way `Inter` already is, so the "technical monospace accent" the tokens describe actually renders as one.

## Design decisions at a glance
- **Colors**: `ink` (near-black shell) + `accent` (coral/amber signal color) for chrome; `slate`/`brand` untouched for content — matches the "don't recolor content" instruction.
- **Motion**: `pulse-dot` reserved for one honest use (current-page liveness in nav) rather than fabricating fake agent activity states; palette open/close reuses `fade-in`/`slide-up`.
- **Typography**: JetBrains Mono for all-caps section labels, agent stage tags, and keyboard hints; body/prose stays on Inter.
- **Layout**: prompt bar trigger is bottom-center (not bottom-right) to stay clear of the existing bottom-right toast stack.

## How I tested this
- `npx vitest run` in `apps/web` — 64/64 passing (57 pre-existing + 7 new in `__tests__/prompt-bar.test.tsx`). Had to update `__tests__/auth-gate.test.tsx` to wrap in `ToastProvider`, matching how `app/layout.tsx` actually nests providers now that `AuthGate` mounts `PromptBar` (which calls `useToast()`).
- `npx tsc --noEmit` — clean.
- `npm run lint` — clean (one pre-existing, unrelated `next/image` warning on `Avatar.tsx`).
- `npm run build` — clean production build, confirms the Google Fonts fetch for JetBrains Mono succeeds at build time.
- Manual pass in a real browser (`npm run dev`): opened via click and via `⌘K`, arrow-navigated the agent list, submitted both an explicit selection and free text, confirmed the toast text and default-routing behavior, confirmed Escape/backdrop-click close.

## Screenshots / recording
Not attached — see the design decisions section above and the diff for exact markup/classes; happy to add a recording if useful.

## Checklist
- [x] Tests added/updated and passing locally
- [x] `tsc`, `lint`, `build` clean
- [x] No existing component props/APIs changed
- [x] Branch pushed to `origin` (same-repo), not a fork