### PR TITLE
Design system: migrate to Raindeer mockup visual language (foundation)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,6 @@ Thumbs.db
 .cache/
 tmp/
 *.tmp
+
+# --- Design reference material (not app code) ---
+/Raindeer Social Startup Onboarding/

--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -10,7 +10,11 @@ from apps.api.observability import init_sentry
 from apps.api.routers.analytics import router as analytics_router
 from apps.api.routers.brands import router as brands_router
 from apps.api.routers.calendar import router as calendar_router
+from apps.api.routers.content_ai import router as content_ai_router
+from apps.api.routers.creative import router as creative_router
 from apps.api.routers.onboarding import router as onboarding_router
+from apps.api.routers.posts import router as posts_router
+from apps.api.routers.research import router as research_router
 from apps.api.routers.review import router as review_router
 from apps.api.routers.social_accounts import router as social_accounts_router
 
@@ -39,7 +43,11 @@ app.include_router(auth_router)
 app.include_router(analytics_router)
 app.include_router(brands_router)
 app.include_router(calendar_router)
+app.include_router(content_ai_router)
+app.include_router(creative_router)
 app.include_router(onboarding_router)
+app.include_router(posts_router)
+app.include_router(research_router)
 app.include_router(review_router)
 app.include_router(social_accounts_router)
 

--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -8,6 +8,7 @@ from apps.api.middleware.logging import RequestLoggingMiddleware, configure_json
 from apps.api.middleware.rate_limit import RateLimitMiddleware
 from apps.api.observability import init_sentry
 from apps.api.routers.analytics import router as analytics_router
+from apps.api.routers.arena import router as arena_router
 from apps.api.routers.brands import router as brands_router
 from apps.api.routers.calendar import router as calendar_router
 from apps.api.routers.onboarding import router as onboarding_router
@@ -37,6 +38,7 @@ app.add_middleware(
 )
 app.include_router(auth_router)
 app.include_router(analytics_router)
+app.include_router(arena_router)
 app.include_router(brands_router)
 app.include_router(calendar_router)
 app.include_router(onboarding_router)

--- a/apps/api/routers/arena.py
+++ b/apps/api/routers/arena.py
@@ -1,0 +1,123 @@
+"""Issue #124 — read-only endpoint composing one pipeline run's AgentRun
+history, Post, and ReviewFeedback rows for the Content Arena screen
+(apps/web/app/arena/page.tsx) to render as a DAG. Nothing here writes
+anything — see schemas/arena.py's docstring for why this exists as its own
+join rather than the frontend fetching three separate endpoints (one of
+which, AgentRun, doesn't have a list endpoint at all yet) and stitching
+them together itself.
+"""
+
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from apps.api.auth.dependencies import CurrentUser, get_current_user
+from apps.api.config.database import get_db
+from apps.api.models import AgentRun, Brand, ContentCalendarEvent, Post, ReviewFeedback
+from apps.api.schemas.arena import (
+    ArenaAgentRunRead,
+    ArenaPostRead,
+    ArenaReviewFeedbackRead,
+    ArenaRunRead,
+)
+from packages.agents.pipeline.graph import PIPELINE_STAGES
+
+router = APIRouter(prefix="/brands/{brand_id}/arena", tags=["arena"])
+
+# Every AgentRun row run_pipeline (packages/agents/pipeline/graph.py) logs
+# for a single run_pipeline() call is written inside that call's one open
+# transaction, and Postgres's now() (what AgentRun.created_at's
+# server_default resolves to) is constant for the whole transaction — so
+# rows from the same run can share an identical created_at and a plain
+# `ORDER BY created_at` can't tell them apart. Breaking ties by each row's
+# position in the pipeline's own stage order gives the correct sequence
+# for that common case while still respecting created_at across genuinely
+# separate runs/resumes (e.g. a human_review approval that resumes the
+# graph in a later request/transaction).
+_STAGE_ORDER = {stage: index for index, stage in enumerate(PIPELINE_STAGES)}
+
+
+def _agent_run_sort_key(run: AgentRun) -> tuple:
+    return (run.created_at, _STAGE_ORDER.get(run.agent_type.value, len(PIPELINE_STAGES)))
+
+
+def _get_org_brand(db: Session, brand_id: uuid.UUID, org_id: str) -> Brand:
+    brand = (
+        db.query(Brand)
+        .filter(Brand.id == brand_id, Brand.organization_id == uuid.UUID(org_id))
+        .first()
+    )
+    if brand is None:
+        # 404, not 403 — don't leak whether a brand with this id exists in
+        # another org. Same convention as review.py/calendar.py.
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Brand not found")
+    return brand
+
+
+def _run_for_post(db: Session, post: Post | None, calendar_event_id: uuid.UUID | None) -> ArenaRunRead:
+    if post is None:
+        return ArenaRunRead(
+            calendar_event_id=calendar_event_id, post=None, agent_runs=[], review_feedback=[]
+        )
+
+    agent_runs = sorted(
+        db.query(AgentRun).filter(AgentRun.post_id == post.id).all(),
+        key=_agent_run_sort_key,
+    )
+    review_feedback = (
+        db.query(ReviewFeedback)
+        .filter(ReviewFeedback.post_id == post.id)
+        .order_by(ReviewFeedback.created_at)
+        .all()
+    )
+    return ArenaRunRead(
+        calendar_event_id=post.calendar_event_id,
+        post=ArenaPostRead.model_validate(post),
+        agent_runs=[ArenaAgentRunRead.model_validate(run) for run in agent_runs],
+        review_feedback=[ArenaReviewFeedbackRead.model_validate(f) for f in review_feedback],
+    )
+
+
+@router.get("/by-event/{event_id}", response_model=ArenaRunRead)
+def get_arena_run_for_event(
+    brand_id: uuid.UUID,
+    event_id: uuid.UUID,
+    db: Session = Depends(get_db),
+    current_user: CurrentUser = Depends(get_current_user),
+) -> ArenaRunRead:
+    """The pipeline run for one calendar event. packages/agents/pipeline/
+    trigger.py's _get_or_create_post keeps a 1:1 ContentCalendarEvent:Post
+    relationship, so there is at most one Post to find here — None if the
+    event hasn't been triggered yet (still SCHEDULED)."""
+    brand = _get_org_brand(db, brand_id, current_user.org_id)
+    event = (
+        db.query(ContentCalendarEvent)
+        .filter(ContentCalendarEvent.id == event_id, ContentCalendarEvent.brand_id == brand.id)
+        .first()
+    )
+    if event is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Calendar event not found")
+
+    post = db.query(Post).filter(Post.calendar_event_id == event.id).first()
+    return _run_for_post(db, post, event.id)
+
+
+@router.get("/latest", response_model=ArenaRunRead)
+def get_latest_arena_run(
+    brand_id: uuid.UUID,
+    db: Session = Depends(get_db),
+    current_user: CurrentUser = Depends(get_current_user),
+) -> ArenaRunRead:
+    """The brand's most recently created Post — the run the Arena canvas
+    opens by default when it isn't deep-linked to a specific calendar
+    event. `post` is None (and agent_runs/review_feedback empty) when the
+    brand has no posts yet at all."""
+    brand = _get_org_brand(db, brand_id, current_user.org_id)
+    post = (
+        db.query(Post)
+        .filter(Post.brand_id == brand.id)
+        .order_by(Post.created_at.desc())
+        .first()
+    )
+    return _run_for_post(db, post, post.calendar_event_id if post else None)

--- a/apps/api/routers/content_ai.py
+++ b/apps/api/routers/content_ai.py
@@ -1,0 +1,98 @@
+"""Issue #126 — the Content AI workspace page's API surface: the
+image-first fast path that skips copywriting entirely and goes straight
+to visuals.
+
+Generation Engine's media hook (packages/agents/pipeline/nodes/
+generation_engine.py) already calls the real fal.ai-backed adapter
+(Issue #22, packages/integrations/image_gen/fal_provider.py) through
+ImageProvider — but only ever as a step of the per-post pipeline, driven
+by a creative brief's `format` field. This endpoint calls a sibling
+function, generate_standalone_images (added alongside that hook), which
+reuses the exact same ImageProvider + StorageProvider interface calls
+without requiring a Post or creative brief — just a free-form prompt plus
+the aspect-ratio/style/brand-lock choices the Content AI page collects.
+
+Logged as an AgentRun(agent_type=GENERATION, post_id=None) — same
+"no Post exists for a standalone call" convention apps/api/routers/
+creative.py's angle endpoint uses.
+"""
+
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from apps.api.auth.dependencies import CurrentUser
+from apps.api.config.database import get_db
+from apps.api.middleware.rbac import require_role
+from apps.api.models import AgentRun, AgentType, Brand, UserRole
+from apps.api.schemas.content_ai import ContentAIGenerateRequest, ContentAIGenerateResponse
+from packages.agents.pipeline.nodes.generation_engine import generate_standalone_images
+
+router = APIRouter(prefix="/brands/{brand_id}/content-ai", tags=["content-ai"])
+
+WRITE_ROLES = (UserRole.OWNER, UserRole.ADMIN, UserRole.EDITOR)
+
+
+def _get_org_brand(db: Session, brand_id: uuid.UUID, org_id: str) -> Brand:
+    brand = (
+        db.query(Brand)
+        .filter(Brand.id == brand_id, Brand.organization_id == uuid.UUID(org_id))
+        .first()
+    )
+    if brand is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Brand not found")
+    return brand
+
+
+def _compose_prompt(brand: Brand, payload: ContentAIGenerateRequest) -> str:
+    """Folds the page's aspect-ratio/style/brand-lock choices into the
+    prompt handed to ImageProvider — no client-side image manipulation,
+    just richer prompt text, same "reshape what's already decided, don't
+    invent a second code path" spirit as generation_engine.py's own
+    _build_image_prompt."""
+    parts = [payload.prompt.strip()]
+    if payload.style:
+        parts.append(f"Style: {payload.style}.")
+    if payload.aspect_ratio:
+        parts.append(f"Aspect ratio: {payload.aspect_ratio}.")
+    if payload.lock_brand_colors:
+        colors = ", ".join(brand.colors) if brand.colors else None
+        brand_hint = f"Use {brand.name}'s brand colors"
+        if colors:
+            brand_hint += f" ({colors})"
+        brand_hint += " and logo; no off-brand palettes."
+        parts.append(brand_hint)
+    return " ".join(parts)
+
+
+@router.post("/generate", response_model=ContentAIGenerateResponse, status_code=status.HTTP_201_CREATED)
+def generate_images(
+    brand_id: uuid.UUID,
+    payload: ContentAIGenerateRequest,
+    db: Session = Depends(get_db),
+    current_user: CurrentUser = Depends(require_role(*WRITE_ROLES)),
+) -> ContentAIGenerateResponse:
+    brand = _get_org_brand(db, brand_id, current_user.org_id)
+
+    prompt = _compose_prompt(brand, payload)
+    variants = generate_standalone_images(prompt, count=payload.count, path_prefix=str(brand.id))
+
+    db.add(
+        AgentRun(
+            post_id=None,
+            agent_type=AgentType.GENERATION,
+            input={
+                "brand_id": str(brand.id),
+                "prompt": payload.prompt,
+                "aspect_ratio": payload.aspect_ratio,
+                "style": payload.style,
+                "lock_brand_colors": payload.lock_brand_colors,
+                "count": payload.count,
+            },
+            output={"variants": variants},
+        )
+    )
+    db.flush()
+
+    return ContentAIGenerateResponse(variants=variants)

--- a/apps/api/routers/creative.py
+++ b/apps/api/routers/creative.py
@@ -1,0 +1,68 @@
+"""Issue #126 — the standalone Creative workspace page's API surface.
+
+Creative Engine (Issue #20) previously only ran as the pipeline's second
+stage, turning an upstream Research brief into one per-platform brief.
+The Creative page instead takes a free-form brief typed directly by the
+user and wants six distinct angle/format cards to choose from — a
+different shape (many candidate angles, not one brief per platform), so
+this calls a sibling function, generate_creative_angles (added alongside
+_creative_brief in packages/agents/pipeline/nodes/creative_engine.py),
+rather than the existing per-post node. Same LLMProvider-only,
+degrade-on-failure contract as the rest of that module.
+
+Logged as an AgentRun(agent_type=CREATIVE, post_id=None) — no Post exists
+for a standalone angle-generation call, same "post_id null, context in
+input" convention apps/api/models/agent_run.py documents for
+weekly_report.py.
+"""
+
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from apps.api.auth.dependencies import CurrentUser
+from apps.api.config.database import get_db
+from apps.api.middleware.rbac import require_role
+from apps.api.models import AgentRun, AgentType, Brand, UserRole
+from apps.api.schemas.creative import CreativeAnglesRequest, CreativeAnglesResponse
+from packages.agents.pipeline.nodes.creative_engine import generate_creative_angles
+
+router = APIRouter(prefix="/brands/{brand_id}/creative", tags=["creative"])
+
+WRITE_ROLES = (UserRole.OWNER, UserRole.ADMIN, UserRole.EDITOR)
+
+
+def _get_org_brand(db: Session, brand_id: uuid.UUID, org_id: str) -> Brand:
+    brand = (
+        db.query(Brand)
+        .filter(Brand.id == brand_id, Brand.organization_id == uuid.UUID(org_id))
+        .first()
+    )
+    if brand is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Brand not found")
+    return brand
+
+
+@router.post("/angles", response_model=CreativeAnglesResponse, status_code=status.HTTP_201_CREATED)
+def generate_angles(
+    brand_id: uuid.UUID,
+    payload: CreativeAnglesRequest,
+    db: Session = Depends(get_db),
+    current_user: CurrentUser = Depends(require_role(*WRITE_ROLES)),
+) -> CreativeAnglesResponse:
+    brand = _get_org_brand(db, brand_id, current_user.org_id)
+
+    angles = generate_creative_angles(brand, payload.brief, count=payload.count)
+
+    db.add(
+        AgentRun(
+            post_id=None,
+            agent_type=AgentType.CREATIVE,
+            input={"brand_id": str(brand.id), "brief": payload.brief, "count": payload.count},
+            output={"angles": angles},
+        )
+    )
+    db.flush()
+
+    return CreativeAnglesResponse(angles=angles)

--- a/apps/api/routers/posts.py
+++ b/apps/api/routers/posts.py
@@ -1,0 +1,59 @@
+"""Issue #126 — a general, read-only Post listing for a brand.
+
+Every existing Post-reading endpoint is scoped to one pipeline stage:
+apps/api/routers/review.py's review-queue only lists Posts paused at
+human_review, and apps/api/routers/calendar.py returns
+ContentCalendarEvent rows, whose own status field a rejection never
+updates (see packages/agents/pipeline/graph.py — rejecting only ever sets
+Post.current_pipeline_stage to REJECTED). The Create Post page's "Recent
+runs" list needs every Post regardless of stage — including terminal
+REJECTED/FAILED ones — so it can show a real "Blocked" status rather than
+one invented for the UI. This router adds exactly that: one additive,
+read-only endpoint over the existing Post table.
+"""
+
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from apps.api.auth.dependencies import CurrentUser, get_current_user
+from apps.api.config.database import get_db
+from apps.api.models import Brand, Post
+from apps.api.schemas.post import PostRead
+
+router = APIRouter(prefix="/brands/{brand_id}/posts", tags=["posts"])
+
+DEFAULT_LIMIT = 20
+MAX_LIMIT = 100
+
+
+def _get_org_brand(db: Session, brand_id: uuid.UUID, org_id: str) -> Brand:
+    brand = (
+        db.query(Brand)
+        .filter(Brand.id == brand_id, Brand.organization_id == uuid.UUID(org_id))
+        .first()
+    )
+    if brand is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Brand not found")
+    return brand
+
+
+@router.get("", response_model=list[PostRead])
+def list_posts(
+    brand_id: uuid.UUID,
+    limit: int = DEFAULT_LIMIT,
+    db: Session = Depends(get_db),
+    current_user: CurrentUser = Depends(get_current_user),
+) -> list[Post]:
+    """Every Post for this brand, newest first, regardless of pipeline
+    stage — for the Create Post page's "Recent runs" list."""
+    brand = _get_org_brand(db, brand_id, current_user.org_id)
+    capped_limit = max(1, min(limit, MAX_LIMIT))
+    return (
+        db.query(Post)
+        .filter(Post.brand_id == brand.id)
+        .order_by(Post.created_at.desc())
+        .limit(capped_limit)
+        .all()
+    )

--- a/apps/api/routers/research.py
+++ b/apps/api/routers/research.py
@@ -1,0 +1,119 @@
+"""Issue #126 — the standalone Research workspace page's API surface.
+
+Before this, Research Engine (Issue #19) only ran as one stage of the
+per-post pipeline (packages/agents/pipeline/graph.py) — there was no way
+to see fresh trend results without paying for Creative/Generation/
+Reviewer/Human Review too. This router exposes exactly the Research
+Engine's own logic (packages/agents/pipeline/nodes/research_engine.py's
+run_standalone_research, a thin wrapper around the same _research_brief
+the pipeline node uses) through two endpoints:
+
+  * POST .../research/run    — runs a fresh standalone research brief for
+                                the brand right now.
+  * GET  .../research/latest — returns the most recent standalone (or
+                                pipeline) research brief for the brand
+                                without re-running anything, for the page
+                                to render on load.
+
+A standalone run is stored the same way every other AgentRun is (Issue
+#18's convention): as an AgentRun(agent_type=RESEARCH) row. Since
+AgentRun has no brand_id column, it's tied to an ad hoc Post (brand_id
+set, calendar_event_id left null) — the same "a post can be generated ad
+hoc" case apps/api/models/post.py already documents, rather than a
+one-off schema change to AgentRun.
+"""
+
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from apps.api.auth.dependencies import CurrentUser, get_current_user
+from apps.api.config.database import get_db
+from apps.api.middleware.rbac import require_role
+from apps.api.models import AgentRun, AgentType, Brand, Post, UserRole
+from apps.api.schemas.research import ResearchRunRead
+from packages.agents.pipeline.nodes.research_engine import run_standalone_research
+
+router = APIRouter(prefix="/brands/{brand_id}/research", tags=["research"])
+
+WRITE_ROLES = (UserRole.OWNER, UserRole.ADMIN, UserRole.EDITOR)
+
+
+def _get_org_brand(db: Session, brand_id: uuid.UUID, org_id: str) -> Brand:
+    brand = (
+        db.query(Brand)
+        .filter(Brand.id == brand_id, Brand.organization_id == uuid.UUID(org_id))
+        .first()
+    )
+    if brand is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Brand not found")
+    return brand
+
+
+def _to_read(run: AgentRun, brand_id: uuid.UUID) -> ResearchRunRead:
+    return ResearchRunRead(
+        id=run.id,
+        post_id=run.post_id,
+        brand_id=brand_id,
+        created_at=run.created_at,
+        brief=run.output or {},
+    )
+
+
+@router.post("/run", response_model=ResearchRunRead, status_code=status.HTTP_201_CREATED)
+def run_research(
+    brand_id: uuid.UUID,
+    db: Session = Depends(get_db),
+    current_user: CurrentUser = Depends(require_role(*WRITE_ROLES)),
+) -> ResearchRunRead:
+    """Runs a fresh standalone research brief for this brand and logs it
+    as an AgentRun, same as the pipeline's own research stage does — just
+    without a full pipeline run around it."""
+    brand = _get_org_brand(db, brand_id, current_user.org_id)
+
+    post = Post(brand_id=brand.id)
+    db.add(post)
+    db.flush()
+    db.refresh(post)
+
+    brief = run_standalone_research(db, post)
+
+    run = AgentRun(
+        post_id=post.id,
+        agent_type=AgentType.RESEARCH,
+        input={"post_id": str(post.id), "trigger": "standalone"},
+        output=brief,
+    )
+    db.add(run)
+    db.flush()
+    db.refresh(run)
+
+    return _to_read(run, brand.id)
+
+
+@router.get("/latest", response_model=ResearchRunRead)
+def latest_research(
+    brand_id: uuid.UUID,
+    db: Session = Depends(get_db),
+    current_user: CurrentUser = Depends(get_current_user),
+) -> ResearchRunRead:
+    """The most recent research brief for this brand (standalone or from
+    a per-post pipeline run) — lets the page show what's already known
+    without triggering a new run just to view it."""
+    brand = _get_org_brand(db, brand_id, current_user.org_id)
+
+    run = (
+        db.query(AgentRun)
+        .join(Post, AgentRun.post_id == Post.id)
+        .filter(Post.brand_id == brand.id, AgentRun.agent_type == AgentType.RESEARCH)
+        .order_by(AgentRun.created_at.desc())
+        .first()
+    )
+    if run is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="No research has been run yet for this brand",
+        )
+
+    return _to_read(run, brand.id)

--- a/apps/api/schemas/arena.py
+++ b/apps/api/schemas/arena.py
@@ -1,0 +1,86 @@
+"""Issue #124 — read-only composition of one pipeline run for the Content
+Arena screen (apps/web/app/arena/page.tsx) to render as a DAG: the
+ContentCalendarEvent it's for (if any), the Post it produced, every
+AgentRun row logged for that Post so far, and the Post's full
+ReviewFeedback history. Nothing here writes anything — it's a join over
+three tables the pipeline (packages/agents/pipeline/graph.py) already
+populates node-by-node, so the Arena canvas doesn't have to stitch
+together several existing endpoints (none of which currently expose
+AgentRun at all) itself.
+"""
+
+import uuid
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict
+
+from apps.api.models.agent_run import AgentType
+from apps.api.models.post import PipelineStage
+from apps.api.models.review_feedback import ReviewSource, ReviewVerdict
+
+
+class ArenaAgentRunRead(BaseModel):
+    """Mirrors apps/api/models/agent_run.py::AgentRun. `input` is
+    deliberately omitted: run_pipeline (packages/agents/pipeline/graph.py)
+    only ever writes {"post_id": ...} into it, never a real prompt, so it
+    has nothing an inspector panel could usefully show. `output` is kept
+    since it's the node's real structured result (research_brief /
+    creative_brief / generation_output / review_output, per stage)."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    agent_type: AgentType
+    output: dict | None
+    model: str | None
+    tokens: int | None
+    cost: float | None
+    latency_ms: float | None
+    created_at: datetime
+
+
+class ArenaReviewFeedbackRead(BaseModel):
+    """Same shape as apps/api/schemas/review.py::ReviewFeedbackRead, minus
+    post_id (redundant here — the whole payload is already scoped to one
+    post)."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    source: ReviewSource
+    score: float
+    verdict: ReviewVerdict
+    comments: dict
+    created_at: datetime
+
+
+class ArenaPostRead(BaseModel):
+    """A thin Post projection — just what the Arena canvas needs to know
+    where the run stands and what it produced, not the full Post row
+    (publish_results/publish_error are omitted; they're the publish
+    queue's concern, not this run's DAG)."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    calendar_event_id: uuid.UUID | None
+    current_pipeline_stage: PipelineStage
+    body_text: dict | None
+    media: list | None
+    created_at: datetime
+    updated_at: datetime
+
+
+class ArenaRunRead(BaseModel):
+    """One pipeline run, in a shape the Content Arena canvas (Issue #124)
+    can render directly: the calendar event it's for (if any), the Post it
+    produced (None if the event has no Post yet — e.g. still SCHEDULED),
+    every AgentRun row logged for that Post so far — oldest first, the
+    same order the pipeline graph actually executed them in — and the
+    Post's full review history (AI + human, same "one ordered log"
+    convention as apps/api/schemas/review.py::ReviewQueuePostRead)."""
+
+    calendar_event_id: uuid.UUID | None
+    post: ArenaPostRead | None
+    agent_runs: list[ArenaAgentRunRead]
+    review_feedback: list[ArenaReviewFeedbackRead]

--- a/apps/api/schemas/content_ai.py
+++ b/apps/api/schemas/content_ai.py
@@ -1,0 +1,28 @@
+from pydantic import BaseModel, Field
+
+DEFAULT_VARIANT_COUNT = 4
+MAX_VARIANT_COUNT = 4
+
+
+class ContentAIGenerateRequest(BaseModel):
+    """Body for POST .../content-ai/generate — the Content AI page's
+    image-first fast path. `prompt` is the free-form image description;
+    `aspect_ratio`/`style` are folded into the composed prompt handed to
+    ImageProvider, and `lock_brand_colors` appends an instruction to stay
+    within the brand's palette/logo rather than doing any client-side
+    color manipulation."""
+
+    prompt: str = Field(min_length=1)
+    aspect_ratio: str | None = None
+    style: str | None = None
+    lock_brand_colors: bool = True
+    count: int = Field(default=DEFAULT_VARIANT_COUNT, ge=1, le=MAX_VARIANT_COUNT)
+
+
+class ContentAIVariantRead(BaseModel):
+    status: str
+    url: str | None
+
+
+class ContentAIGenerateResponse(BaseModel):
+    variants: list[ContentAIVariantRead]

--- a/apps/api/schemas/creative.py
+++ b/apps/api/schemas/creative.py
@@ -1,0 +1,24 @@
+from pydantic import BaseModel, Field
+
+from packages.agents.pipeline.nodes.creative_engine import ANGLE_COUNT
+
+
+class CreativeAnglesRequest(BaseModel):
+    """Body for POST .../creative/angles. `brief` is the Creative page's
+    free-form textarea — the only input generate_creative_angles needs."""
+
+    brief: str = Field(min_length=1)
+    count: int = Field(default=ANGLE_COUNT, ge=1, le=ANGLE_COUNT)
+
+
+class CreativeAngleRead(BaseModel):
+    format: str
+    angle: str
+    hook: str
+    why: str
+    cta: str
+    score: int
+
+
+class CreativeAnglesResponse(BaseModel):
+    angles: list[CreativeAngleRead]

--- a/apps/api/schemas/post.py
+++ b/apps/api/schemas/post.py
@@ -1,0 +1,28 @@
+import uuid
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict
+
+from apps.api.models.post import PipelineStage
+
+
+class PostRead(BaseModel):
+    """Issue #126 — the Create Post page's "Recent runs" list needs every
+    Post for a brand regardless of pipeline stage (including the terminal
+    REJECTED/FAILED stages), which no existing endpoint returns: the
+    review-queue (apps/api/routers/review.py) only lists Posts paused at
+    human_review, and calendar events (apps/api/routers/calendar.py)
+    track a separate, coarser status that a rejection never updates (see
+    packages/agents/pipeline/graph.py — REJECTED only ever sets
+    Post.current_pipeline_stage). This mirrors ReviewQueuePostRead's shape
+    minus the review-history join, which "recent runs" doesn't need."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    brand_id: uuid.UUID
+    calendar_event_id: uuid.UUID | None
+    current_pipeline_stage: PipelineStage
+    body_text: dict | None
+    created_at: datetime
+    updated_at: datetime

--- a/apps/api/schemas/research.py
+++ b/apps/api/schemas/research.py
@@ -1,0 +1,20 @@
+import uuid
+from datetime import datetime
+from typing import Any
+
+from pydantic import BaseModel
+
+
+class ResearchRunRead(BaseModel):
+    """Issue #126 — one standalone Research Engine run (see
+    packages/agents/pipeline/nodes/research_engine.py::run_standalone_research),
+    surfaced outside the per-post pipeline so the Research workspace page
+    can render trend cards without a full 5-stage run. `brief` is exactly
+    the dict _research_brief produces: brand_context, platform_trends,
+    industry_trends, timing_signal."""
+
+    id: uuid.UUID
+    post_id: uuid.UUID
+    brand_id: uuid.UUID
+    created_at: datetime
+    brief: dict[str, Any]

--- a/apps/api/tests/test_arena.py
+++ b/apps/api/tests/test_arena.py
@@ -1,0 +1,270 @@
+"""Issue #124 — the Content Arena canvas's read-only run-composition
+endpoint (apps/api/routers/arena.py). Like test_review.py, this drives a
+real Post through packages.agents.pipeline.graph.run_pipeline (rather than
+hand-setting Post.current_pipeline_stage) so the AgentRun rows returned are
+the same ones the real pipeline logs, not a shortcut.
+"""
+
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+from fastapi.testclient import TestClient
+
+from apps.api.auth.jwt import create_access_token, hash_password
+from apps.api.main import app
+from apps.api.models import (
+    AgentRun,
+    AgentType,
+    Brand,
+    ContentCalendarEvent,
+    Organization,
+    Post,
+    User,
+    UserRole,
+)
+from packages.agents.pipeline.checkpointer import get_postgres_checkpointer
+from packages.agents.pipeline.graph import run_pipeline
+
+client = TestClient(app)
+uses_test_session = pytest.mark.usefixtures("override_get_db")
+
+
+@pytest.fixture()
+def thread_cleanup():
+    """Same reasoning as test_review.py's fixture of the same name:
+    pipeline checkpoint rows live in Postgres on a connection separate
+    from db_session's rolled-back transaction, so they need explicit
+    teardown."""
+    thread_ids: list[str] = []
+    yield thread_ids
+    if not thread_ids:
+        return
+    with get_postgres_checkpointer() as checkpointer:
+        for thread_id in thread_ids:
+            checkpointer.delete_thread(thread_id)
+
+
+def _setup_brand(db_session, suffix: str = "") -> tuple[Brand, User]:
+    org = Organization(name="Acme Agency")
+    db_session.add(org)
+    db_session.flush()
+
+    user = User(
+        organization_id=org.id,
+        email=f"editor{suffix}@acme.test",
+        password_hash=hash_password("test-password"),
+        role=UserRole.EDITOR,
+    )
+    brand = Brand(organization_id=org.id, name="Acme Widgets")
+    db_session.add_all([user, brand])
+    db_session.flush()
+    return brand, user
+
+
+def _auth_headers(user: User) -> dict[str, str]:
+    token = create_access_token(
+        user_id=str(user.id), org_id=str(user.organization_id), role=user.role.value
+    )
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _post_at_human_review(db_session, brand: Brand, thread_cleanup, calendar_event_id=None) -> Post:
+    """Runs a real Post through the pipeline graph up to (and pausing at)
+    the human_review interrupt, logging real AgentRun rows for research,
+    creative, generation and reviewer along the way — same mechanism
+    test_review.py uses."""
+    post = Post(brand_id=brand.id, calendar_event_id=calendar_event_id)
+    db_session.add(post)
+    db_session.flush()
+    thread_cleanup.append(str(post.id))
+
+    with get_postgres_checkpointer() as checkpointer:
+        list(run_pipeline(db_session, post, checkpointer))
+
+    db_session.refresh(post)
+    return post
+
+
+# --- by-event -------------------------------------------------------------
+
+
+@uses_test_session
+def test_get_run_for_event_returns_agent_runs_in_order(db_session, thread_cleanup) -> None:
+    brand, user = _setup_brand(db_session)
+    event = ContentCalendarEvent(
+        brand_id=brand.id,
+        title="Launch",
+        target_platforms=["linkedin"],
+        desired_format="image",
+        target_datetime=datetime(2026, 9, 1, 12, 0, tzinfo=timezone.utc),
+    )
+    db_session.add(event)
+    db_session.flush()
+
+    post = _post_at_human_review(db_session, brand, thread_cleanup, calendar_event_id=event.id)
+
+    response = client.get(
+        f"/brands/{brand.id}/arena/by-event/{event.id}", headers=_auth_headers(user)
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["calendar_event_id"] == str(event.id)
+    assert body["post"]["id"] == str(post.id)
+    assert body["post"]["current_pipeline_stage"] == "human_review"
+
+    stages = [run["agent_type"] for run in body["agent_runs"]]
+    assert stages == ["research", "creative", "generation", "reviewer"]
+    # Ordered oldest-first (pipeline execution order), not reversed.
+    timestamps = [run["created_at"] for run in body["agent_runs"]]
+    assert timestamps == sorted(timestamps)
+
+    # The AI reviewer's pass (Issue #24) is attached as review history.
+    sources = [f["source"] for f in body["review_feedback"]]
+    assert sources == ["ai_reviewer"]
+
+    # `input` is never exposed — see schemas/arena.py's docstring.
+    assert "input" not in body["agent_runs"][0]
+
+
+@uses_test_session
+def test_get_run_for_event_without_a_post_yet(db_session) -> None:
+    brand, user = _setup_brand(db_session)
+    event = ContentCalendarEvent(
+        brand_id=brand.id,
+        title="Not triggered yet",
+        target_platforms=["linkedin"],
+        desired_format="image",
+        target_datetime=datetime(2026, 9, 1, 12, 0, tzinfo=timezone.utc),
+    )
+    db_session.add(event)
+    db_session.flush()
+
+    response = client.get(
+        f"/brands/{brand.id}/arena/by-event/{event.id}", headers=_auth_headers(user)
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["calendar_event_id"] == str(event.id)
+    assert body["post"] is None
+    assert body["agent_runs"] == []
+    assert body["review_feedback"] == []
+
+
+@uses_test_session
+def test_get_run_for_unknown_event_is_404(db_session) -> None:
+    brand, user = _setup_brand(db_session)
+
+    response = client.get(
+        f"/brands/{brand.id}/arena/by-event/{uuid.uuid4()}", headers=_auth_headers(user)
+    )
+
+    assert response.status_code == 404
+
+
+@uses_test_session
+def test_cross_org_event_access_returns_404(db_session) -> None:
+    brand, _owner = _setup_brand(db_session, suffix="-1")
+    _brand2, other_user = _setup_brand(db_session, suffix="-2")
+    event = ContentCalendarEvent(
+        brand_id=brand.id,
+        title="Launch",
+        target_platforms=["linkedin"],
+        desired_format="image",
+        target_datetime=datetime(2026, 9, 1, 12, 0, tzinfo=timezone.utc),
+    )
+    db_session.add(event)
+    db_session.flush()
+
+    response = client.get(
+        f"/brands/{brand.id}/arena/by-event/{event.id}", headers=_auth_headers(other_user)
+    )
+
+    assert response.status_code == 404
+
+
+# --- latest -----------------------------------------------------------------
+
+
+@uses_test_session
+def test_get_latest_run_returns_most_recently_created_post(db_session, thread_cleanup) -> None:
+    brand, user = _setup_brand(db_session)
+    older = Post(brand_id=brand.id)
+    db_session.add(older)
+    db_session.flush()
+    # Postgres's now() is constant for the whole transaction, so both Posts
+    # would otherwise get an identical server-generated created_at within
+    # this one test transaction — force `older` to genuinely predate
+    # `newer` so the ORDER BY created_at DESC this endpoint relies on has
+    # something real to sort by.
+    older.created_at = datetime(2020, 1, 1, tzinfo=timezone.utc)
+    db_session.flush()
+
+    newer = _post_at_human_review(db_session, brand, thread_cleanup)
+
+    response = client.get(f"/brands/{brand.id}/arena/latest", headers=_auth_headers(user))
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["post"]["id"] == str(newer.id)
+    assert older.id != newer.id
+
+
+@uses_test_session
+def test_get_latest_run_with_no_posts_yet(db_session) -> None:
+    brand, user = _setup_brand(db_session)
+
+    response = client.get(f"/brands/{brand.id}/arena/latest", headers=_auth_headers(user))
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["post"] is None
+    assert body["calendar_event_id"] is None
+    assert body["agent_runs"] == []
+
+
+@uses_test_session
+def test_get_latest_run_unknown_brand_is_404(db_session, thread_cleanup) -> None:
+    brand, user = _setup_brand(db_session)
+    _post_at_human_review(db_session, brand, thread_cleanup)
+
+    response = client.get(f"/brands/{uuid.uuid4()}/arena/latest", headers=_auth_headers(user))
+
+    assert response.status_code == 404
+
+
+@uses_test_session
+def test_agent_runs_expose_real_cost_and_token_data(db_session) -> None:
+    """Confirms the endpoint passes through AgentRun's real
+    model/tokens/cost/latency columns rather than only the stage name —
+    the Arena inspector panel (Issue #124) needs these for real stats."""
+    brand, user = _setup_brand(db_session)
+    post = Post(brand_id=brand.id)
+    db_session.add(post)
+    db_session.flush()
+
+    db_session.add(
+        AgentRun(
+            post_id=post.id,
+            agent_type=AgentType.GENERATION,
+            input={"post_id": str(post.id)},
+            output={"generation_output": {"model": "sonnet", "tokens": 512, "cost": 0.12}},
+            model="sonnet",
+            tokens=512,
+            cost=0.12,
+            latency_ms=845.5,
+        )
+    )
+    db_session.flush()
+
+    response = client.get(f"/brands/{brand.id}/arena/latest", headers=_auth_headers(user))
+
+    assert response.status_code == 200
+    run = response.json()["agent_runs"][0]
+    assert run["model"] == "sonnet"
+    assert run["tokens"] == 512
+    assert run["cost"] == 0.12
+    assert run["latency_ms"] == 845.5
+    assert run["output"]["generation_output"]["model"] == "sonnet"

--- a/apps/api/tests/test_content_ai.py
+++ b/apps/api/tests/test_content_ai.py
@@ -1,0 +1,147 @@
+"""Tests for Issue #126's Content AI workspace page (the image-first fast
+path):
+  1. packages/agents/pipeline/nodes/generation_engine.py::generate_standalone_images
+     calls ImageProvider + StorageProvider only through their interfaces —
+     the same real fal.ai-backed adapter (Issue #22) the per-post pipeline
+     uses — and returns `count` variants.
+  2. A failed variant degrades to {"status": "failed"} without aborting
+     the rest of the batch.
+  3. apps/api/routers/content_ai.py's POST .../content-ai/generate folds
+     aspect-ratio/style/brand-lock into the prompt and logs an
+     AgentRun(agent_type=generation, post_id=None).
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from apps.api.auth.jwt import create_access_token, hash_password
+from apps.api.main import app
+from apps.api.models import AgentRun, AgentType, Brand, Organization, User, UserRole
+from packages.agents.pipeline.nodes.generation_engine import generate_standalone_images
+from packages.integrations.image_gen.base import ImageResult
+
+client = TestClient(app)
+uses_test_session = pytest.mark.usefixtures("override_get_db")
+
+IMAGE_PATCH_TARGET = "packages.agents.pipeline.nodes.generation_engine.get_image_provider"
+STORAGE_PATCH_TARGET = "packages.agents.pipeline.nodes.generation_engine.get_storage_provider"
+
+
+def _setup_brand(db_session, role: UserRole = UserRole.EDITOR) -> tuple[Brand, User]:
+    org = Organization(name="Acme Agency")
+    db_session.add(org)
+    db_session.flush()
+
+    user = User(
+        organization_id=org.id,
+        email=f"{role.value}@acme.test",
+        password_hash=hash_password("test-password"),
+        role=role,
+    )
+    brand = Brand(
+        organization_id=org.id, name="Acme Widgets", industry="Outdoor gear", colors=["#1B4DFF", "#0A1633"]
+    )
+    db_session.add_all([user, brand])
+    db_session.flush()
+    return brand, user
+
+
+def _auth_headers(user: User) -> dict[str, str]:
+    token = create_access_token(
+        user_id=str(user.id), org_id=str(user.organization_id), role=user.role.value
+    )
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _mock_image_provider() -> MagicMock:
+    provider = MagicMock()
+    provider.generate.return_value = ImageResult(url="https://fal.media/files/generated-abc.png")
+    return provider
+
+
+def _mock_download():
+    return (b"fake-bytes", "image/png")
+
+
+# --- engine -------------------------------------------------------------
+
+
+def test_generate_standalone_images_returns_requested_count() -> None:
+    with patch(IMAGE_PATCH_TARGET, return_value=_mock_image_provider()), patch(
+        STORAGE_PATCH_TARGET
+    ) as mock_storage, patch(
+        "packages.agents.pipeline.nodes.generation_engine._download_image_bytes",
+        return_value=_mock_download(),
+    ):
+        mock_storage.return_value.upload.return_value = "https://storage.example/img.png"
+        results = generate_standalone_images("editorial navy card", count=4)
+
+    assert len(results) == 4
+    assert all(r["status"] == "generated" for r in results)
+    assert all(r["url"] == "https://storage.example/img.png" for r in results)
+
+
+def test_generate_standalone_images_degrades_a_failed_variant() -> None:
+    with patch(IMAGE_PATCH_TARGET, side_effect=Exception("fal.ai unreachable")):
+        results = generate_standalone_images("editorial navy card", count=2)
+
+    assert len(results) == 2
+    assert all(r == {"status": "failed", "url": None} for r in results)
+
+
+# --- router --------------------------------------------------------------
+
+
+@uses_test_session
+def test_generate_images_endpoint_logs_agent_run(db_session) -> None:
+    brand, user = _setup_brand(db_session)
+
+    with patch(IMAGE_PATCH_TARGET, return_value=_mock_image_provider()), patch(
+        STORAGE_PATCH_TARGET
+    ) as mock_storage, patch(
+        "packages.agents.pipeline.nodes.generation_engine._download_image_bytes",
+        return_value=_mock_download(),
+    ):
+        mock_storage.return_value.upload.return_value = "https://storage.example/img.png"
+        response = client.post(
+            f"/brands/{brand.id}/content-ai/generate",
+            headers=_auth_headers(user),
+            json={
+                "prompt": "Editorial typographic card, deep navy",
+                "aspect_ratio": "1:1",
+                "style": "editorial",
+                "lock_brand_colors": True,
+                "count": 4,
+            },
+        )
+
+    assert response.status_code == 201
+    body = response.json()
+    assert len(body["variants"]) == 4
+    assert all(v["status"] == "generated" for v in body["variants"])
+
+    run = (
+        db_session.query(AgentRun)
+        .filter(AgentRun.agent_type == AgentType.GENERATION, AgentRun.post_id.is_(None))
+        .order_by(AgentRun.created_at.desc())
+        .first()
+    )
+    assert run is not None
+    assert run.input["brand_id"] == str(brand.id)
+    assert run.input["aspect_ratio"] == "1:1"
+    assert len(run.output["variants"]) == 4
+
+
+@uses_test_session
+def test_generate_images_endpoint_rejects_viewer_role(db_session) -> None:
+    brand, _ = _setup_brand(db_session, role=UserRole.EDITOR)
+    _, viewer = _setup_brand(db_session, role=UserRole.VIEWER)
+
+    response = client.post(
+        f"/brands/{brand.id}/content-ai/generate",
+        headers=_auth_headers(viewer),
+        json={"prompt": "A mountain at sunrise"},
+    )
+    assert response.status_code == 403

--- a/apps/api/tests/test_creative_workspace.py
+++ b/apps/api/tests/test_creative_workspace.py
@@ -1,0 +1,144 @@
+"""Tests for Issue #126's standalone Creative workspace page:
+  1. packages/agents/pipeline/nodes/creative_engine.py::generate_creative_angles
+     calls LLMProvider only through its interface and returns exactly
+     `count` distinct angle cards.
+  2. It degrades to the fixed fallback angles (not an error) when the LLM
+     call/parse fails — same contract as _generate_platform_briefs.
+  3. apps/api/routers/creative.py's POST .../creative/angles logs an
+     AgentRun(agent_type=creative, post_id=None).
+"""
+
+import json
+import uuid
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from apps.api.auth.jwt import create_access_token, hash_password
+from apps.api.main import app
+from apps.api.models import AgentRun, AgentType, Brand, Organization, User, UserRole
+from packages.agents.pipeline.nodes.creative_engine import (
+    ANGLE_COUNT,
+    REQUIRED_ANGLE_KEYS,
+    generate_creative_angles,
+)
+from packages.integrations.llm.base import LLMResponse
+
+client = TestClient(app)
+uses_test_session = pytest.mark.usefixtures("override_get_db")
+
+LLM_PATCH_TARGET = "packages.agents.pipeline.nodes.creative_engine.get_llm_provider"
+
+
+def _setup_brand(db_session, role: UserRole = UserRole.EDITOR) -> tuple[Brand, User]:
+    org = Organization(name="Acme Agency")
+    db_session.add(org)
+    db_session.flush()
+
+    user = User(
+        organization_id=org.id,
+        email=f"{role.value}@acme.test",
+        password_hash=hash_password("test-password"),
+        role=role,
+    )
+    brand = Brand(organization_id=org.id, name="Acme Widgets", industry="Outdoor gear")
+    db_session.add_all([user, brand])
+    db_session.flush()
+    return brand, user
+
+
+def _auth_headers(user: User) -> dict[str, str]:
+    token = create_access_token(
+        user_id=str(user.id), org_id=str(user.organization_id), role=user.role.value
+    )
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _angle(i: int) -> dict:
+    return {
+        "format": f"format-{i}",
+        "angle": f"angle-{i}",
+        "hook": f"hook-{i}",
+        "why": f"why-{i}",
+        "cta": f"cta-{i}",
+        "score": 90 - i,
+    }
+
+
+def _llm_angles_response(count: int) -> LLMResponse:
+    return LLMResponse(
+        text=json.dumps([_angle(i) for i in range(count)]),
+        model="openrouter/free",
+        input_tokens=100,
+        output_tokens=50,
+    )
+
+
+# --- engine ---------------------------------------------------------
+
+
+def test_generate_creative_angles_returns_six_distinct_cards() -> None:
+    brand = Brand(organization_id=uuid.uuid4(), name="Acme", industry="Outdoor gear")
+    with patch(LLM_PATCH_TARGET) as mock_llm:
+        mock_llm.return_value.complete.return_value = _llm_angles_response(ANGLE_COUNT)
+        angles = generate_creative_angles(brand, "Post about our new product launch")
+
+    assert len(angles) == ANGLE_COUNT
+    for angle in angles:
+        assert all(key in angle for key in REQUIRED_ANGLE_KEYS)
+    formats = {a["format"] for a in angles}
+    assert len(formats) == ANGLE_COUNT
+
+
+def test_generate_creative_angles_falls_back_on_llm_failure() -> None:
+    brand = Brand(organization_id=uuid.uuid4(), name="Acme", industry="Outdoor gear")
+    with patch(LLM_PATCH_TARGET, side_effect=Exception("LLM unreachable")):
+        angles = generate_creative_angles(brand, "Post about our new product launch")
+
+    assert len(angles) == ANGLE_COUNT
+    for angle in angles:
+        assert all(key in angle for key in REQUIRED_ANGLE_KEYS)
+
+
+# --- router -----------------------------------------------------------
+
+
+@uses_test_session
+def test_generate_angles_endpoint_logs_agent_run(db_session) -> None:
+    brand, user = _setup_brand(db_session)
+
+    with patch(LLM_PATCH_TARGET) as mock_llm:
+        mock_llm.return_value.complete.return_value = _llm_angles_response(ANGLE_COUNT)
+        response = client.post(
+            f"/brands/{brand.id}/creative/angles",
+            headers=_auth_headers(user),
+            json={"brief": "Launch our new contract-review turnaround feature"},
+        )
+
+    assert response.status_code == 201
+    body = response.json()
+    assert len(body["angles"]) == ANGLE_COUNT
+
+    run = (
+        db_session.query(AgentRun)
+        .filter(AgentRun.agent_type == AgentType.CREATIVE, AgentRun.post_id.is_(None))
+        .order_by(AgentRun.created_at.desc())
+        .first()
+    )
+    assert run is not None
+    assert run.input["brand_id"] == str(brand.id)
+    assert len(run.output["angles"]) == ANGLE_COUNT
+
+
+@uses_test_session
+def test_generate_angles_endpoint_rejects_viewer_role(db_session) -> None:
+    brand, _ = _setup_brand(db_session, role=UserRole.EDITOR)
+    _, viewer = _setup_brand(db_session, role=UserRole.VIEWER)
+
+    response = client.post(
+        f"/brands/{brand.id}/creative/angles",
+        headers=_auth_headers(viewer),
+        json={"brief": "Launch our new feature"},
+    )
+    assert response.status_code == 403

--- a/apps/api/tests/test_posts_list.py
+++ b/apps/api/tests/test_posts_list.py
@@ -1,0 +1,94 @@
+"""Tests for Issue #126's GET /brands/{brand_id}/posts — the general,
+read-only Post listing the Create Post page's "Recent runs" list needs
+(no existing endpoint returns Posts across every pipeline stage; see
+apps/api/routers/posts.py's module docstring)."""
+
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from fastapi.testclient import TestClient
+
+from apps.api.auth.jwt import create_access_token, hash_password
+from apps.api.main import app
+from apps.api.models import Brand, Organization, PipelineStage, Post, User, UserRole
+
+client = TestClient(app)
+uses_test_session = pytest.mark.usefixtures("override_get_db")
+
+
+def _setup_brand(db_session, role: UserRole = UserRole.EDITOR, suffix: str = "") -> tuple[Brand, User]:
+    org = Organization(name="Acme Agency")
+    db_session.add(org)
+    db_session.flush()
+
+    user = User(
+        organization_id=org.id,
+        email=f"{role.value}{suffix}@acme.test",
+        password_hash=hash_password("test-password"),
+        role=role,
+    )
+    brand = Brand(organization_id=org.id, name="Acme Widgets")
+    db_session.add_all([user, brand])
+    db_session.flush()
+    return brand, user
+
+
+def _auth_headers(user: User) -> dict[str, str]:
+    token = create_access_token(
+        user_id=str(user.id), org_id=str(user.organization_id), role=user.role.value
+    )
+    return {"Authorization": f"Bearer {token}"}
+
+
+@uses_test_session
+def test_list_posts_returns_every_stage_newest_first(db_session) -> None:
+    brand, user = _setup_brand(db_session)
+
+    base = datetime.now(timezone.utc)
+    rejected = Post(
+        brand_id=brand.id, current_pipeline_stage=PipelineStage.REJECTED, created_at=base
+    )
+    research = Post(
+        brand_id=brand.id,
+        current_pipeline_stage=PipelineStage.RESEARCH,
+        created_at=base + timedelta(seconds=1),
+    )
+    completed = Post(
+        brand_id=brand.id,
+        current_pipeline_stage=PipelineStage.COMPLETED,
+        created_at=base + timedelta(seconds=2),
+    )
+    db_session.add_all([rejected, research, completed])
+    db_session.flush()
+
+    response = client.get(f"/brands/{brand.id}/posts", headers=_auth_headers(user))
+
+    assert response.status_code == 200
+    body = response.json()
+    assert len(body) == 3
+    stages = {p["current_pipeline_stage"] for p in body}
+    assert stages == {"rejected", "research", "completed"}
+    # Newest first.
+    assert body[0]["id"] == str(completed.id)
+
+
+@uses_test_session
+def test_list_posts_scoped_to_brand_and_org(db_session) -> None:
+    brand, user = _setup_brand(db_session)
+    other_brand, _ = _setup_brand(db_session, suffix="-2")
+
+    db_session.add(Post(brand_id=other_brand.id))
+    db_session.flush()
+
+    response = client.get(f"/brands/{brand.id}/posts", headers=_auth_headers(user))
+    assert response.status_code == 200
+    assert response.json() == []
+
+
+@uses_test_session
+def test_list_posts_404s_for_unknown_brand(db_session) -> None:
+    _, user = _setup_brand(db_session)
+
+    response = client.get(f"/brands/{uuid.uuid4()}/posts", headers=_auth_headers(user))
+    assert response.status_code == 404

--- a/apps/api/tests/test_research_workspace.py
+++ b/apps/api/tests/test_research_workspace.py
@@ -1,0 +1,145 @@
+"""Tests for Issue #126's standalone Research workspace page:
+  1. packages/agents/pipeline/nodes/research_engine.py::run_standalone_research
+     reuses _research_brief exactly (same shape, same degrade-on-failure
+     behavior) for an ad hoc Post.
+  2. apps/api/routers/research.py's POST .../research/run creates the ad
+     hoc Post, runs the brief, and logs an AgentRun(agent_type=research).
+  3. GET .../research/latest returns the most recent one without
+     triggering a new run, and 404s when none exists yet.
+"""
+
+import uuid
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from apps.api.auth.jwt import create_access_token, hash_password
+from apps.api.main import app
+from apps.api.models import AgentRun, AgentType, Brand, Organization, Post, User, UserRole
+from packages.agents.pipeline.nodes.research_engine import run_standalone_research
+from packages.integrations.search.base import SearchResult
+
+client = TestClient(app)
+uses_test_session = pytest.mark.usefixtures("override_get_db")
+
+SEARCH_PATCH_TARGET = "packages.agents.pipeline.nodes.research_engine.get_search_provider"
+EMBED_PATCH_TARGET = "apps.api.services.brand_retrieval.get_embedding_provider"
+
+
+def _setup_brand(db_session, role: UserRole = UserRole.EDITOR) -> tuple[Brand, User]:
+    org = Organization(name="Acme Agency")
+    db_session.add(org)
+    db_session.flush()
+
+    user = User(
+        organization_id=org.id,
+        email=f"{role.value}@acme.test",
+        password_hash=hash_password("test-password"),
+        role=role,
+    )
+    brand = Brand(organization_id=org.id, name="Acme Widgets", industry="Outdoor gear")
+    db_session.add_all([user, brand])
+    db_session.flush()
+    return brand, user
+
+
+def _auth_headers(user: User) -> dict[str, str]:
+    token = create_access_token(
+        user_id=str(user.id), org_id=str(user.organization_id), role=user.role.value
+    )
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _mock_search_provider():
+    provider = type(
+        "StubSearch",
+        (),
+        {"search": lambda self, query, max_results=5: [SearchResult(title=f"Result for {query}", url="https://example.com", content="c")]},
+    )()
+    return provider
+
+
+# --- engine wrapper ---------------------------------------------------
+
+
+def test_run_standalone_research_reuses_research_brief_shape(db_session) -> None:
+    brand, _ = _setup_brand(db_session)
+    post = Post(brand_id=brand.id)
+    db_session.add(post)
+    db_session.flush()
+
+    with patch(SEARCH_PATCH_TARGET, return_value=_mock_search_provider()), patch(
+        EMBED_PATCH_TARGET, side_effect=Exception("no embedding provider configured")
+    ):
+        brief = run_standalone_research(db_session, post)
+
+    assert brief["post_id"] == str(post.id)
+    assert "platform_trends" in brief
+    assert "industry_trends" in brief
+    assert "timing_signal" in brief
+
+
+# --- router: POST /run -------------------------------------------------
+
+
+@uses_test_session
+def test_run_research_endpoint_creates_ad_hoc_post_and_agent_run(db_session) -> None:
+    brand, user = _setup_brand(db_session)
+
+    with patch(SEARCH_PATCH_TARGET, return_value=_mock_search_provider()), patch(
+        EMBED_PATCH_TARGET, side_effect=Exception("no embedding provider configured")
+    ):
+        response = client.post(
+            f"/brands/{brand.id}/research/run", headers=_auth_headers(user)
+        )
+
+    assert response.status_code == 201
+    body = response.json()
+    assert body["brand_id"] == str(brand.id)
+    assert "platform_trends" in body["brief"]
+
+    post = db_session.query(Post).filter(Post.id == uuid.UUID(body["post_id"])).first()
+    assert post is not None
+    assert post.brand_id == brand.id
+    assert post.calendar_event_id is None
+
+    run = db_session.query(AgentRun).filter(AgentRun.post_id == post.id).first()
+    assert run is not None
+    assert run.agent_type == AgentType.RESEARCH
+    assert run.output == body["brief"]
+
+
+@uses_test_session
+def test_run_research_endpoint_rejects_viewer_role(db_session) -> None:
+    brand, _ = _setup_brand(db_session, role=UserRole.EDITOR)
+    _, viewer = _setup_brand(db_session, role=UserRole.VIEWER)
+
+    response = client.post(f"/brands/{brand.id}/research/run", headers=_auth_headers(viewer))
+    assert response.status_code == 403
+
+
+# --- router: GET /latest ------------------------------------------------
+
+
+@uses_test_session
+def test_latest_research_returns_404_when_none_exists(db_session) -> None:
+    brand, user = _setup_brand(db_session)
+
+    response = client.get(f"/brands/{brand.id}/research/latest", headers=_auth_headers(user))
+    assert response.status_code == 404
+
+
+@uses_test_session
+def test_latest_research_returns_most_recent_run(db_session) -> None:
+    brand, user = _setup_brand(db_session)
+
+    with patch(SEARCH_PATCH_TARGET, return_value=_mock_search_provider()), patch(
+        EMBED_PATCH_TARGET, side_effect=Exception("no embedding provider configured")
+    ):
+        run_response = client.post(f"/brands/{brand.id}/research/run", headers=_auth_headers(user))
+    assert run_response.status_code == 201
+
+    latest_response = client.get(f"/brands/{brand.id}/research/latest", headers=_auth_headers(user))
+    assert latest_response.status_code == 200
+    assert latest_response.json()["post_id"] == run_response.json()["post_id"]

--- a/apps/web/__tests__/api.test.ts
+++ b/apps/web/__tests__/api.test.ts
@@ -1,5 +1,13 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
-import { ApiError, createBrand, fetchBrands, login, uploadBrandLogo } from "@/lib/api";
+import {
+  ApiError,
+  createBrand,
+  fetchArenaRunForEvent,
+  fetchBrands,
+  fetchLatestArenaRun,
+  login,
+  uploadBrandLogo,
+} from "@/lib/api";
 
 describe("api client", () => {
   const originalFetch = global.fetch;
@@ -95,5 +103,48 @@ describe("api client", () => {
     expect(options.headers.Authorization).toBe("Bearer test-token");
     expect(options.body).toBeInstanceOf(FormData);
     expect((options.body as FormData).get("file")).toBe(file);
+  });
+
+  it("fetchArenaRunForEvent hits the by-event endpoint with the bearer token", async () => {
+    const run = { calendar_event_id: "event-1", post: null, agent_runs: [], review_feedback: [] };
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: async () => run,
+    });
+
+    const result = await fetchArenaRunForEvent("test-token", "brand-1", "event-1");
+
+    expect(result).toEqual(run);
+    const [url, options] = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(url).toContain("/brands/brand-1/arena/by-event/event-1");
+    expect(options.headers.Authorization).toBe("Bearer test-token");
+  });
+
+  it("fetchArenaRunForEvent raises ApiError on non-OK responses", async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: false,
+      status: 404,
+      json: async () => ({ detail: "Calendar event not found" }),
+    });
+
+    await expect(fetchArenaRunForEvent("test-token", "brand-1", "missing")).rejects.toMatchObject({
+      message: "Calendar event not found",
+      status: 404,
+    });
+  });
+
+  it("fetchLatestArenaRun hits the latest endpoint with the bearer token", async () => {
+    const run = { calendar_event_id: null, post: null, agent_runs: [], review_feedback: [] };
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: async () => run,
+    });
+
+    const result = await fetchLatestArenaRun("test-token", "brand-1");
+
+    expect(result).toEqual(run);
+    const [url, options] = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(url).toContain("/brands/brand-1/arena/latest");
+    expect(options.headers.Authorization).toBe("Bearer test-token");
   });
 });

--- a/apps/web/__tests__/arena-build-nodes.test.ts
+++ b/apps/web/__tests__/arena-build-nodes.test.ts
@@ -1,0 +1,204 @@
+import { describe, expect, it } from "vitest";
+import { buildArenaNodes } from "@/app/arena/build-nodes";
+import type { ArenaAgentRun, ArenaReviewFeedback, ArenaRun, Brand, CalendarEvent } from "@/lib/api";
+
+function makeRun(overrides: Partial<ArenaRun> = {}): ArenaRun {
+  return {
+    calendar_event_id: null,
+    post: null,
+    agent_runs: [],
+    review_feedback: [],
+    ...overrides,
+  };
+}
+
+function makeAgentRun(overrides: Partial<ArenaAgentRun>): ArenaAgentRun {
+  return {
+    id: "run-1",
+    agent_type: "research",
+    output: null,
+    model: null,
+    tokens: null,
+    cost: null,
+    latency_ms: null,
+    created_at: "2026-08-20T10:00:00Z",
+    ...overrides,
+  };
+}
+
+function findNode(run: ArenaRun, event: CalendarEvent | null, brand: Brand | null, id: string) {
+  const nodes = buildArenaNodes(run, event, brand);
+  const node = nodes.find((n) => n.id === id);
+  if (!node) throw new Error(`node ${id} not found`);
+  return node;
+}
+
+describe("buildArenaNodes", () => {
+  it("marks a stage DONE and pulls real cost/tokens once an AgentRun exists", () => {
+    const run = makeRun({
+      post: {
+        id: "post-1",
+        calendar_event_id: null,
+        current_pipeline_stage: "generation",
+        body_text: null,
+        media: null,
+        created_at: "2026-08-20T10:00:00Z",
+        updated_at: "2026-08-20T10:00:00Z",
+      },
+      agent_runs: [
+        makeAgentRun({
+          agent_type: "generation",
+          model: "sonnet",
+          tokens: 512,
+          cost: 0.12,
+          latency_ms: 845,
+          output: { generation_output: { platforms: { linkedin: { body_text: "hi" } }, model: "sonnet" } },
+        }),
+      ],
+    });
+
+    const node = findNode(run, null, null, "generation");
+
+    expect(node.status).toBe("DONE");
+    expect(node.stats).toEqual(
+      expect.arrayContaining([
+        { label: "DRAFTS", value: "1" },
+        { label: "TOKENS", value: "512" },
+        { label: "COST", value: "$0.12" },
+      ])
+    );
+  });
+
+  it("marks a stage QUEUED (not fabricated as running) when it hasn't executed yet", () => {
+    const run = makeRun({
+      post: {
+        id: "post-1",
+        calendar_event_id: null,
+        current_pipeline_stage: "research",
+        body_text: null,
+        media: null,
+        created_at: "2026-08-20T10:00:00Z",
+        updated_at: "2026-08-20T10:00:00Z",
+      },
+      agent_runs: [],
+    });
+
+    const node = findNode(run, null, null, "generation");
+
+    expect(node.status).toBe("QUEUED");
+    expect(node.agentRun).toBeNull();
+    expect(node.lines).toContain("not run yet");
+  });
+
+  it("marks human_review WAITING when the post is durably paused there with no AgentRun yet", () => {
+    const run = makeRun({
+      post: {
+        id: "post-1",
+        calendar_event_id: null,
+        current_pipeline_stage: "human_review",
+        body_text: null,
+        media: null,
+        created_at: "2026-08-20T10:00:00Z",
+        updated_at: "2026-08-20T10:04:00Z",
+      },
+      agent_runs: [],
+    });
+
+    const node = findNode(run, null, null, "human_review");
+
+    expect(node.status).toBe("WAITING");
+    expect(node.lines[0]).toMatch(/waiting on a human decision/i);
+  });
+
+  it("marks downstream stages SKIPPED when the run was rejected at human_review", () => {
+    const run = makeRun({
+      post: {
+        id: "post-1",
+        calendar_event_id: null,
+        current_pipeline_stage: "rejected",
+        body_text: null,
+        media: null,
+        created_at: "2026-08-20T10:00:00Z",
+        updated_at: "2026-08-20T10:04:00Z",
+      },
+      agent_runs: [makeAgentRun({ agent_type: "human_review", output: {} })],
+      review_feedback: [
+        {
+          id: "fb-1",
+          source: "human",
+          score: 0,
+          verdict: "reject",
+          comments: {},
+          created_at: "2026-08-20T10:05:00Z",
+        },
+      ],
+    });
+
+    expect(findNode(run, null, null, "human_review").status).toBe("DONE");
+    expect(findNode(run, null, null, "scheduler").status).toBe("SKIPPED");
+    expect(findNode(run, null, null, "publisher").status).toBe("SKIPPED");
+    expect(findNode(run, null, null, "analytics_collector").status).toBe("SKIPPED");
+  });
+
+  it("surfaces the AI reviewer's real score/verdict on the reviewer node", () => {
+    const reviewFeedback: ArenaReviewFeedback[] = [
+      {
+        id: "fb-ai-1",
+        source: "ai_reviewer",
+        score: 84,
+        verdict: "approve",
+        comments: { platforms: {}, model: "openrouter/free" },
+        created_at: "2026-08-20T10:03:00Z",
+      },
+    ];
+    const run = makeRun({
+      post: {
+        id: "post-1",
+        calendar_event_id: null,
+        current_pipeline_stage: "human_review",
+        body_text: null,
+        media: null,
+        created_at: "2026-08-20T10:00:00Z",
+        updated_at: "2026-08-20T10:03:00Z",
+      },
+      agent_runs: [makeAgentRun({ agent_type: "reviewer", cost: 0.05, output: { review_output: {} } })],
+      review_feedback: reviewFeedback,
+    });
+
+    const node = findNode(run, null, null, "reviewer");
+
+    expect(node.status).toBe("DONE");
+    expect(node.lines[0]).toBe("score 84/100 · approve");
+  });
+
+  it("renders the campaign-brief context node from the real calendar event", () => {
+    const event: CalendarEvent = {
+      id: "event-1",
+      brand_id: "brand-1",
+      title: "DPDP launch carousel",
+      description: null,
+      target_platforms: ["linkedin", "x"],
+      desired_format: "carousel",
+      target_datetime: "2026-09-01T12:00:00Z",
+      status: "pipeline_running",
+      created_at: "2026-08-01T00:00:00Z",
+      updated_at: "2026-08-01T00:00:00Z",
+    };
+
+    const node = findNode(makeRun(), event, null, "brief");
+
+    expect(node.status).toBe("READ");
+    expect(node.lines[0]).toBe("DPDP launch carousel");
+    expect(node.stats).toEqual(
+      expect.arrayContaining([{ label: "PLATFORMS", value: "2" }, { label: "FORMAT", value: "carousel" }])
+    );
+  });
+
+  it("shows a clear placeholder for the brief node when there is no calendar event", () => {
+    const node = findNode(makeRun(), null, null, "brief");
+
+    expect(node.status).toBe("READ");
+    expect(node.lines).toEqual(["No calendar event — ad hoc post"]);
+    expect(node.stats).toEqual([]);
+  });
+});

--- a/apps/web/__tests__/arena-page.test.tsx
+++ b/apps/web/__tests__/arena-page.test.tsx
@@ -1,0 +1,178 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import ArenaPage from "@/app/arena/page";
+import { AuthProvider } from "@/lib/auth-context";
+import { BrandProvider } from "@/lib/brand-context";
+import type { ArenaRun } from "@/lib/api";
+
+const fetchBrandsMock = vi.fn();
+const fetchLatestArenaRunMock = vi.fn();
+const fetchArenaRunForEventMock = vi.fn();
+const fetchCalendarEventsMock = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+vi.mock("@/lib/api", () => ({
+  fetchBrands: (...args: unknown[]) => fetchBrandsMock(...args),
+  fetchLatestArenaRun: (...args: unknown[]) => fetchLatestArenaRunMock(...args),
+  fetchArenaRunForEvent: (...args: unknown[]) => fetchArenaRunForEventMock(...args),
+  fetchCalendarEvents: (...args: unknown[]) => fetchCalendarEventsMock(...args),
+}));
+
+const BRANDS = [
+  {
+    id: "brand-1",
+    organization_id: "org-1",
+    name: "Acme Co",
+    industry: "Legal tech",
+    logo_url: null,
+    target_audience: null,
+    colors: ["#000"],
+    tone_descriptors: ["direct"],
+    product_catalog: null,
+    brand_report: null,
+    created_at: "2026-01-01",
+    updated_at: "2026-01-01",
+  },
+];
+
+const CALENDAR_EVENTS = [
+  {
+    id: "event-1",
+    brand_id: "brand-1",
+    title: "DPDP launch carousel",
+    description: null,
+    target_platforms: ["linkedin", "x"],
+    desired_format: "carousel",
+    target_datetime: "2026-09-01T12:00:00Z",
+    status: "pipeline_running",
+    created_at: "2026-08-01T00:00:00Z",
+    updated_at: "2026-08-01T00:00:00Z",
+  },
+];
+
+function makeRun(overrides: Partial<ArenaRun> = {}): ArenaRun {
+  return {
+    calendar_event_id: "event-1",
+    post: {
+      id: "post-1",
+      calendar_event_id: "event-1",
+      current_pipeline_stage: "human_review",
+      body_text: { linkedin: "70% of contracts fail diligence." },
+      media: null,
+      created_at: "2026-08-20T10:00:00Z",
+      updated_at: "2026-08-20T10:04:00Z",
+    },
+    agent_runs: [
+      {
+        id: "run-research",
+        agent_type: "research",
+        output: { research_brief: { industry_trends: [{ title: "DPDP readiness", url: "https://meity.gov.in/x" }] } },
+        model: "sonnet",
+        tokens: 400,
+        cost: 0.08,
+        latency_ms: 1200,
+        created_at: "2026-08-20T10:00:30Z",
+      },
+    ],
+    review_feedback: [
+      {
+        id: "fb-ai-1",
+        source: "ai_reviewer",
+        score: 84,
+        verdict: "approve",
+        comments: { platforms: {}, model: "openrouter/free" },
+        created_at: "2026-08-20T10:03:00Z",
+      },
+    ],
+    ...overrides,
+  };
+}
+
+function renderPage() {
+  return render(
+    <AuthProvider>
+      <BrandProvider>
+        <ArenaPage />
+      </BrandProvider>
+    </AuthProvider>
+  );
+}
+
+describe("ArenaPage", () => {
+  beforeEach(() => {
+    fetchBrandsMock.mockReset();
+    fetchLatestArenaRunMock.mockReset();
+    fetchArenaRunForEventMock.mockReset();
+    fetchCalendarEventsMock.mockReset();
+
+    window.localStorage.clear();
+    window.localStorage.setItem("raindeer.auth.token", "test-token");
+
+    fetchBrandsMock.mockResolvedValue(BRANDS);
+    fetchCalendarEventsMock.mockResolvedValue(CALENDAR_EVENTS);
+    fetchLatestArenaRunMock.mockResolvedValue(makeRun());
+  });
+
+  it("fetches the latest run for the selected brand and renders the real event title", async () => {
+    renderPage();
+
+    await waitFor(() => expect(fetchLatestArenaRunMock).toHaveBeenCalledWith("test-token", "brand-1"));
+    expect(await screen.findByText("RUNNING")).toBeInTheDocument();
+    expect(screen.getAllByText("DPDP launch carousel").length).toBeGreaterThan(0);
+  });
+
+  it("renders real AgentRun data in the research node and trace tab", async () => {
+    renderPage();
+
+    await screen.findByText("RUNNING");
+
+    // Node card + inspector summary line, derived from the real
+    // research_brief output (appears in both places).
+    expect(screen.getAllByText("1 source found").length).toBeGreaterThan(0);
+    // Trace tab entry for the same AgentRun row.
+    expect(screen.getByText(/research complete/)).toBeInTheDocument();
+  });
+
+  it("selecting a different node updates the inspector panel", async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    await screen.findByText("RUNNING");
+
+    await user.click(screen.getByRole("button", { name: "Select Kavi · Generation" }));
+
+    // The inspector's header now shows the selected node's name.
+    const inspectorHeadings = screen.getAllByText("Kavi · Generation");
+    expect(inspectorHeadings.length).toBeGreaterThan(1);
+  });
+
+  it("the 'Skip to review' control really links to /review-queue", async () => {
+    renderPage();
+
+    await screen.findByText("RUNNING");
+
+    const link = screen.getByRole("link", { name: /Skip to review/ });
+    expect(link).toHaveAttribute("href", "/review-queue");
+  });
+
+  it("never fabricates a system prompt — shows a clear not-available state", async () => {
+    renderPage();
+
+    await screen.findByText("RUNNING");
+
+    expect(screen.getByText(/Not available yet/)).toBeInTheDocument();
+  });
+
+  it("shows an empty state instead of fetching when no brand is selected", async () => {
+    fetchBrandsMock.mockResolvedValue([]);
+
+    renderPage();
+
+    expect(await screen.findByText("Select a brand to see its Content Arena.")).toBeInTheDocument();
+    expect(fetchLatestArenaRunMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/__tests__/auth-gate.test.tsx
+++ b/apps/web/__tests__/auth-gate.test.tsx
@@ -75,4 +75,29 @@ describe("AuthGate", () => {
       expect(replace).toHaveBeenCalledWith("/login?from=%2Fanalytics");
     });
   });
+
+  it("renders full-bleed routes (e.g. Content Arena) without the Nav sidebar", async () => {
+    mockPathname = "/arena";
+    window.localStorage.setItem("raindeer.auth.token", "test-token");
+
+    renderGate();
+
+    await waitFor(() => {
+      expect(screen.getByText("protected content")).toBeInTheDocument();
+    });
+    expect(replace).not.toHaveBeenCalled();
+    // Nav renders a "Main navigation" landmark — absent on full-bleed routes.
+    expect(screen.queryByRole("navigation", { name: "Main navigation" })).not.toBeInTheDocument();
+  });
+
+  it("still redirects unauthenticated visitors away from full-bleed routes", async () => {
+    mockPathname = "/arena";
+
+    renderGate();
+
+    await waitFor(() => {
+      expect(replace).toHaveBeenCalledWith("/login?from=%2Farena");
+    });
+    expect(screen.queryByText("protected content")).not.toBeInTheDocument();
+  });
 });

--- a/apps/web/__tests__/content-ai-page.test.tsx
+++ b/apps/web/__tests__/content-ai-page.test.tsx
@@ -1,0 +1,124 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { act, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import ContentAIPage from "@/app/content-ai/page";
+import { AuthProvider } from "@/lib/auth-context";
+import { BrandProvider } from "@/lib/brand-context";
+import { ToastProvider } from "@/components/ui/Toast";
+import type { ContentAIVariant } from "@/lib/api";
+
+const fetchBrandsMock = vi.fn();
+const generateContentAIImagesMock = vi.fn();
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return {
+    ...actual,
+    fetchBrands: (...args: unknown[]) => fetchBrandsMock(...args),
+    generateContentAIImages: (...args: unknown[]) => generateContentAIImagesMock(...args),
+  };
+});
+
+const BRANDS = [
+  {
+    id: "brand-1",
+    organization_id: "org-1",
+    name: "Acme Co",
+    industry: null,
+    logo_url: null,
+    target_audience: null,
+    colors: null,
+    tone_descriptors: null,
+    product_catalog: null,
+    brand_report: null,
+    created_at: "2026-01-01",
+    updated_at: "2026-01-01",
+  },
+];
+
+function makeVariants(): ContentAIVariant[] {
+  return [
+    { status: "generated", url: "https://storage.example/1.png" },
+    { status: "generated", url: "https://storage.example/2.png" },
+    { status: "failed", url: null },
+    { status: "generated", url: "https://storage.example/4.png" },
+  ];
+}
+
+function renderPage() {
+  return render(
+    <ToastProvider>
+      <AuthProvider>
+        <BrandProvider>
+          <ContentAIPage />
+        </BrandProvider>
+      </AuthProvider>
+    </ToastProvider>
+  );
+}
+
+describe("ContentAIPage", () => {
+  beforeEach(() => {
+    fetchBrandsMock.mockReset();
+    generateContentAIImagesMock.mockReset();
+
+    window.localStorage.clear();
+    window.localStorage.setItem("raindeer.auth.token", "test-token");
+
+    fetchBrandsMock.mockResolvedValue(BRANDS);
+  });
+
+  it("generates variants with the chosen aspect ratio, style, and brand lock", async () => {
+    generateContentAIImagesMock.mockResolvedValue(makeVariants());
+    const user = userEvent.setup();
+
+    renderPage();
+    await waitFor(() => expect(fetchBrandsMock).toHaveBeenCalled());
+    await screen.findByLabelText("Describe the image");
+
+    await user.click(screen.getByRole("button", { name: "Portrait 4:5" }));
+    await user.click(screen.getByRole("button", { name: "Bold" }));
+
+    await act(async () => {
+      await user.click(screen.getByRole("button", { name: /Generate 4 variants/ }));
+    });
+
+    await waitFor(() =>
+      expect(generateContentAIImagesMock).toHaveBeenCalledWith(
+        "test-token",
+        "brand-1",
+        expect.objectContaining({
+          aspect_ratio: "4:5",
+          style: "bold",
+          lock_brand_colors: true,
+          count: 4,
+        })
+      )
+    );
+
+    const images = await screen.findAllByRole("img");
+    expect(images).toHaveLength(3);
+    expect(screen.getByText("Generation failed")).toBeInTheDocument();
+  });
+
+  it("unchecks brand lock and passes it through", async () => {
+    generateContentAIImagesMock.mockResolvedValue(makeVariants());
+    const user = userEvent.setup();
+
+    renderPage();
+    await screen.findByLabelText("Describe the image");
+
+    await user.click(screen.getByLabelText("Lock to brand colours and logo"));
+    await act(async () => {
+      await user.click(screen.getByRole("button", { name: /Generate 4 variants/ }));
+    });
+
+    await waitFor(() =>
+      expect(generateContentAIImagesMock).toHaveBeenCalledWith(
+        "test-token",
+        "brand-1",
+        expect.objectContaining({ lock_brand_colors: false })
+      )
+    );
+  });
+});

--- a/apps/web/__tests__/create-post-page.test.tsx
+++ b/apps/web/__tests__/create-post-page.test.tsx
@@ -1,0 +1,130 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { act, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import CreatePostPage from "@/app/create-post/page";
+import { AuthProvider } from "@/lib/auth-context";
+import { BrandProvider } from "@/lib/brand-context";
+import { ToastProvider } from "@/components/ui/Toast";
+import type { PostSummary } from "@/lib/api";
+
+const fetchBrandsMock = vi.fn();
+const fetchRecentPostsMock = vi.fn();
+const createCalendarEventMock = vi.fn();
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return {
+    ...actual,
+    fetchBrands: (...args: unknown[]) => fetchBrandsMock(...args),
+    fetchRecentPosts: (...args: unknown[]) => fetchRecentPostsMock(...args),
+    createCalendarEvent: (...args: unknown[]) => createCalendarEventMock(...args),
+  };
+});
+
+const BRANDS = [
+  {
+    id: "brand-1",
+    organization_id: "org-1",
+    name: "Acme Co",
+    industry: null,
+    logo_url: null,
+    target_audience: null,
+    colors: null,
+    tone_descriptors: null,
+    product_catalog: null,
+    brand_report: null,
+    created_at: "2026-01-01",
+    updated_at: "2026-01-01",
+  },
+];
+
+function makePost(overrides: Partial<PostSummary> = {}): PostSummary {
+  return {
+    id: "post-1",
+    brand_id: "brand-1",
+    calendar_event_id: "event-1",
+    current_pipeline_stage: "completed",
+    body_text: { linkedin: "Check out our new widget line!" },
+    created_at: "2026-08-20T10:00:00Z",
+    updated_at: "2026-08-20T10:00:00Z",
+    ...overrides,
+  };
+}
+
+function renderPage() {
+  return render(
+    <ToastProvider>
+      <AuthProvider>
+        <BrandProvider>
+          <CreatePostPage />
+        </BrandProvider>
+      </AuthProvider>
+    </ToastProvider>
+  );
+}
+
+describe("CreatePostPage", () => {
+  beforeEach(() => {
+    fetchBrandsMock.mockReset();
+    fetchRecentPostsMock.mockReset();
+    createCalendarEventMock.mockReset();
+
+    window.localStorage.clear();
+    window.localStorage.setItem("raindeer.auth.token", "test-token");
+
+    fetchBrandsMock.mockResolvedValue(BRANDS);
+    fetchRecentPostsMock.mockResolvedValue([]);
+  });
+
+  it("shows a real Blocked status for a rejected post in recent runs", async () => {
+    fetchRecentPostsMock.mockResolvedValue([
+      makePost({ id: "post-rejected", current_pipeline_stage: "rejected" }),
+      makePost({ id: "post-done", current_pipeline_stage: "completed" }),
+    ]);
+
+    renderPage();
+
+    await waitFor(() => expect(fetchRecentPostsMock).toHaveBeenCalledWith("test-token", "brand-1"));
+    expect(await screen.findByText("Blocked")).toBeInTheDocument();
+    expect(screen.getByText("Completed")).toBeInTheDocument();
+  });
+
+  it("queues a post via the real calendar-event endpoint and refreshes recent runs", async () => {
+    createCalendarEventMock.mockResolvedValue({});
+    const user = userEvent.setup();
+
+    renderPage();
+    await waitFor(() => expect(fetchRecentPostsMock).toHaveBeenCalledTimes(1));
+
+    await user.click(screen.getByRole("button", { name: "X" }));
+
+    await act(async () => {
+      await user.click(screen.getByRole("button", { name: /Run all agents/ }));
+    });
+
+    await waitFor(() => expect(createCalendarEventMock).toHaveBeenCalledTimes(1));
+    const [token, brandId, payload] = createCalendarEventMock.mock.calls[0];
+    expect(token).toBe("test-token");
+    expect(brandId).toBe("brand-1");
+    expect(payload.target_platforms).toEqual(expect.arrayContaining(["linkedin", "x"]));
+    expect(typeof payload.target_datetime).toBe("string");
+
+    await waitFor(() => expect(fetchRecentPostsMock).toHaveBeenCalledTimes(2));
+  });
+
+  it("requires at least one platform before queuing", async () => {
+    const user = userEvent.setup();
+    renderPage();
+    await waitFor(() => expect(fetchRecentPostsMock).toHaveBeenCalled());
+
+    // LinkedIn starts selected by default — deselect it to leave none.
+    await user.click(screen.getByRole("button", { name: "LinkedIn" }));
+
+    await act(async () => {
+      await user.click(screen.getByRole("button", { name: /Run all agents/ }));
+    });
+
+    expect(await screen.findByText(/Select at least one platform/)).toBeInTheDocument();
+    expect(createCalendarEventMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/__tests__/creative-page.test.tsx
+++ b/apps/web/__tests__/creative-page.test.tsx
@@ -1,0 +1,113 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { act, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import CreativePage from "@/app/creative/page";
+import { AuthProvider } from "@/lib/auth-context";
+import { BrandProvider } from "@/lib/brand-context";
+import { ToastProvider } from "@/components/ui/Toast";
+import type { CreativeAngle } from "@/lib/api";
+
+const fetchBrandsMock = vi.fn();
+const generateCreativeAnglesMock = vi.fn();
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return {
+    ...actual,
+    fetchBrands: (...args: unknown[]) => fetchBrandsMock(...args),
+    generateCreativeAngles: (...args: unknown[]) => generateCreativeAnglesMock(...args),
+  };
+});
+
+const BRANDS = [
+  {
+    id: "brand-1",
+    organization_id: "org-1",
+    name: "Acme Co",
+    industry: null,
+    logo_url: null,
+    target_audience: null,
+    colors: null,
+    tone_descriptors: null,
+    product_catalog: null,
+    brand_report: null,
+    created_at: "2026-01-01",
+    updated_at: "2026-01-01",
+  },
+];
+
+function makeAngles(count = 6): CreativeAngle[] {
+  return Array.from({ length: count }, (_, i) => ({
+    format: `Format ${i}`,
+    angle: `Angle ${i}`,
+    hook: `Hook number ${i}`,
+    why: `Why this works ${i}`,
+    cta: `CTA ${i}`,
+    score: 90 - i,
+  }));
+}
+
+function renderPage() {
+  return render(
+    <ToastProvider>
+      <AuthProvider>
+        <BrandProvider>
+          <CreativePage />
+        </BrandProvider>
+      </AuthProvider>
+    </ToastProvider>
+  );
+}
+
+describe("CreativePage", () => {
+  beforeEach(() => {
+    fetchBrandsMock.mockReset();
+    generateCreativeAnglesMock.mockReset();
+
+    window.localStorage.clear();
+    window.localStorage.setItem("raindeer.auth.token", "test-token");
+
+    fetchBrandsMock.mockResolvedValue(BRANDS);
+  });
+
+  it("generates and renders 6 angle cards from the brief", async () => {
+    generateCreativeAnglesMock.mockResolvedValue(makeAngles());
+    const user = userEvent.setup();
+
+    renderPage();
+
+    await waitFor(() => expect(fetchBrandsMock).toHaveBeenCalled());
+    await screen.findByLabelText("Creative brief");
+
+    await act(async () => {
+      await user.click(screen.getByRole("button", { name: "Generate all 6 →" }));
+    });
+
+    await waitFor(() =>
+      expect(generateCreativeAnglesMock).toHaveBeenCalledWith(
+        "test-token",
+        "brand-1",
+        expect.any(String)
+      )
+    );
+
+    expect(await screen.findByText("Hook number 0")).toBeInTheDocument();
+    expect(screen.getByText("Hook number 5")).toBeInTheDocument();
+    expect(screen.getAllByText(/Why this works/).length).toBe(6);
+  });
+
+  it("shows an error and no cards when generation fails", async () => {
+    generateCreativeAnglesMock.mockRejectedValue(new Error("LLM unreachable"));
+    const user = userEvent.setup();
+
+    renderPage();
+    await screen.findByLabelText("Creative brief");
+
+    await act(async () => {
+      await user.click(screen.getByRole("button", { name: "Generate all 6 →" }));
+    });
+
+    expect(await screen.findByText("LLM unreachable")).toBeInTheDocument();
+    expect(screen.queryByText(/Hook number/)).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/__tests__/research-page.test.tsx
+++ b/apps/web/__tests__/research-page.test.tsx
@@ -1,0 +1,121 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { act, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import ResearchPage from "@/app/research/page";
+import { AuthProvider } from "@/lib/auth-context";
+import { BrandProvider } from "@/lib/brand-context";
+import { ToastProvider } from "@/components/ui/Toast";
+import type { ResearchRun } from "@/lib/api";
+
+const fetchBrandsMock = vi.fn();
+const fetchLatestResearchMock = vi.fn();
+const runResearchMock = vi.fn();
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return {
+    ...actual,
+    fetchBrands: (...args: unknown[]) => fetchBrandsMock(...args),
+    fetchLatestResearch: (...args: unknown[]) => fetchLatestResearchMock(...args),
+    runResearch: (...args: unknown[]) => runResearchMock(...args),
+  };
+});
+
+const BRANDS = [
+  {
+    id: "brand-1",
+    organization_id: "org-1",
+    name: "Acme Co",
+    industry: null,
+    logo_url: null,
+    target_audience: null,
+    colors: null,
+    tone_descriptors: null,
+    product_catalog: null,
+    brand_report: null,
+    created_at: "2026-01-01",
+    updated_at: "2026-01-01",
+  },
+];
+
+function makeRun(overrides: Partial<ResearchRun> = {}): ResearchRun {
+  return {
+    id: "run-1",
+    post_id: "post-1",
+    brand_id: "brand-1",
+    created_at: "2026-08-20T10:00:00Z",
+    brief: {
+      post_id: "post-1",
+      brand_context: [],
+      platform_trends: {
+        linkedin: [
+          { title: "DPDP deadline is reshaping compliance content", url: "https://example.com/a", content: "Founders are posting about it." },
+        ],
+      },
+      industry_trends: [
+        { title: "Legal tech funding up 40%", url: "https://news.example.com/b", content: "Investment trend." },
+      ],
+      timing_signal: {
+        researched_at: "2026-08-20T09:55:00Z",
+        platforms: ["linkedin"],
+        trending_topics: ["DPDP deadline", "diligence failure rate"],
+        target_datetime: null,
+      },
+    },
+    ...overrides,
+  };
+}
+
+function renderPage() {
+  return render(
+    <ToastProvider>
+      <AuthProvider>
+        <BrandProvider>
+          <ResearchPage />
+        </BrandProvider>
+      </AuthProvider>
+    </ToastProvider>
+  );
+}
+
+describe("ResearchPage", () => {
+  beforeEach(() => {
+    fetchBrandsMock.mockReset();
+    fetchLatestResearchMock.mockReset();
+    runResearchMock.mockReset();
+
+    window.localStorage.clear();
+    window.localStorage.setItem("raindeer.auth.token", "test-token");
+
+    fetchBrandsMock.mockResolvedValue(BRANDS);
+    fetchLatestResearchMock.mockResolvedValue(null);
+  });
+
+  it("shows an empty state and lets the user run research for the first time", async () => {
+    const user = userEvent.setup();
+    runResearchMock.mockResolvedValue(makeRun());
+
+    renderPage();
+
+    await waitFor(() => expect(fetchLatestResearchMock).toHaveBeenCalledWith("test-token", "brand-1"));
+    expect(await screen.findByText(/No research yet/)).toBeInTheDocument();
+
+    await act(async () => {
+      await user.click(screen.getAllByRole("button", { name: /Run new research/ })[0]);
+    });
+
+    await waitFor(() => expect(runResearchMock).toHaveBeenCalledWith("test-token", "brand-1"));
+    expect(await screen.findByText(/DPDP deadline is reshaping compliance content/)).toBeInTheDocument();
+    expect(screen.getByText(/Legal tech funding up 40%/)).toBeInTheDocument();
+    expect(screen.getByText("diligence failure rate")).toBeInTheDocument();
+  });
+
+  it("renders trend cards from the most recent research on load", async () => {
+    fetchLatestResearchMock.mockResolvedValue(makeRun());
+
+    renderPage();
+
+    expect(await screen.findByText(/DPDP deadline is reshaping compliance content/)).toBeInTheDocument();
+    expect(screen.getAllByText("linkedin").length).toBeGreaterThan(0);
+  });
+});

--- a/apps/web/app/arena/block-library.ts
+++ b/apps/web/app/arena/block-library.ts
@@ -1,0 +1,61 @@
+// Static block-type palette for the left sidebar (Issue #124 scopes this
+// to "a static visual list of block types — no drag-drop needed"). This
+// is UI chrome describing what kinds of blocks the pipeline is built
+// from, not per-run telemetry, so it's fine for it to be a fixed list
+// rather than derived from a specific run.
+export interface LibraryItem {
+  icon: string;
+  label: string;
+  color: string;
+}
+
+export interface LibraryGroup {
+  group: string;
+  items: LibraryItem[];
+}
+
+export const BLOCK_LIBRARY: LibraryGroup[] = [
+  {
+    group: "AGENTS",
+    items: [
+      { icon: "V", label: "Research · Ved", color: "#1B4DFF" },
+      { icon: "K", label: "Creative · Keshav", color: "#6B32C9" },
+      { icon: "K", label: "Generation · Kavi", color: "#0E7A4E" },
+      { icon: "N", label: "Reviewer · Neer", color: "#B46A00" },
+      { icon: "A", label: "Onboarding · Aarav", color: "#2C5FD6" },
+    ],
+  },
+  {
+    group: "TOOLS",
+    items: [
+      { icon: "⌕", label: "Web search", color: "#2B3D6B" },
+      { icon: "↗", label: "Trend radar", color: "#2B3D6B" },
+      { icon: "▧", label: "Image gen", color: "#2B3D6B" },
+      { icon: "▶", label: "Video gen", color: "#2B3D6B" },
+    ],
+  },
+  {
+    group: "DATA",
+    items: [
+      { icon: "B", label: "Brand memory", color: "#0B2A6B" },
+      { icon: "◍", label: "Audience", color: "#0B2A6B" },
+      { icon: "▲", label: "Past performance", color: "#0B2A6B" },
+    ],
+  },
+  {
+    group: "FLOW",
+    items: [
+      { icon: "☺", label: "Human approval", color: "#1B4DFF" },
+      { icon: "◇", label: "Condition", color: "#8B5BD6" },
+      { icon: "◷", label: "Wait until", color: "#8B5BD6" },
+    ],
+  },
+  {
+    group: "OUTPUT",
+    items: [
+      { icon: "◷", label: "Scheduler", color: "#1E7FB8" },
+      { icon: "➤", label: "Publisher", color: "#1E7FB8" },
+      { icon: "▲", label: "Analytics loop", color: "#C2477F" },
+    ],
+  },
+];

--- a/apps/web/app/arena/build-dock.ts
+++ b/apps/web/app/arena/build-dock.ts
@@ -1,0 +1,161 @@
+// Builds the bottom dock's four tabs (Trace / Outputs / Cost / Sources)
+// straight from the real AgentRun/Post rows in an ArenaRun — no invented
+// telemetry. Kept separate from build-nodes.ts (which is about the
+// canvas) since the dock reads the same run but summarizes it
+// differently (a flat timeline instead of per-node cards).
+import type { AgentType, ArenaAgentRun, ArenaRun } from "@/lib/api";
+import { formatClock, formatCost, formatTokens, truncate } from "./format";
+
+export const AGENT_DISPLAY_NAME: Record<AgentType, string> = {
+  research: "Ved",
+  creative: "Keshav",
+  generation: "Kavi",
+  reviewer: "Neer",
+  human_review: "system",
+  scheduler: "Scheduler",
+  publisher: "Publisher",
+  analytics_collector: "Analytics",
+};
+
+export interface TraceEntry {
+  id: string;
+  time: string;
+  who: string;
+  text: string;
+}
+
+function summarize(agentRun: ArenaAgentRun): string {
+  const output = agentRun.output ?? {};
+  switch (agentRun.agent_type) {
+    case "research": {
+      const brief = output.research_brief as { industry_trends?: { title: string }[] } | undefined;
+      const count = brief?.industry_trends?.length ?? 0;
+      return `research complete · ${count} industry trend${count === 1 ? "" : "s"} found`;
+    }
+    case "creative": {
+      const brief = output.creative_brief as { platforms?: Record<string, unknown> } | undefined;
+      const count = Object.keys(brief?.platforms ?? {}).length;
+      return `creative brief ready · ${count} platform${count === 1 ? "" : "s"}`;
+    }
+    case "generation": {
+      const gen = output.generation_output as { platforms?: Record<string, unknown> } | undefined;
+      const count = Object.keys(gen?.platforms ?? {}).length;
+      return `generated ${count} draft${count === 1 ? "" : "s"}` + (agentRun.model ? ` with ${agentRun.model}` : "");
+    }
+    case "reviewer":
+      return "reviewer pass complete — see Governance for score/verdict";
+    case "human_review":
+      return "resumed from the human_review checkpoint";
+    case "scheduler":
+      return "scheduler stage recorded (not yet implemented)";
+    case "publisher":
+      return "handed off to the publish queue";
+    case "analytics_collector":
+      return "analytics collector stage recorded (not yet implemented)";
+    default:
+      return "stage complete";
+  }
+}
+
+export function buildTrace(run: ArenaRun): TraceEntry[] {
+  return run.agent_runs.map((agentRun) => ({
+    id: agentRun.id,
+    time: agentRun.created_at,
+    who: AGENT_DISPLAY_NAME[agentRun.agent_type],
+    text: summarize(agentRun),
+  }));
+}
+
+export interface SourceEntry {
+  title: string;
+  url: string;
+  domain: string;
+}
+
+function domainOf(url: string): string {
+  try {
+    return new URL(url).hostname.replace(/^www\./, "");
+  } catch {
+    return url;
+  }
+}
+
+/** Real search results the Research Engine actually retrieved
+ * (packages/agents/pipeline/nodes/research_engine.py's
+ * industry_trends/platform_trends), not invented sources. Empty when
+ * research hasn't run yet. */
+export function buildSources(run: ArenaRun): SourceEntry[] {
+  const researchRun = run.agent_runs.find((r) => r.agent_type === "research");
+  const brief = researchRun?.output?.research_brief as
+    | {
+        industry_trends?: { title: string; url: string }[];
+        platform_trends?: Record<string, { title: string; url: string }[]>;
+      }
+    | undefined;
+  if (!brief) return [];
+
+  const results: { title: string; url: string }[] = [...(brief.industry_trends ?? [])];
+  for (const list of Object.values(brief.platform_trends ?? {})) {
+    if (Array.isArray(list)) results.push(...list);
+  }
+
+  const seen = new Set<string>();
+  const sources: SourceEntry[] = [];
+  for (const result of results) {
+    if (!result?.url || seen.has(result.url)) continue;
+    seen.add(result.url);
+    sources.push({ title: result.title || result.url, url: result.url, domain: domainOf(result.url) });
+  }
+  return sources;
+}
+
+export interface CostRow {
+  agentType: AgentType;
+  who: string;
+  model: string;
+  tokens: string;
+  cost: string;
+}
+
+export function buildCostRows(run: ArenaRun): CostRow[] {
+  return run.agent_runs
+    .filter((r) => r.cost !== null || r.tokens !== null)
+    .map((r) => ({
+      agentType: r.agent_type,
+      who: AGENT_DISPLAY_NAME[r.agent_type],
+      model: r.model ?? "—",
+      tokens: formatTokens(r.tokens),
+      cost: formatCost(r.cost),
+    }));
+}
+
+export function totalCost(run: ArenaRun): number {
+  return run.agent_runs.reduce((sum, r) => sum + (r.cost ?? 0), 0);
+}
+
+export function totalTokens(run: ArenaRun): number {
+  return run.agent_runs.reduce((sum, r) => sum + (r.tokens ?? 0), 0);
+}
+
+export interface DraftThumb {
+  platform: string;
+  format: string;
+  url: string;
+  captionPreview: string;
+}
+
+/** Real generated Post media (apps/api/models/post.py::Post.media) — empty
+ * (not filled with placeholders) when generation hasn't produced any
+ * media yet, e.g. a text-only run or one that hasn't reached generation. */
+export function buildDraftThumbs(run: ArenaRun): DraftThumb[] {
+  const media = run.post?.media ?? [];
+  const bodyText = run.post?.body_text ?? {};
+  return media.map((item) => ({
+    platform: item.platform,
+    format: item.format,
+    url: item.url,
+    captionPreview: bodyText[item.platform] ? truncate(bodyText[item.platform], 60) : "",
+  }));
+}
+
+export { formatClock };

--- a/apps/web/app/arena/build-nodes.ts
+++ b/apps/web/app/arena/build-nodes.ts
@@ -1,0 +1,335 @@
+// Merges the real data an Arena run has (ArenaRun from the API, plus the
+// CalendarEvent/Brand it belongs to) onto the static graph topology
+// (topology.ts) to produce what the canvas actually renders. This is
+// deliberately the one place that decides "what does this node say" —
+// kept as pure functions, no React, so it's unit-testable without
+// mounting the page.
+import type { ArenaAgentRun, ArenaReviewFeedback, ArenaRun, Brand, CalendarEvent } from "@/lib/api";
+import { formatCost, formatLatency, formatTokens, truncate } from "./format";
+import { ArenaNodeId, NODE_LAYOUT, NodeLayout } from "./topology";
+
+export type NodeStatus = "DONE" | "WAITING" | "QUEUED" | "SKIPPED" | "READ";
+
+export interface ArenaNodeView extends NodeLayout {
+  status: NodeStatus;
+  /** 1-3 short summary lines shown on the node card's body. */
+  lines: string[];
+  /** Up to 3 label/value stat tiles — real numbers only, "—" when absent. */
+  stats: { label: string; value: string }[];
+  /** One-line footer, e.g. a timestamp or a static description of what a
+   * still-stub stage does. */
+  footer: string;
+  /** The backing AgentRun row, if this stage has run — null for context
+   * nodes and for stages that haven't executed yet. */
+  agentRun: ArenaAgentRun | null;
+  /** ReviewFeedback rows relevant to this node (reviewer: ai_reviewer
+   * rows; human_review: human rows) — empty for every other node. */
+  reviewFeedback: ArenaReviewFeedback[];
+}
+
+const PIPELINE_STAGE_ORDER: ArenaNodeId[] = [
+  "research",
+  "creative",
+  "generation",
+  "reviewer",
+  "human_review",
+  "scheduler",
+  "publisher",
+  "analytics_collector",
+];
+
+// What each stage's real code actually does — static, factual, and true
+// regardless of whether it has run yet. Several of these (scheduler,
+// analytics_collector) are still stub nodes in
+// packages/agents/pipeline/graph.py — said plainly here rather than
+// implying they do something they don't.
+const STAGE_DESCRIPTIONS: Record<ArenaNodeId, string> = {
+  brief: "The calendar event this run was triggered from.",
+  brand: "Brand voice, audience and compliance rules retrieved for this run.",
+  research: "Gathers platform + industry trend research and brand context.",
+  creative: "Turns the research brief into a per-platform angle/hook/CTA.",
+  generation: "Writes per-platform copy (and media, where the brief calls for it).",
+  reviewer: "Scores the draft against brand voice/compliance and platform fit.",
+  human_review: "Durable pause — waits for a human decision, resumable across restarts.",
+  scheduler: "Not yet implemented — still a stub node that only records that it ran.",
+  publisher: "Hands the post to the async publish queue for each target platform.",
+  analytics_collector: "Not yet implemented — still a stub node that only records that it ran.",
+};
+
+function isTerminalRejected(post: ArenaRun["post"]): boolean {
+  return post?.current_pipeline_stage === "rejected";
+}
+
+function findAgentRun(agentRuns: ArenaAgentRun[], id: ArenaNodeId): ArenaAgentRun | null {
+  return agentRuns.find((run) => run.agent_type === id) ?? null;
+}
+
+function statusFor(
+  id: ArenaNodeId,
+  run: ArenaRun,
+  agentRun: ArenaAgentRun | null
+): NodeStatus {
+  if (agentRun) return "DONE";
+  if (id === "human_review" && run.post?.current_pipeline_stage === "human_review") {
+    return "WAITING";
+  }
+  const stageIndex = PIPELINE_STAGE_ORDER.indexOf(id);
+  if (isTerminalRejected(run.post) && stageIndex > PIPELINE_STAGE_ORDER.indexOf("human_review")) {
+    return "SKIPPED";
+  }
+  return "QUEUED";
+}
+
+function contextBriefNode(base: NodeLayout, event: CalendarEvent | null): ArenaNodeView {
+  if (!event) {
+    return {
+      ...base,
+      status: "READ",
+      lines: ["No calendar event — ad hoc post"],
+      stats: [],
+      footer: STAGE_DESCRIPTIONS.brief,
+      agentRun: null,
+      reviewFeedback: [],
+    };
+  }
+  return {
+    ...base,
+    status: "READ",
+    lines: [
+      truncate(event.title, 42),
+      `platforms: ${event.target_platforms.join(", ") || "—"}`,
+      `format: ${event.desired_format}`,
+    ],
+    stats: [
+      { label: "PLATFORMS", value: String(event.target_platforms.length) },
+      { label: "STATUS", value: event.status },
+      { label: "FORMAT", value: event.desired_format },
+    ],
+    footer: `calendar event · ${new Date(event.target_datetime).toLocaleDateString()}`,
+    agentRun: null,
+    reviewFeedback: [],
+  };
+}
+
+function contextBrandNode(base: NodeLayout, brand: Brand | null): ArenaNodeView {
+  if (!brand) {
+    return {
+      ...base,
+      status: "READ",
+      lines: ["No brand selected"],
+      stats: [],
+      footer: STAGE_DESCRIPTIONS.brand,
+      agentRun: null,
+      reviewFeedback: [],
+    };
+  }
+  return {
+    ...base,
+    status: "READ",
+    lines: [
+      brand.industry ?? "industry not set",
+      `${brand.tone_descriptors?.length ?? 0} tone descriptors`,
+    ],
+    stats: [
+      { label: "INDUSTRY", value: brand.industry ?? "—" },
+      { label: "COLORS", value: String(brand.colors?.length ?? 0) },
+      { label: "REPORT", value: brand.brand_report ? "ready" : "none" },
+    ],
+    footer: brand.name,
+    agentRun: null,
+    reviewFeedback: [],
+  };
+}
+
+function researchLines(agentRun: ArenaAgentRun): { lines: string[]; stats: { label: string; value: string }[] } {
+  const brief = agentRun.output?.research_brief as
+    | { platform_trends?: Record<string, unknown[]>; industry_trends?: { title: string }[] }
+    | undefined;
+  const platformTrendCount = brief?.platform_trends
+    ? Object.values(brief.platform_trends).reduce((sum, arr) => sum + (Array.isArray(arr) ? arr.length : 0), 0)
+    : 0;
+  const industryTrends = brief?.industry_trends ?? [];
+  const sourceCount = platformTrendCount + industryTrends.length;
+  return {
+    lines: [
+      `${sourceCount} source${sourceCount === 1 ? "" : "s"} found`,
+      industryTrends[0]?.title ? truncate(industryTrends[0].title, 48) : "no industry trend surfaced",
+    ],
+    stats: [
+      { label: "SOURCES", value: String(sourceCount) },
+      { label: "COST", value: formatCost(agentRun.cost) },
+      { label: "LATENCY", value: formatLatency(agentRun.latency_ms) },
+    ],
+  };
+}
+
+function creativeLines(agentRun: ArenaAgentRun): { lines: string[]; stats: { label: string; value: string }[] } {
+  const brief = agentRun.output?.creative_brief as
+    | { platforms?: Record<string, { hook?: string; format?: string }> }
+    | undefined;
+  const platforms = brief?.platforms ?? {};
+  const platformIds = Object.keys(platforms);
+  const firstHook = platformIds[0] ? platforms[platformIds[0]]?.hook : undefined;
+  return {
+    lines: [
+      `${platformIds.length} platform brief${platformIds.length === 1 ? "" : "s"}`,
+      firstHook ? truncate(firstHook, 52) : "no hook generated",
+    ],
+    stats: [
+      { label: "PLATFORMS", value: String(platformIds.length) },
+      { label: "MODEL", value: agentRun.model ?? "—" },
+      { label: "COST", value: formatCost(agentRun.cost) },
+    ],
+  };
+}
+
+function generationLines(agentRun: ArenaAgentRun): { lines: string[]; stats: { label: string; value: string }[] } {
+  const output = agentRun.output?.generation_output as
+    | { platforms?: Record<string, unknown> }
+    | undefined;
+  const platformIds = Object.keys(output?.platforms ?? {});
+  return {
+    lines: [
+      `${platformIds.length} draft${platformIds.length === 1 ? "" : "s"} written`,
+      agentRun.model ? `model: ${agentRun.model}` : "model not recorded",
+    ],
+    stats: [
+      { label: "DRAFTS", value: String(platformIds.length) },
+      { label: "TOKENS", value: formatTokens(agentRun.tokens) },
+      { label: "COST", value: formatCost(agentRun.cost) },
+    ],
+  };
+}
+
+function reviewerLines(
+  agentRun: ArenaAgentRun,
+  reviewFeedback: ArenaReviewFeedback[]
+): { lines: string[]; stats: { label: string; value: string }[] } {
+  const latest = reviewFeedback[reviewFeedback.length - 1];
+  return {
+    lines: latest
+      ? [`score ${latest.score.toFixed(0)}/100 · ${latest.verdict}`]
+      : ["review pass complete"],
+    stats: [
+      { label: "SCORE", value: latest ? latest.score.toFixed(0) : "—" },
+      { label: "VERDICT", value: latest ? latest.verdict : "—" },
+      { label: "COST", value: formatCost(agentRun.cost) },
+    ],
+  };
+}
+
+function humanReviewLines(
+  run: ArenaRun,
+  agentRun: ArenaAgentRun | null,
+  humanFeedback: ArenaReviewFeedback[]
+): { lines: string[]; stats: { label: string; value: string }[] } {
+  if (!agentRun && run.post?.current_pipeline_stage === "human_review") {
+    return {
+      lines: ["Paused — waiting on a human decision", "durable interrupt · resumes exactly here"],
+      stats: [{ label: "PENDING", value: "1" }, { label: "SINCE", value: formatClockShort(run.post.updated_at) }, { label: "SLA", value: "—" }],
+    };
+  }
+  const latest = humanFeedback[humanFeedback.length - 1];
+  if (latest) {
+    return {
+      lines: [`${latest.verdict} by a human reviewer`],
+      stats: [{ label: "VERDICT", value: latest.verdict }, { label: "SCORE", value: latest.score.toFixed(0) }, { label: "AT", value: formatClockShort(latest.created_at) }],
+    };
+  }
+  return { lines: ["not reached yet"], stats: [] };
+}
+
+function formatClockShort(iso: string): string {
+  const d = new Date(iso);
+  return Number.isNaN(d.getTime()) ? "—" : d.toLocaleTimeString(undefined, { hour: "2-digit", minute: "2-digit" });
+}
+
+function genericStageLines(agentRun: ArenaAgentRun): { lines: string[]; stats: { label: string; value: string }[] } {
+  return {
+    lines: [STAGE_DESCRIPTIONS[agentRun.agent_type], "ran successfully"],
+    stats: [
+      { label: "MODEL", value: agentRun.model ?? "—" },
+      { label: "COST", value: formatCost(agentRun.cost) },
+      { label: "LATENCY", value: formatLatency(agentRun.latency_ms) },
+    ],
+  };
+}
+
+function stageNode(
+  base: NodeLayout,
+  id: ArenaNodeId,
+  run: ArenaRun
+): ArenaNodeView {
+  const agentRun = findAgentRun(run.agent_runs, id);
+  const status = statusFor(id, run, agentRun);
+  const reviewFeedback =
+    id === "reviewer"
+      ? run.review_feedback.filter((f) => f.source === "ai_reviewer")
+      : id === "human_review"
+        ? run.review_feedback.filter((f) => f.source === "human")
+        : [];
+
+  if (!agentRun) {
+    const waiting = status === "WAITING";
+    const skipped = status === "SKIPPED";
+    let extra: { lines: string[]; stats: { label: string; value: string }[] } = {
+      lines: [skipped ? "skipped — run was rejected before reaching here" : "not run yet"],
+      stats: [],
+    };
+    if (id === "human_review" || waiting) {
+      extra = humanReviewLines(run, null, reviewFeedback);
+    }
+    return {
+      ...base,
+      status,
+      lines: extra.lines,
+      stats: extra.stats,
+      footer: STAGE_DESCRIPTIONS[id],
+      agentRun: null,
+      reviewFeedback,
+    };
+  }
+
+  let extra: { lines: string[]; stats: { label: string; value: string }[] };
+  switch (id) {
+    case "research":
+      extra = researchLines(agentRun);
+      break;
+    case "creative":
+      extra = creativeLines(agentRun);
+      break;
+    case "generation":
+      extra = generationLines(agentRun);
+      break;
+    case "reviewer":
+      extra = reviewerLines(agentRun, reviewFeedback);
+      break;
+    case "human_review":
+      extra = humanReviewLines(run, agentRun, reviewFeedback);
+      break;
+    default:
+      extra = genericStageLines(agentRun);
+  }
+
+  return {
+    ...base,
+    status,
+    lines: extra.lines,
+    stats: extra.stats,
+    footer: `${STAGE_DESCRIPTIONS[id]} · ${formatClockShort(agentRun.created_at)}`,
+    agentRun,
+    reviewFeedback,
+  };
+}
+
+export function buildArenaNodes(
+  run: ArenaRun,
+  event: CalendarEvent | null,
+  brand: Brand | null
+): ArenaNodeView[] {
+  return NODE_LAYOUT.map((base) => {
+    if (base.id === "brief") return contextBriefNode(base, event);
+    if (base.id === "brand") return contextBrandNode(base, brand);
+    return stageNode(base, base.id, run);
+  });
+}

--- a/apps/web/app/arena/dock.tsx
+++ b/apps/web/app/arena/dock.tsx
@@ -1,0 +1,175 @@
+"use client";
+
+import { useState } from "react";
+import type { ArenaRun } from "@/lib/api";
+import { buildCostRows, buildDraftThumbs, buildSources, buildTrace, totalCost, totalTokens } from "./build-dock";
+import { formatClock, formatCost, formatTokens } from "./format";
+
+type DockTab = "trace" | "outputs" | "cost" | "sources";
+
+const AGENT_COLOR: Record<string, string> = {
+  Ved: "#8FB4FF",
+  Keshav: "#C9A6FF",
+  Kavi: "#6BE3B0",
+  Neer: "#FFC46B",
+  system: "#7C8AB4",
+  Scheduler: "#7FD4FF",
+  Publisher: "#7FD4FF",
+  Analytics: "#FF9BC4",
+};
+
+export function Dock({ run }: { run: ArenaRun }) {
+  const [tab, setTab] = useState<DockTab>("trace");
+  const trace = buildTrace(run);
+  const costRows = buildCostRows(run);
+  const sources = buildSources(run);
+  const drafts = buildDraftThumbs(run);
+
+  const tabs: { id: DockTab; label: string; count: number | string }[] = [
+    { id: "trace", label: "Trace", count: trace.length },
+    { id: "outputs", label: "Outputs", count: Object.keys(run.post?.body_text ?? {}).length },
+    { id: "cost", label: "Cost", count: formatCost(totalCost(run)) },
+    { id: "sources", label: "Sources", count: sources.length },
+  ];
+
+  return (
+    <div className="grid h-[196px] min-h-0 grid-cols-[minmax(0,1fr)_320px] border-t border-arenadark-border bg-arenadark-panel">
+      <div className="flex min-h-0 flex-col border-r border-arenadark-border">
+        <div className="flex items-center gap-1 px-3.5 pt-2">
+          {tabs.map((t) => (
+            <button
+              key={t.id}
+              type="button"
+              onClick={() => setTab(t.id)}
+              aria-pressed={tab === t.id}
+              className="rounded-t-lg px-2.5 py-1.5 text-[11.5px] font-bold"
+              style={{ color: tab === t.id ? "#fff" : "#7C8AB4", background: tab === t.id ? "#131C3B" : "transparent" }}
+            >
+              {t.label} <span className="font-semibold text-arenadark-muted">{t.count}</span>
+            </button>
+          ))}
+        </div>
+
+        <div className="flex-1 overflow-auto px-3.5 py-2">
+          {tab === "trace" &&
+            (trace.length === 0 ? (
+              <EmptyDockState text="No agent runs logged yet for this run." />
+            ) : (
+              <ul className="flex flex-col gap-1.5" aria-label="Run trace">
+                {[...trace].reverse().map((entry) => (
+                  <li key={entry.id} className="flex items-start gap-2.5">
+                    <span className="flex-none pt-px font-mono text-[10px] text-arenadark-muted">
+                      {formatClock(entry.time)}
+                    </span>
+                    <span
+                      className="w-[70px] flex-none text-[10.5px] font-extrabold"
+                      style={{ color: AGENT_COLOR[entry.who] ?? "#93A2CC" }}
+                    >
+                      {entry.who}
+                    </span>
+                    <span className="min-w-0 text-[11.5px] leading-relaxed text-arenadark-text3">{entry.text}</span>
+                  </li>
+                ))}
+              </ul>
+            ))}
+
+          {tab === "outputs" &&
+            (!run.post?.body_text || Object.keys(run.post.body_text).length === 0 ? (
+              <EmptyDockState text="No generated copy yet — Generation hasn't run." />
+            ) : (
+              <ul className="flex flex-col gap-2">
+                {Object.entries(run.post.body_text).map(([platform, text]) => (
+                  <li key={platform} className="rounded-[9px] border border-arenadark-border3 bg-arenadark-panel3 px-2.5 py-2">
+                    <div className="mb-1 text-[9.5px] font-extrabold uppercase tracking-wide text-arenadark-muted">
+                      {platform}
+                    </div>
+                    <p className="text-[11.5px] leading-relaxed text-arenadark-text2">{text}</p>
+                  </li>
+                ))}
+              </ul>
+            ))}
+
+          {tab === "cost" &&
+            (costRows.length === 0 ? (
+              <EmptyDockState text="No cost/token data recorded yet." />
+            ) : (
+              <div>
+                <div className="mb-2 flex gap-4 text-[11.5px] text-arenadark-text2">
+                  <span>
+                    Total cost <b className="text-white">{formatCost(totalCost(run))}</b>
+                  </span>
+                  <span>
+                    Total tokens <b className="text-white">{formatTokens(totalTokens(run))}</b>
+                  </span>
+                </div>
+                <ul className="flex flex-col gap-1">
+                  {costRows.map((row) => (
+                    <li key={row.agentType} className="flex items-center gap-3 text-[11.5px] text-arenadark-text3">
+                      <span className="w-20 flex-none font-bold" style={{ color: AGENT_COLOR[row.who] ?? "#93A2CC" }}>
+                        {row.who}
+                      </span>
+                      <span className="w-28 flex-none font-mono text-[10.5px]">{row.model}</span>
+                      <span className="w-16 flex-none">{row.tokens} tok</span>
+                      <span>{row.cost}</span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            ))}
+
+          {tab === "sources" &&
+            (sources.length === 0 ? (
+              <EmptyDockState text="No sources yet — Research hasn't run." />
+            ) : (
+              <ul className="flex flex-col gap-1.5">
+                {sources.map((source) => (
+                  <li key={source.url} className="text-[11.5px]">
+                    <a
+                      href={source.url}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="font-semibold text-arenadark-text2 hover:underline"
+                    >
+                      {source.title}
+                    </a>
+                    <span className="ml-2 text-[11px] text-arenadark-muted">{source.domain}</span>
+                  </li>
+                ))}
+              </ul>
+            ))}
+        </div>
+      </div>
+
+      <div className="flex min-h-0 flex-col">
+        <div className="flex items-center gap-2 px-3.5 pb-1.5 pt-2.5">
+          <span className="text-[9.5px] font-extrabold tracking-[.13em] text-arenadark-muted">DRAFT MEDIA</span>
+          <span className="rounded-[5px] bg-[#152249] px-1.5 py-0.5 text-[10px] font-bold text-[#8FB4FF]">
+            {drafts.length}
+          </span>
+        </div>
+        <div className="flex flex-1 gap-2 overflow-auto px-3.5 pb-3">
+          {drafts.length === 0 ? (
+            <EmptyDockState text="No media generated for this run yet." />
+          ) : (
+            drafts.map((draft, i) => (
+              <div key={i} className="w-28 flex-none overflow-hidden rounded-[10px] border border-arenadark-border3 bg-arenadark-panel3">
+                {/* eslint-disable-next-line @next/next/no-img-element -- real Post.media URLs from arbitrary storage hosts, same as components/ui/Avatar.tsx */}
+                <img src={draft.url} alt={`${draft.platform} draft`} className="h-[78px] w-full object-cover" />
+                <div className="flex items-center gap-1 px-2 py-1.5">
+                  <span className="rounded-[4px] bg-arenadark-border3 px-1 text-[8.5px] font-extrabold text-white">
+                    {draft.platform}
+                  </span>
+                  <span className="truncate text-[9.5px] text-arenadark-muted2">{draft.format}</span>
+                </div>
+              </div>
+            ))
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function EmptyDockState({ text }: { text: string }) {
+  return <p className="text-[11.5px] italic text-arenadark-muted">{text}</p>;
+}

--- a/apps/web/app/arena/format.ts
+++ b/apps/web/app/arena/format.ts
@@ -1,0 +1,37 @@
+// Small formatting helpers shared across the Content Arena screen (Issue
+// #124). Kept pure/dependency-free so they're trivial to unit test.
+
+export function formatCost(cost: number | null | undefined): string {
+  if (cost === null || cost === undefined) return "—";
+  return `$${cost.toFixed(2)}`;
+}
+
+export function formatTokens(tokens: number | null | undefined): string {
+  if (tokens === null || tokens === undefined) return "—";
+  return tokens >= 1000 ? `${(tokens / 1000).toFixed(1)}k` : String(tokens);
+}
+
+export function formatLatency(latencyMs: number | null | undefined): string {
+  if (latencyMs === null || latencyMs === undefined) return "—";
+  return latencyMs >= 1000 ? `${(latencyMs / 1000).toFixed(1)}s` : `${Math.round(latencyMs)}ms`;
+}
+
+export function formatClock(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return "—";
+  return d.toLocaleTimeString(undefined, { hour: "2-digit", minute: "2-digit", second: "2-digit" });
+}
+
+export function formatElapsedSince(iso: string, now: Date = new Date()): string {
+  const start = new Date(iso).getTime();
+  if (Number.isNaN(start)) return "—";
+  const totalSeconds = Math.max(0, Math.floor((now.getTime() - start) / 1000));
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return `${String(minutes).padStart(2, "0")}:${String(seconds).padStart(2, "0")}`;
+}
+
+export function truncate(text: string, max: number): string {
+  if (text.length <= max) return text;
+  return `${text.slice(0, max - 1).trimEnd()}…`;
+}

--- a/apps/web/app/arena/inspector.tsx
+++ b/apps/web/app/arena/inspector.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import type { ArenaNodeView } from "./build-nodes";
+
+const isStageNode = (node: ArenaNodeView) => node.id !== "brief" && node.id !== "brand";
+
+export function Inspector({ node }: { node: ArenaNodeView }) {
+  return (
+    <aside className="flex min-h-0 flex-col border-l border-arenadark-border bg-arenadark-panel">
+      <div className="border-b border-arenadark-border px-4 py-3.5">
+        <div className="mb-2.5 flex items-center gap-2.5">
+          <div
+            className="flex h-[26px] w-[26px] flex-none items-center justify-center rounded-lg text-[11px] font-extrabold text-white"
+            style={{ background: node.color }}
+          >
+            {node.initial}
+          </div>
+          <div className="min-w-0 flex-1">
+            <div className="truncate text-sm font-bold text-white">{node.name}</div>
+            <div className="truncate text-[10.5px] text-arenadark-muted2">{node.sub}</div>
+          </div>
+        </div>
+        <div className="grid grid-cols-3 gap-1.5">
+          {node.stats.length > 0 ? (
+            node.stats.map((stat) => (
+              <div key={stat.label} className="rounded-[9px] border border-arenadark-border bg-arenadark-panel3 px-2 py-1.5">
+                <div className="text-[9px] font-bold tracking-wide text-arenadark-muted">{stat.label}</div>
+                <div className="mt-0.5 text-[12.5px] font-extrabold text-arenadark-text2">{stat.value}</div>
+              </div>
+            ))
+          ) : (
+            <div className="col-span-3 text-[11px] text-arenadark-muted">No stats yet</div>
+          )}
+        </div>
+      </div>
+
+      <div className="flex min-h-0 flex-1 flex-col gap-3 overflow-auto px-4 py-3.5">
+        <div>
+          <div className="mb-1.5 text-[10.5px] font-bold text-arenadark-muted2">Summary</div>
+          <div className="flex flex-col gap-1 rounded-[9px] border border-arenadark-border3 bg-arenadark-panel3 px-2.5 py-2">
+            {node.lines.map((line, i) => (
+              <div key={i} className="font-mono text-[11.5px] leading-relaxed text-arenadark-text2">
+                {line}
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {isStageNode(node) && (
+          <div>
+            <div className="mb-1.5 text-[10.5px] font-bold text-arenadark-muted2">System prompt · editable</div>
+            <div className="rounded-[9px] border border-dashed border-arenadark-border3 bg-arenadark-panel3 px-2.5 py-2.5 text-[11.5px] italic text-arenadark-muted">
+              Not available yet — this stage&apos;s AgentRun only records{" "}
+              <code className="not-italic">{"{post_id}"}</code> as input, not the prompt actually sent.
+            </div>
+          </div>
+        )}
+
+        {isStageNode(node) && (
+          <div className="min-h-0">
+            <div className="mb-1.5 text-[10.5px] font-bold text-arenadark-muted2">Raw output</div>
+            {node.agentRun?.output ? (
+              <pre className="max-h-40 overflow-auto whitespace-pre-wrap break-words rounded-[9px] border border-arenadark-border3 bg-arenadark-panel3 px-2.5 py-2 font-mono text-[10.5px] leading-relaxed text-arenadark-text3">
+                {JSON.stringify(node.agentRun.output, null, 2)}
+              </pre>
+            ) : (
+              <div className="rounded-[9px] border border-dashed border-arenadark-border3 bg-arenadark-panel3 px-2.5 py-2.5 text-[11.5px] italic text-arenadark-muted">
+                No output recorded yet — this stage hasn&apos;t run.
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+
+      <div className="flex flex-col gap-1.5 border-t border-arenadark-border px-4 py-3">
+        <button
+          type="button"
+          disabled
+          title="Coming soon"
+          className="h-9 cursor-not-allowed rounded-[10px] bg-brand-600/30 text-[12.5px] font-bold text-white/50"
+        >
+          Re-run from this block · Coming soon
+        </button>
+        <div className="flex gap-1.5">
+          {["Add branch", "Pin output", "Mute"].map((label) => (
+            <button
+              key={label}
+              type="button"
+              disabled
+              title="Coming soon"
+              className="h-8 flex-1 cursor-not-allowed rounded-[9px] border border-arenadark-border3 bg-arenadark-panel3 text-[11.5px] font-semibold text-arenadark-muted2"
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+      </div>
+    </aside>
+  );
+}

--- a/apps/web/app/arena/library-panel.tsx
+++ b/apps/web/app/arena/library-panel.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { BLOCK_LIBRARY } from "./block-library";
+
+/** Static visual list of block types (Issue #124 scopes this to
+ * read-only — no drag-drop). The search box filters the static list
+ * client-side, which is cheap and harmless to include even though
+ * dragging blocks onto the canvas is out of scope. */
+export function LibraryPanel() {
+  const [query, setQuery] = useState("");
+
+  const groups = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return BLOCK_LIBRARY;
+    return BLOCK_LIBRARY.map((group) => ({
+      ...group,
+      items: group.items.filter((item) => item.label.toLowerCase().includes(q)),
+    })).filter((group) => group.items.length > 0);
+  }, [query]);
+
+  return (
+    <aside className="flex min-h-0 flex-col border-r border-arenadark-border bg-arenadark-panel">
+      <div className="border-b border-arenadark-border px-3 pb-2.5 pt-3">
+        <input
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="Search blocks…"
+          aria-label="Search blocks"
+          className="h-8 w-full rounded-[9px] border border-arenadark-border3 bg-arenadark-panel3 px-2.5 text-xs text-arenadark-text2 outline-none placeholder:text-arenadark-muted"
+        />
+      </div>
+      <div className="flex-1 overflow-auto px-2.5 py-2.5">
+        {groups.length === 0 ? (
+          <p className="px-1 text-xs text-arenadark-muted">No blocks match &ldquo;{query}&rdquo;.</p>
+        ) : (
+          groups.map((group) => (
+            <div key={group.group} className="mb-3.5">
+              <div className="mb-1.5 px-0.5 text-[9.5px] font-extrabold tracking-[.13em] text-arenadark-muted">
+                {group.group}
+              </div>
+              <div className="flex flex-col gap-1">
+                {group.items.map((item) => (
+                  <div
+                    key={item.label}
+                    className="flex items-center gap-2 rounded-[9px] border border-arenadark-border bg-arenadark-panel3 px-2 py-1.5"
+                  >
+                    <span
+                      className="flex h-[18px] w-[18px] flex-none items-center justify-center rounded-[5px] text-[9.5px] font-extrabold text-white"
+                      style={{ background: item.color }}
+                    >
+                      {item.icon}
+                    </span>
+                    <span className="text-[11.5px] font-semibold text-arenadark-text2">{item.label}</span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          ))
+        )}
+      </div>
+    </aside>
+  );
+}

--- a/apps/web/app/arena/node-card.tsx
+++ b/apps/web/app/arena/node-card.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import type { ArenaNodeView } from "./build-nodes";
+import { STATUS_STYLES } from "./status-styles";
+
+export function NodeCard({
+  node,
+  isSelected,
+  onSelect,
+}: {
+  node: ArenaNodeView;
+  isSelected: boolean;
+  onSelect: (id: string) => void;
+}) {
+  const statusStyle = STATUS_STYLES[node.status];
+  const isLive = node.status === "WAITING";
+
+  return (
+    <button
+      type="button"
+      onClick={() => onSelect(node.id)}
+      aria-pressed={isSelected}
+      aria-label={`Select ${node.name}`}
+      style={{
+        left: node.x,
+        top: node.y,
+        width: node.w,
+        borderColor: isSelected ? "#3D6BFF" : node.status === "WAITING" ? "#7A5A1E" : "#1D2743",
+        boxShadow: isSelected
+          ? "0 0 0 3px rgba(61,107,255,.18)"
+          : isLive
+            ? "0 0 26px -8px rgba(43,109,255,.7)"
+            : "none",
+      }}
+      className="absolute flex cursor-pointer flex-col overflow-hidden rounded-[13px] border-[1.5px] bg-arenadark-panel2 text-left"
+    >
+      <div
+        className="flex items-center gap-1.5 border-b border-arenadark-border px-2.5 py-2"
+        style={{ background: isSelected ? "#17224A" : "#0F1731" }}
+      >
+        <div
+          className="flex h-[19px] w-[19px] flex-none items-center justify-center rounded-[6px] text-[9px] font-extrabold text-white"
+          style={{ background: node.color }}
+        >
+          {node.initial}
+        </div>
+        <span className="min-w-0 flex-1 truncate text-[11.5px] font-bold text-arenadark-text">{node.name}</span>
+        <span
+          className="flex-none rounded-[5px] px-[5px] py-[2px] text-[8.5px] font-extrabold tracking-wide"
+          style={{ color: statusStyle.fg, background: statusStyle.bg }}
+        >
+          {statusStyle.label}
+        </span>
+      </div>
+      <div className="flex flex-col gap-1 px-2.5 py-2">
+        {node.lines.map((line, i) => (
+          <div key={i} className="truncate font-mono text-[10.5px] leading-tight text-arenadark-text3">
+            {line}
+          </div>
+        ))}
+      </div>
+      <div className="mt-auto truncate border-t border-[#161F3C] bg-arenadark-panel px-2.5 py-1.5 font-mono text-[9.5px] text-arenadark-muted">
+        {node.footer}
+      </div>
+    </button>
+  );
+}

--- a/apps/web/app/arena/page.tsx
+++ b/apps/web/app/arena/page.tsx
@@ -1,0 +1,308 @@
+"use client";
+
+import Link from "next/link";
+import { Suspense, useCallback, useEffect, useMemo, useState } from "react";
+import { useSearchParams } from "next/navigation";
+import {
+  type ArenaRun,
+  type CalendarEvent,
+  fetchArenaRunForEvent,
+  fetchCalendarEvents,
+  fetchLatestArenaRun,
+} from "@/lib/api";
+import { useAuth } from "@/lib/auth-context";
+import { useBrand } from "@/lib/brand-context";
+import { buildArenaNodes } from "./build-nodes";
+import { totalCost } from "./build-dock";
+import { Dock } from "./dock";
+import { formatCost, formatElapsedSince } from "./format";
+import { Inspector } from "./inspector";
+import { LibraryPanel } from "./library-panel";
+import { NodeCard } from "./node-card";
+import { CANVAS_HEIGHT, CANVAS_WIDTH, EDGES, FEEDBACK_EDGE, LANES, edgePath, feedbackPath, type ArenaNodeId } from "./topology";
+
+// Same "keep it live without a manual refresh" convention as
+// apps/web/app/calendar/page.tsx and app/review-queue/page.tsx — a run's
+// AgentRun rows, review feedback, or pipeline stage can change from
+// outside this tab (e.g. the trigger poller advancing it, or a teammate
+// approving it from the Review Queue).
+const POLL_INTERVAL_MS = 15000;
+
+const TERMINAL_STAGES = new Set(["completed", "rejected", "failed"]);
+
+export default function ArenaPage() {
+  return (
+    <Suspense fallback={<div className="min-h-screen bg-arenadark-bg" />}>
+      <ArenaScreen />
+    </Suspense>
+  );
+}
+
+function ArenaScreen() {
+  const { token } = useAuth();
+  const { selectedBrand, selectedBrandId } = useBrand();
+  const searchParams = useSearchParams();
+  const eventIdParam = searchParams.get("event");
+
+  const [run, setRun] = useState<ArenaRun | null>(null);
+  const [events, setEvents] = useState<CalendarEvent[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [selectedNodeId, setSelectedNodeId] = useState<ArenaNodeId>("research");
+  // Purely client-side toggle — the transport controls next to it are
+  // render-only, per Issue #124's scope (no real playback/streaming).
+  const [isPlaying, setIsPlaying] = useState(true);
+  const [now, setNow] = useState(() => new Date());
+
+  const load = useCallback(
+    async (showSpinner: boolean) => {
+      if (!token || !selectedBrandId) {
+        setRun(null);
+        return;
+      }
+      if (showSpinner) setIsLoading(true);
+      setError(null);
+      try {
+        const [runResult, eventList] = await Promise.all([
+          eventIdParam
+            ? fetchArenaRunForEvent(token, selectedBrandId, eventIdParam)
+            : fetchLatestArenaRun(token, selectedBrandId),
+          fetchCalendarEvents(token, selectedBrandId),
+        ]);
+        setRun(runResult);
+        setEvents(eventList);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Failed to load the Content Arena run");
+      } finally {
+        if (showSpinner) setIsLoading(false);
+      }
+    },
+    [token, selectedBrandId, eventIdParam]
+  );
+
+  useEffect(() => {
+    setRun(null);
+    load(true);
+    const interval = setInterval(() => load(false), POLL_INTERVAL_MS);
+    const onFocus = () => load(false);
+    window.addEventListener("focus", onFocus);
+    return () => {
+      clearInterval(interval);
+      window.removeEventListener("focus", onFocus);
+    };
+  }, [load]);
+
+  // Live-ticking clock for the header's elapsed-time stat — the
+  // underlying timestamp (post.created_at) is real, this just keeps the
+  // displayed duration counting up between polls.
+  useEffect(() => {
+    const tick = setInterval(() => setNow(new Date()), 1000);
+    return () => clearInterval(tick);
+  }, []);
+
+  const event = useMemo(() => {
+    if (!run?.calendar_event_id) return null;
+    return events.find((e) => e.id === run.calendar_event_id) ?? null;
+  }, [run, events]);
+
+  const nodes = useMemo(() => {
+    if (!run) return [];
+    return buildArenaNodes(run, event, selectedBrand ?? null);
+  }, [run, event, selectedBrand]);
+
+  const nodesById = useMemo(() => new Map(nodes.map((n) => [n.id, n])), [nodes]);
+  const selectedNode = nodesById.get(selectedNodeId) ?? nodes[0] ?? null;
+
+  const edgeElements = useMemo(() => {
+    if (nodes.length === 0) return [];
+    const straight = EDGES.map(([a, b]) => {
+      const from = nodesById.get(a);
+      const to = nodesById.get(b);
+      if (!from || !to) return null;
+      const isActive = a === selectedNodeId || b === selectedNodeId;
+      return { key: `${a}-${b}`, d: edgePath(from, to), stroke: isActive ? "#3D6BFF" : "#22305C", dash: "6 6" };
+    }).filter((e): e is NonNullable<typeof e> => e !== null);
+
+    const [fa, fb] = FEEDBACK_EDGE;
+    const feedbackFrom = nodesById.get(fa);
+    const feedbackTo = nodesById.get(fb);
+    if (feedbackFrom && feedbackTo) {
+      straight.push({
+        key: `${fa}-${fb}-feedback`,
+        d: feedbackPath(feedbackFrom, feedbackTo),
+        stroke: "#C2477F",
+        dash: "2 7",
+      });
+    }
+    return straight;
+  }, [nodes, nodesById, selectedNodeId]);
+
+  const isRunning = !!run?.post && !TERMINAL_STAGES.has(run.post.current_pipeline_stage);
+  const waitingOnYou = nodes.some((n) => n.status === "WAITING");
+  const runCost = run ? totalCost(run) : 0;
+
+  const headerTitle = event ? event.title : run?.post ? "Ad hoc post run" : "Content Arena";
+
+  return (
+    <div className="flex h-screen flex-col bg-arenadark-bg text-arenadark-text">
+      <header className="flex flex-none items-center justify-between gap-4 border-b border-arenadark-border bg-arenadark-panel px-[18px] py-2.5">
+        <div className="flex min-w-0 items-center gap-3">
+          <Link
+            href="/calendar"
+            className="flex h-[31px] items-center rounded-[9px] border border-arenadark-border3 bg-arenadark-panel3 px-2.5 text-[12.5px] font-semibold text-arenadark-text2"
+          >
+            ←
+          </Link>
+          <div className="min-w-0">
+            <div className="flex items-center gap-2">
+              <span className="truncate text-[14.5px] font-bold text-white">{headerTitle}</span>
+              {run?.post ? (
+                <span
+                  className="flex items-center gap-1.5 rounded-[6px] px-[7px] py-[3px] text-[10px] font-extrabold tracking-wide"
+                  style={
+                    isRunning
+                      ? { color: "#6BE3B0", background: "rgba(107,227,176,.12)", border: "1px solid rgba(107,227,176,.3)" }
+                      : { color: "#7C8AB4", background: "rgba(124,138,180,.12)", border: "1px solid rgba(124,138,180,.3)" }
+                  }
+                >
+                  {isRunning && <i className="h-1.5 w-1.5 animate-rd-blink rounded-full bg-[#6BE3B0]" />}
+                  {isRunning ? "RUNNING" : run.post.current_pipeline_stage.toUpperCase()}
+                </span>
+              ) : null}
+            </div>
+            <div className="mt-0.5 flex items-center gap-3.5">
+              {run?.post ? (
+                <>
+                  <Stat label="elapsed" value={formatElapsedSince(run.post.created_at, now)} />
+                  <Stat label="agent runs" value={String(run.agent_runs.length)} />
+                  <Stat label="spent" value={formatCost(runCost)} />
+                  <Stat label="waiting on you" value={waitingOnYou ? "1" : "0"} />
+                </>
+              ) : (
+                <span className="text-[11px] text-arenadark-muted2">No pipeline run yet for this brand.</span>
+              )}
+            </div>
+          </div>
+        </div>
+        <div className="flex flex-none items-center gap-1.5">
+          <div className="flex items-center gap-0.5 rounded-[9px] border border-arenadark-border3 bg-arenadark-panel3 p-[3px]">
+            <button type="button" onClick={() => {}} aria-label="Skip to start" className="h-[26px] w-7 rounded-[7px] text-[11px] text-arenadark-text2">
+              ⏮
+            </button>
+            <button
+              type="button"
+              onClick={() => setIsPlaying((p) => !p)}
+              aria-label={isPlaying ? "Pause" : "Play"}
+              className="h-[26px] w-7 rounded-[7px] bg-brand-600 text-[11px] text-white"
+            >
+              {isPlaying ? "⏸" : "▶"}
+            </button>
+            <button type="button" onClick={() => {}} aria-label="Skip to end" className="h-[26px] w-7 rounded-[7px] text-[11px] text-arenadark-text2">
+              ⏭
+            </button>
+          </div>
+          <Link
+            href="/review-queue"
+            className="flex h-8 items-center rounded-[9px] bg-brand-600 px-3.5 text-xs font-bold text-white"
+          >
+            Skip to review →
+          </Link>
+        </div>
+      </header>
+
+      {error && (
+        <p role="alert" className="flex-none bg-danger-bg px-4 py-2 text-sm font-medium text-danger">
+          {error}
+        </p>
+      )}
+
+      {!selectedBrand ? (
+        <div className="flex flex-1 items-center justify-center text-sm text-arenadark-muted2">
+          Select a brand to see its Content Arena.
+        </div>
+      ) : isLoading && !run ? (
+        <div role="status" className="flex flex-1 items-center justify-center text-sm text-arenadark-muted2">
+          Loading run…
+        </div>
+      ) : (
+        <div className="grid min-h-0 flex-1 grid-cols-[206px_minmax(0,1fr)_336px]">
+          <LibraryPanel />
+
+          <div className="flex min-h-0 min-w-0 flex-col">
+            <div className="relative flex-1 overflow-auto bg-arenadark-bg">
+              {!run?.post ? (
+                <div className="flex h-full items-center justify-center px-6 text-center text-sm text-arenadark-muted2">
+                  No pipeline runs yet for this brand — trigger a calendar event to see it here.
+                </div>
+              ) : (
+                <div
+                  className="relative"
+                  style={{
+                    width: CANVAS_WIDTH,
+                    height: CANVAS_HEIGHT,
+                    backgroundImage: "radial-gradient(#18213F 1.1px, transparent 1.1px)",
+                    backgroundSize: "26px 26px",
+                  }}
+                >
+                  {LANES.map((lane) => (
+                    <div
+                      key={lane.id}
+                      className="absolute rounded-2xl border border-[#141C36]"
+                      style={{ top: 16, bottom: 16, left: lane.x, width: lane.w, background: "rgba(17,26,54,.35)" }}
+                    >
+                      <div
+                        className="absolute left-3.5 top-2.5 text-[9.5px] font-extrabold tracking-[.16em]"
+                        style={{ color: lane.fg }}
+                      >
+                        {lane.label}
+                      </div>
+                    </div>
+                  ))}
+
+                  <svg className="pointer-events-none absolute inset-0 h-full w-full">
+                    {edgeElements.map((edge) => (
+                      <path
+                        key={edge.key}
+                        d={edge.d}
+                        fill="none"
+                        stroke={edge.stroke}
+                        strokeWidth={1.6}
+                        strokeDasharray={edge.dash}
+                        className="animate-rd-dash"
+                      />
+                    ))}
+                  </svg>
+
+                  {nodes.map((node) => (
+                    <NodeCard
+                      key={node.id}
+                      node={node}
+                      isSelected={node.id === selectedNodeId}
+                      onSelect={(id) => setSelectedNodeId(id as ArenaNodeId)}
+                    />
+                  ))}
+                </div>
+              )}
+            </div>
+
+            {run && <Dock run={run} />}
+          </div>
+
+          {selectedNode ? (
+            <Inspector node={selectedNode} />
+          ) : (
+            <aside className="border-l border-arenadark-border bg-arenadark-panel" />
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function Stat({ label, value }: { label: string; value: string }) {
+  return (
+    <span className="text-[11px] text-arenadark-muted2">
+      <b className="font-bold text-arenadark-text2">{value}</b> {label}
+    </span>
+  );
+}

--- a/apps/web/app/arena/status-styles.ts
+++ b/apps/web/app/arena/status-styles.ts
@@ -1,0 +1,9 @@
+import type { NodeStatus } from "./build-nodes";
+
+export const STATUS_STYLES: Record<NodeStatus, { fg: string; bg: string; label: string }> = {
+  DONE: { fg: "#8FB4FF", bg: "rgba(143,180,255,.14)", label: "DONE" },
+  WAITING: { fg: "#FFC46B", bg: "rgba(255,196,107,.14)", label: "WAITING" },
+  QUEUED: { fg: "#7C8AB4", bg: "rgba(124,138,180,.14)", label: "QUEUED" },
+  SKIPPED: { fg: "#5B6A96", bg: "rgba(91,106,150,.14)", label: "SKIPPED" },
+  READ: { fg: "#8FB4FF", bg: "rgba(143,180,255,.14)", label: "READ" },
+};

--- a/apps/web/app/arena/topology.ts
+++ b/apps/web/app/arena/topology.ts
@@ -1,0 +1,117 @@
+// Static graph topology for the Content Arena canvas (Issue #124) —
+// lanes, node positions, and edges. This mirrors the layout of "Raindeer
+// Social Startup Onboarding/Raindeer Social.dc.html"'s CONTENT ARENA
+// block, trimmed to the nodes that map onto something real: the mockup
+// invents several flavor sub-steps per lane (trend radar, social
+// listening, A/B hook split, risk & compliance, alerts & handoff, ...)
+// that have no backend counterpart at all, and Issue #124 is explicit
+// that node data must come from real data wherever it exists rather than
+// inventing telemetry for things the pipeline doesn't track. So this
+// graph has exactly one node per real thing: the two pieces of context a
+// run reads (the calendar event's brief, the brand) plus the eight real
+// pipeline stages (apps/api/models/agent_run.py::AgentType /
+// packages/agents/pipeline/graph.py::PIPELINE_STAGES).
+import type { AgentType } from "@/lib/api";
+
+export type ArenaNodeId =
+  | "brief"
+  | "brand"
+  | AgentType; // research | creative | generation | reviewer | human_review | scheduler | publisher | analytics_collector
+
+export interface LaneDef {
+  id: string;
+  label: string;
+  x: number;
+  w: number;
+  fg: string;
+}
+
+// x/w chosen to comfortably fit each lane's node width(s) plus gutters,
+// same left-to-right pipeline reading order as the mockup's LANES array.
+export const LANES: LaneDef[] = [
+  { id: "context", label: "CONTEXT", x: 14, w: 210, fg: "#5B6A96" },
+  { id: "research", label: "RESEARCH · VED", x: 240, w: 230, fg: "#8FB4FF" },
+  { id: "strategy", label: "STRATEGY · KESHAV", x: 486, w: 230, fg: "#C9A6FF" },
+  { id: "production", label: "PRODUCTION · KAVI", x: 732, w: 230, fg: "#6BE3B0" },
+  { id: "governance", label: "GOVERNANCE · NEER", x: 978, w: 250, fg: "#FFC46B" },
+  { id: "distribution", label: "DISTRIBUTION", x: 1244, w: 230, fg: "#7FD4FF" },
+  { id: "learning", label: "LEARNING", x: 1490, w: 200, fg: "#FF9BC4" },
+];
+
+export interface NodeLayout {
+  id: ArenaNodeId;
+  lane: string;
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+  color: string;
+  initial: string;
+  name: string;
+  /** Shown in the inspector header under the node name. */
+  sub: string;
+}
+
+export const NODE_LAYOUT: NodeLayout[] = [
+  { id: "brief", lane: "context", x: 28, y: 70, w: 182, h: 108, color: "#5B6784", initial: "▤", name: "Campaign brief", sub: "Calendar event · input" },
+  { id: "brand", lane: "context", x: 28, y: 210, w: 182, h: 108, color: "#0B2A6B", initial: "B", name: "Brand memory", sub: "Brand · read-only" },
+  { id: "research", lane: "research", x: 254, y: 90, w: 202, h: 170, color: "#1B4DFF", initial: "V", name: "Ved · Research", sub: "Research engine" },
+  { id: "creative", lane: "strategy", x: 500, y: 90, w: 202, h: 160, color: "#6B32C9", initial: "K", name: "Keshav · Creative", sub: "Creative engine" },
+  { id: "generation", lane: "production", x: 746, y: 90, w: 202, h: 160, color: "#0E7A4E", initial: "K", name: "Kavi · Generation", sub: "Generation engine" },
+  { id: "reviewer", lane: "governance", x: 992, y: 70, w: 222, h: 150, color: "#B46A00", initial: "N", name: "Neer · Reviewer", sub: "Reviewer engine" },
+  { id: "human_review", lane: "governance", x: 992, y: 250, w: 222, h: 140, color: "#1B4DFF", initial: "☺", name: "Human approval", sub: "Flow · durable interrupt" },
+  { id: "scheduler", lane: "distribution", x: 1258, y: 90, w: 202, h: 110, color: "#1E7FB8", initial: "◷", name: "Scheduler", sub: "Distribution" },
+  { id: "publisher", lane: "distribution", x: 1258, y: 240, w: 202, h: 130, color: "#1E7FB8", initial: "➤", name: "Publisher", sub: "Distribution" },
+  { id: "analytics_collector", lane: "learning", x: 1504, y: 150, w: 172, h: 140, color: "#C2477F", initial: "▲", name: "Analytics collector", sub: "Learning loop · always on" },
+];
+
+export const NODE_LAYOUT_BY_ID: Record<string, NodeLayout> = Object.fromEntries(
+  NODE_LAYOUT.map((n) => [n.id, n])
+);
+
+// [from, to] pairs — same left-to-right pipeline order as
+// packages/agents/pipeline/graph.py::PIPELINE_STAGES, plus the two
+// context nodes feeding into research.
+export const EDGES: [ArenaNodeId, ArenaNodeId][] = [
+  ["brief", "research"],
+  ["brand", "research"],
+  ["research", "creative"],
+  ["creative", "generation"],
+  ["generation", "reviewer"],
+  ["reviewer", "human_review"],
+  ["human_review", "scheduler"],
+  ["scheduler", "publisher"],
+  ["publisher", "analytics_collector"],
+];
+
+// The one feedback edge the mockup calls out explicitly (dashed, its own
+// color) — analytics_collector really does feed the *next* run's research
+// stage (Post.brand_id's brand memory accumulates engagement_snapshots),
+// just not this run's own research node, hence drawn separately from the
+// straight-line EDGES above.
+export const FEEDBACK_EDGE: [ArenaNodeId, ArenaNodeId] = ["analytics_collector", "research"];
+
+export const CANVAS_WIDTH = 1820;
+export const CANVAS_HEIGHT = 460;
+
+/** A smooth left-to-right cubic bezier between two node edges, same shape
+ * as the mockup's own `path()` helper. */
+export function edgePath(a: NodeLayout, b: NodeLayout): string {
+  const x1 = a.x + a.w;
+  const y1 = a.y + a.h / 2;
+  const x2 = b.x;
+  const y2 = b.y + b.h / 2;
+  const dx = Math.max(36, (x2 - x1) / 2);
+  return `M${x1},${y1} C${x1 + dx},${y1} ${x2 - dx},${y2} ${x2},${y2}`;
+}
+
+/** The feedback edge loops under the canvas rather than straight across —
+ * same visual treatment as the mockup's FEEDBACK path. */
+export function feedbackPath(from: NodeLayout, to: NodeLayout): string {
+  const x1 = from.x + from.w / 2;
+  const y1 = from.y + from.h;
+  const x2 = to.x + to.w / 2;
+  const y2 = to.y + to.h;
+  const loopY = CANVAS_HEIGHT - 30;
+  return `M${x1},${y1} C${x1},${loopY} ${x2},${loopY} ${x2},${y2}`;
+}

--- a/apps/web/app/content-ai/page.tsx
+++ b/apps/web/app/content-ai/page.tsx
@@ -1,0 +1,231 @@
+"use client";
+
+import { useState } from "react";
+import { generateContentAIImages, type ContentAIVariant } from "@/lib/api";
+import { useAuth } from "@/lib/auth-context";
+import { useBrand } from "@/lib/brand-context";
+import { Button } from "@/components/ui/Button";
+import { Card } from "@/components/ui/Card";
+import { cn } from "@/components/ui/cn";
+import { EmptyState } from "@/components/ui/EmptyState";
+import { Field, Textarea } from "@/components/ui/Input";
+import { PageHeader } from "@/components/ui/PageHeader";
+import { Skeleton } from "@/components/ui/Skeleton";
+import { useToast } from "@/components/ui/Toast";
+
+const ASPECT_RATIOS = [
+  { value: "1:1", label: "Square 1:1" },
+  { value: "4:5", label: "Portrait 4:5" },
+  { value: "9:16", label: "Story 9:16" },
+  { value: "16:9", label: "Landscape 16:9" },
+];
+
+const STYLES = [
+  { value: "editorial", label: "Editorial" },
+  { value: "minimal", label: "Minimal" },
+  { value: "bold", label: "Bold" },
+  { value: "photographic", label: "Photographic" },
+  { value: "illustrated", label: "Illustrated" },
+];
+
+const DEFAULT_PROMPT =
+  "Editorial typographic card, deep navy, one bold statistic, thin grid lines, no stock photography.";
+const VARIANT_COUNT = 4;
+
+function ChipButton({
+  active,
+  onClick,
+  children,
+}: {
+  active: boolean;
+  onClick: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        "rounded-[9px] border px-2.5 py-1.5 text-[12.5px] font-semibold transition-colors",
+        active
+          ? "border-brand-600 bg-brand-50 text-brand-700"
+          : "border-line bg-white text-ink-600 hover:bg-canvas",
+      )}
+    >
+      {children}
+    </button>
+  );
+}
+
+export default function ContentAIPage() {
+  const { token } = useAuth();
+  const { selectedBrand, selectedBrandId } = useBrand();
+  const { push } = useToast();
+
+  const [prompt, setPrompt] = useState(DEFAULT_PROMPT);
+  const [aspectRatio, setAspectRatio] = useState(ASPECT_RATIOS[0].value);
+  const [style, setStyle] = useState(STYLES[0].value);
+  const [lockBrandColors, setLockBrandColors] = useState(true);
+  const [variants, setVariants] = useState<ContentAIVariant[]>([]);
+  const [isGenerating, setIsGenerating] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleGenerate() {
+    if (!token || !selectedBrandId) return;
+    if (!prompt.trim()) {
+      setError("Describe the image first.");
+      return;
+    }
+
+    setIsGenerating(true);
+    setError(null);
+    try {
+      const result = await generateContentAIImages(token, selectedBrandId, {
+        prompt,
+        aspect_ratio: aspectRatio,
+        style,
+        lock_brand_colors: lockBrandColors,
+        count: VARIANT_COUNT,
+      });
+      setVariants(result);
+      const failed = result.filter((v) => v.status === "failed").length;
+      if (failed > 0) {
+        push(`${failed} of ${result.length} variants failed to generate`, "error");
+      } else {
+        push("Generated 4 variants", "success");
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Failed to generate images";
+      setError(message);
+      push(message, "error");
+    } finally {
+      setIsGenerating(false);
+    }
+  }
+
+  return (
+    <div>
+      <PageHeader
+        title="Content AI"
+        description="Straight to the visual. Pick a style, describe the image, get variants built around it."
+      />
+
+      {!selectedBrand ? (
+        <EmptyState title="No brand selected" description="Select a brand to generate images for it." />
+      ) : (
+        <div className="grid grid-cols-1 gap-4 lg:grid-cols-[320px_minmax(0,1fr)]">
+          <Card className="flex h-fit flex-col gap-4 p-4">
+            <div>
+              <div className="mb-2 text-xs font-bold text-ink-600">Aspect ratio</div>
+              <div className="flex flex-wrap gap-1.5">
+                {ASPECT_RATIOS.map((option) => (
+                  <ChipButton
+                    key={option.value}
+                    active={aspectRatio === option.value}
+                    onClick={() => setAspectRatio(option.value)}
+                  >
+                    {option.label}
+                  </ChipButton>
+                ))}
+              </div>
+            </div>
+
+            <Field label="Describe the image" htmlFor="content-ai-prompt">
+              <Textarea
+                id="content-ai-prompt"
+                value={prompt}
+                onChange={(event) => setPrompt(event.target.value)}
+                rows={4}
+              />
+            </Field>
+
+            <div>
+              <div className="mb-2 text-xs font-bold text-ink-600">Style</div>
+              <div className="flex flex-wrap gap-1.5">
+                {STYLES.map((option) => (
+                  <ChipButton
+                    key={option.value}
+                    active={style === option.value}
+                    onClick={() => setStyle(option.value)}
+                  >
+                    {option.label}
+                  </ChipButton>
+                ))}
+              </div>
+            </div>
+
+            <label className="flex items-center gap-2.5 rounded-[11px] border border-brand-100 bg-brand-50 px-3 py-2.5 text-[12.5px] text-ink-700">
+              <input
+                type="checkbox"
+                checked={lockBrandColors}
+                onChange={(event) => setLockBrandColors(event.target.checked)}
+                className="h-[15px] w-[15px] accent-brand-600"
+              />
+              Lock to brand colours and logo
+            </label>
+
+            {error && (
+              <p role="alert" className="text-sm font-medium text-danger">
+                {error}
+              </p>
+            )}
+
+            <Button onClick={handleGenerate} isLoading={isGenerating} className="h-11 w-full">
+              Generate {VARIANT_COUNT} variants
+            </Button>
+          </Card>
+
+          <div>
+            {isGenerating ? (
+              <div role="status" aria-live="polite" className="grid grid-cols-1 gap-3.5 sm:grid-cols-2">
+                <span className="sr-only">Generating images…</span>
+                {Array.from({ length: VARIANT_COUNT }).map((_, i) => (
+                  <Skeleton key={i} className="aspect-square w-full rounded-2xl" />
+                ))}
+              </div>
+            ) : variants.length === 0 ? (
+              <EmptyState
+                title="No variants yet"
+                description="Generate 4 variants to see real images produced by the image-generation pipeline."
+              />
+            ) : (
+              <ul className="grid grid-cols-1 gap-3.5 sm:grid-cols-2">
+                {variants.map((variant, index) => (
+                  <li key={index}>
+                    <Card className="overflow-hidden">
+                      {variant.status === "generated" && variant.url ? (
+                        // eslint-disable-next-line @next/next/no-img-element
+                        <img
+                          src={variant.url}
+                          alt={`Generated variant ${index + 1}`}
+                          className="aspect-square w-full object-cover"
+                        />
+                      ) : (
+                        <div className="flex aspect-square w-full items-center justify-center bg-canvas text-sm font-medium text-ink-300">
+                          Generation failed
+                        </div>
+                      )}
+                      <div className="flex items-center gap-2 p-3">
+                        <span className="text-[11.5px] text-ink-300">Variant {index + 1}</span>
+                        {variant.status === "generated" && variant.url ? (
+                          <a
+                            href={variant.url}
+                            target="_blank"
+                            rel="noreferrer"
+                            className="ml-auto text-[11.5px] font-bold text-brand-600 hover:underline"
+                          >
+                            Use this
+                          </a>
+                        ) : null}
+                      </div>
+                    </Card>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/app/create-post/page.tsx
+++ b/apps/web/app/create-post/page.tsx
@@ -1,0 +1,241 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import {
+  createCalendarEvent,
+  fetchRecentPosts,
+  type PipelineStage,
+  type PostSummary,
+} from "@/lib/api";
+import { useAuth } from "@/lib/auth-context";
+import { useBrand } from "@/lib/brand-context";
+import { Badge, type BadgeTone } from "@/components/ui/Badge";
+import { Button } from "@/components/ui/Button";
+import { Card } from "@/components/ui/Card";
+import { cn } from "@/components/ui/cn";
+import { EmptyState } from "@/components/ui/EmptyState";
+import { Field, Select, Textarea } from "@/components/ui/Input";
+import { PageHeader } from "@/components/ui/PageHeader";
+import { Skeleton } from "@/components/ui/Skeleton";
+import { useToast } from "@/components/ui/Toast";
+
+// Kept in sync with apps/api/models/content_calendar_event.py::SUPPORTED_PLATFORMS
+// — same list apps/web/app/calendar/event-form.tsx uses.
+const PLATFORM_OPTIONS: { value: string; label: string }[] = [
+  { value: "linkedin", label: "LinkedIn" },
+  { value: "x", label: "X" },
+];
+
+const FORMAT_OPTIONS = ["text", "image", "video", "carousel"];
+
+const DEFAULT_BRIEF =
+  "Post about our new contract-review turnaround — 11 days to 40 minutes. Founder voice, not corporate.";
+
+// current_pipeline_stage -> what the Create Post page shows. "rejected" is
+// the real terminal stage a human reviewer's rejection sets (Issue #25,
+// apps/api/routers/review.py::reject_post) — "Blocked" is just this page's
+// label for it, not an invented backend status.
+const STAGE_DISPLAY: Record<PipelineStage, { label: string; tone: BadgeTone }> = {
+  research: { label: "Researching", tone: "blue" },
+  creative: { label: "Writing angles", tone: "blue" },
+  generation: { label: "Generating", tone: "blue" },
+  reviewer: { label: "AI review", tone: "blue" },
+  human_review: { label: "Awaiting review", tone: "amber" },
+  scheduler: { label: "Scheduling", tone: "blue" },
+  publisher: { label: "Publishing", tone: "blue" },
+  analytics_collector: { label: "Publishing", tone: "blue" },
+  completed: { label: "Completed", tone: "green" },
+  rejected: { label: "Blocked", tone: "red" },
+  failed: { label: "Failed", tone: "red" },
+};
+
+function summaryTitle(post: PostSummary): string {
+  const firstPlatform = post.body_text ? Object.values(post.body_text)[0] : null;
+  if (firstPlatform) return firstPlatform.slice(0, 80);
+  return `Post ${post.id.slice(0, 8)}`;
+}
+
+export default function CreatePostPage() {
+  const { token } = useAuth();
+  const { selectedBrand, selectedBrandId } = useBrand();
+  const { push } = useToast();
+
+  const [brief, setBrief] = useState(DEFAULT_BRIEF);
+  const [platforms, setPlatforms] = useState<string[]>(["linkedin"]);
+  const [format, setFormat] = useState(FORMAT_OPTIONS[0]);
+  const [isRunning, setIsRunning] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const [runs, setRuns] = useState<PostSummary[]>([]);
+  const [isLoadingRuns, setIsLoadingRuns] = useState(false);
+
+  const loadRuns = useCallback(async () => {
+    if (!token || !selectedBrandId) {
+      setRuns([]);
+      return;
+    }
+    setIsLoadingRuns(true);
+    try {
+      const result = await fetchRecentPosts(token, selectedBrandId);
+      setRuns(result);
+    } catch {
+      // Recent runs is a convenience list — a failed refresh shouldn't
+      // block the compose form above it.
+    } finally {
+      setIsLoadingRuns(false);
+    }
+  }, [token, selectedBrandId]);
+
+  useEffect(() => {
+    loadRuns();
+  }, [loadRuns]);
+
+  function togglePlatform(value: string) {
+    setPlatforms((current) => (current.includes(value) ? current.filter((p) => p !== value) : [...current, value]));
+  }
+
+  async function handleRunAllAgents() {
+    if (!token || !selectedBrandId) return;
+    if (platforms.length === 0) {
+      setError("Select at least one platform.");
+      return;
+    }
+    if (!brief.trim()) {
+      setError("Describe the post first.");
+      return;
+    }
+
+    setIsRunning(true);
+    setError(null);
+    try {
+      // Reuses the real calendar-event creation endpoint (Issue #26) with
+      // an immediate target_datetime — apps/api/services/pipeline
+      // trigger.py's Celery Beat poller (Issue #29) picks up any event
+      // within its lead time and starts the real 5-stage pipeline for it,
+      // the same path a normal scheduled post takes.
+      await createCalendarEvent(token, selectedBrandId, {
+        title: brief.slice(0, 120),
+        description: brief,
+        target_platforms: platforms,
+        desired_format: format,
+        target_datetime: new Date().toISOString(),
+      });
+      push("Queued — all agents will run shortly", "success");
+      loadRuns();
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Failed to queue post";
+      setError(message);
+      push(message, "error");
+    } finally {
+      setIsRunning(false);
+    }
+  }
+
+  return (
+    <div>
+      <PageHeader
+        title="Create a post"
+        description="Describe it, pick platforms, and all agents run together on the real pipeline."
+      />
+
+      {!selectedBrand ? (
+        <EmptyState title="No brand selected" description="Select a brand to create a post for it." />
+      ) : (
+        <>
+          <Card className="mb-6 p-5">
+            <Field label="Brief" htmlFor="create-post-brief">
+              <Textarea
+                id="create-post-brief"
+                value={brief}
+                onChange={(event) => setBrief(event.target.value)}
+                rows={4}
+              />
+            </Field>
+
+            <div className="mt-4 flex flex-wrap items-center gap-2.5 border-t border-line-faint pt-4">
+              {PLATFORM_OPTIONS.map((option) => {
+                const active = platforms.includes(option.value);
+                return (
+                  <button
+                    key={option.value}
+                    type="button"
+                    onClick={() => togglePlatform(option.value)}
+                    aria-pressed={active}
+                    className={cn(
+                      "rounded-[9px] border px-2.5 py-1.5 text-[12.5px] font-semibold transition-colors",
+                      active
+                        ? "border-brand-600 bg-brand-50 text-brand-700"
+                        : "border-line bg-white text-ink-600 hover:bg-canvas",
+                    )}
+                  >
+                    {option.label}
+                  </button>
+                );
+              })}
+
+              <Select
+                value={format}
+                onChange={(event) => setFormat(event.target.value)}
+                aria-label="Desired format"
+                className="ml-1 h-9 w-auto"
+              >
+                {FORMAT_OPTIONS.map((option) => (
+                  <option key={option} value={option}>
+                    {option}
+                  </option>
+                ))}
+              </Select>
+
+              <Button onClick={handleRunAllAgents} isLoading={isRunning} className="ml-auto">
+                ✧ Run all agents
+              </Button>
+            </div>
+
+            {error && (
+              <p role="alert" className="mt-3 text-sm font-medium text-danger">
+                {error}
+              </p>
+            )}
+          </Card>
+
+          <div className="mb-3 flex items-center gap-2.5">
+            <span className="text-[11.5px] font-extrabold tracking-[0.1em] text-ink-300">RECENT RUNS</span>
+            <div className="h-px flex-1 bg-line-faint" />
+          </div>
+
+          {isLoadingRuns && runs.length === 0 ? (
+            <div role="status" aria-live="polite" className="space-y-2.5">
+              <span className="sr-only">Loading recent runs…</span>
+              {[0, 1, 2].map((i) => (
+                <Skeleton key={i} className="h-16 w-full rounded-[13px]" />
+              ))}
+            </div>
+          ) : runs.length === 0 ? (
+            <EmptyState title="No runs yet" description="Posts you create will show up here." />
+          ) : (
+            <ul className="flex flex-col gap-2.5">
+              {runs.map((post) => {
+                const display = STAGE_DISPLAY[post.current_pipeline_stage];
+                return (
+                  <li key={post.id}>
+                    <Card className="flex items-center gap-3.5 p-3.5">
+                      <div className="min-w-0 flex-1">
+                        <div className="truncate text-[13.5px] font-semibold text-ink-950">
+                          {summaryTitle(post)}
+                        </div>
+                        <div className="mt-0.5 text-[11.5px] text-ink-300">
+                          {new Date(post.created_at).toLocaleString()}
+                        </div>
+                      </div>
+                      <Badge tone={display.tone}>{display.label}</Badge>
+                    </Card>
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/apps/web/app/creative/page.tsx
+++ b/apps/web/app/creative/page.tsx
@@ -1,0 +1,139 @@
+"use client";
+
+import { useState } from "react";
+import { generateCreativeAngles, type CreativeAngle } from "@/lib/api";
+import { useAuth } from "@/lib/auth-context";
+import { useBrand } from "@/lib/brand-context";
+import { Button } from "@/components/ui/Button";
+import { Card } from "@/components/ui/Card";
+import { EmptyState } from "@/components/ui/EmptyState";
+import { Field, Textarea } from "@/components/ui/Input";
+import { PageHeader } from "@/components/ui/PageHeader";
+import { Skeleton } from "@/components/ui/Skeleton";
+import { useToast } from "@/components/ui/Toast";
+
+const DEFAULT_BRIEF =
+  "Post about our new contract-review turnaround — 11 days to 40 minutes. Founder voice, not corporate.";
+
+export default function CreativePage() {
+  const { token } = useAuth();
+  const { selectedBrand, selectedBrandId } = useBrand();
+  const { push } = useToast();
+
+  const [brief, setBrief] = useState(DEFAULT_BRIEF);
+  const [angles, setAngles] = useState<CreativeAngle[]>([]);
+  const [isGenerating, setIsGenerating] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleGenerate() {
+    if (!token || !selectedBrandId) return;
+    if (!brief.trim()) {
+      setError("Describe what this post should be about first.");
+      return;
+    }
+
+    setIsGenerating(true);
+    setError(null);
+    try {
+      const result = await generateCreativeAngles(token, selectedBrandId, brief);
+      setAngles(result);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Failed to generate angles";
+      setError(message);
+      push(message, "error");
+    } finally {
+      setIsGenerating(false);
+    }
+  }
+
+  return (
+    <div>
+      <PageHeader
+        title={
+          <span className="flex items-center gap-2.5">
+            <span className="flex h-8 w-8 items-center justify-center rounded-[10px] bg-gradient-to-br from-agent-keshav-from to-agent-keshav-to text-xs font-extrabold text-white">
+              K
+            </span>
+            Creative · Keshav
+          </span>
+        }
+        description="Turns a brief into angles that sound like you. Pick one, or generate all six."
+        action={
+          <Button onClick={handleGenerate} isLoading={isGenerating} disabled={!selectedBrand}>
+            Generate all 6 →
+          </Button>
+        }
+      />
+
+      {!selectedBrand ? (
+        <EmptyState title="No brand selected" description="Select a brand to generate angles for it." />
+      ) : (
+        <>
+          <Card className="mb-5 p-5">
+            <Field label="Creative brief" htmlFor="creative-brief">
+              <Textarea
+                id="creative-brief"
+                value={brief}
+                onChange={(event) => setBrief(event.target.value)}
+                rows={4}
+              />
+            </Field>
+            {error && (
+              <p role="alert" className="mt-2 text-sm font-medium text-danger">
+                {error}
+              </p>
+            )}
+          </Card>
+
+          {isGenerating ? (
+            <div role="status" aria-live="polite" className="grid grid-cols-1 gap-3.5 sm:grid-cols-2 lg:grid-cols-3">
+              <span className="sr-only">Generating angles…</span>
+              {[0, 1, 2, 3, 4, 5].map((i) => (
+                <Card key={i} className="space-y-3 p-4">
+                  <Skeleton className="h-4 w-20" />
+                  <Skeleton className="h-10 w-full" />
+                  <Skeleton className="h-3 w-full" />
+                </Card>
+              ))}
+            </div>
+          ) : angles.length === 0 ? (
+            <EmptyState
+              title="No angles yet"
+              description="Generate all 6 to see distinct angle/format cards for this brief."
+            />
+          ) : (
+            <ul className="grid grid-cols-1 gap-3.5 sm:grid-cols-2 lg:grid-cols-3">
+              {angles.map((angle, index) => (
+                <li key={`${angle.format}-${index}`}>
+                  <Card className="flex h-full flex-col overflow-hidden">
+                    <div className="flex items-center gap-2 border-b border-line-faint px-4 py-3">
+                      <span className="rounded-[5px] bg-agent-keshav-solid px-1.5 py-0.5 text-[9.5px] font-extrabold text-white">
+                        K
+                      </span>
+                      <span className="text-[11.5px] font-semibold text-ink-500">{angle.format}</span>
+                      <span className="ml-auto text-[11.5px] font-extrabold text-agent-keshav-solid">
+                        {angle.score}
+                      </span>
+                    </div>
+                    <div className="flex flex-1 flex-col gap-2.5 p-4">
+                      <p className="font-serif text-[19px] italic leading-tight text-ink-950">
+                        {angle.hook}
+                      </p>
+                      <p className="text-[12.5px] leading-relaxed text-ink-500">{angle.why}</p>
+                      <div className="mt-auto flex items-center gap-1.5 pt-2">
+                        <span className="rounded-[6px] bg-violet-bg px-1.5 py-0.5 text-[11px] font-bold text-violet">
+                          {angle.cta}
+                        </span>
+                        <span className="ml-auto text-[11px] font-medium text-ink-300">{angle.angle}</span>
+                      </div>
+                    </div>
+                  </Card>
+                </li>
+              ))}
+            </ul>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -8,7 +8,7 @@
   }
 
   * {
-    border-color: theme("colors.slate.200");
+    border-color: theme("colors.line.soft");
   }
 
   html,
@@ -17,7 +17,7 @@
   }
 
   body {
-    @apply bg-slate-50 text-slate-900 antialiased;
+    @apply bg-canvas text-ink-950 antialiased;
   }
 
   ::selection {

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import { Inter } from "next/font/google";
+import { Plus_Jakarta_Sans, Instrument_Serif, JetBrains_Mono } from "next/font/google";
 import type { ReactNode } from "react";
 import "./globals.css";
 import { AuthProvider } from "@/lib/auth-context";
@@ -7,7 +7,24 @@ import { BrandProvider } from "@/lib/brand-context";
 import { AuthGate } from "@/components/auth-gate";
 import { ToastProvider } from "@/components/ui/Toast";
 
-const inter = Inter({ subsets: ["latin"], variable: "--font-inter" });
+// Matches "Raindeer Social Startup Onboarding/Raindeer Social.dc.html"'s
+// <helmet> font-face declaration exactly.
+const jakarta = Plus_Jakarta_Sans({
+  subsets: ["latin"],
+  weight: ["400", "500", "600", "700", "800"],
+  variable: "--font-jakarta",
+});
+const instrumentSerif = Instrument_Serif({
+  subsets: ["latin"],
+  weight: "400",
+  style: ["normal", "italic"],
+  variable: "--font-instrument-serif",
+});
+const jetbrainsMono = JetBrains_Mono({
+  subsets: ["latin"],
+  weight: ["400", "500"],
+  variable: "--font-jetbrains-mono",
+});
 
 export const metadata: Metadata = {
   title: "Raindeer Social",
@@ -20,7 +37,10 @@ export const metadata: Metadata = {
 // is what scopes brand-aware pages to the switcher's current selection.
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
-    <html lang="en" className={inter.variable}>
+    <html
+      lang="en"
+      className={`${jakarta.variable} ${instrumentSerif.variable} ${jetbrainsMono.variable}`}
+    >
       <body className="font-sans">
         <ToastProvider>
           <AuthProvider>

--- a/apps/web/app/research/page.tsx
+++ b/apps/web/app/research/page.tsx
@@ -1,0 +1,218 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { fetchLatestResearch, runResearch, type ResearchRun } from "@/lib/api";
+import { useAuth } from "@/lib/auth-context";
+import { useBrand } from "@/lib/brand-context";
+import { Badge } from "@/components/ui/Badge";
+import { Button } from "@/components/ui/Button";
+import { Card, CardBody } from "@/components/ui/Card";
+import { EmptyState } from "@/components/ui/EmptyState";
+import { PageHeader } from "@/components/ui/PageHeader";
+import { Skeleton } from "@/components/ui/Skeleton";
+import { useToast } from "@/components/ui/Toast";
+
+interface TrendItem {
+  platform: string | null;
+  title: string;
+  content: string;
+  url: string;
+}
+
+function domainOf(url: string): string {
+  try {
+    return new URL(url).hostname.replace(/^www\./, "");
+  } catch {
+    return url;
+  }
+}
+
+function trendItemsFrom(run: ResearchRun): TrendItem[] {
+  const items: TrendItem[] = [];
+  for (const [platform, results] of Object.entries(run.brief.platform_trends ?? {})) {
+    for (const result of results) {
+      items.push({ platform, ...result });
+    }
+  }
+  for (const result of run.brief.industry_trends ?? []) {
+    items.push({ platform: null, ...result });
+  }
+  return items;
+}
+
+export default function ResearchPage() {
+  const { token } = useAuth();
+  const { selectedBrand, selectedBrandId } = useBrand();
+  const { push } = useToast();
+
+  const [run, setRun] = useState<ResearchRun | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [isRunning, setIsRunning] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    if (!token || !selectedBrandId) {
+      setRun(null);
+      return;
+    }
+    setIsLoading(true);
+    setError(null);
+    try {
+      const result = await fetchLatestResearch(token, selectedBrandId);
+      setRun(result);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load research");
+    } finally {
+      setIsLoading(false);
+    }
+  }, [token, selectedBrandId]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  async function handleRun() {
+    if (!token || !selectedBrandId) return;
+    setIsRunning(true);
+    try {
+      const result = await runResearch(token, selectedBrandId);
+      setRun(result);
+      push("Research complete", "success");
+    } catch (err) {
+      push(err instanceof Error ? err.message : "Failed to run research", "error");
+    } finally {
+      setIsRunning(false);
+    }
+  }
+
+  const trendItems = run ? trendItemsFrom(run) : [];
+
+  return (
+    <div>
+      <PageHeader
+        title={
+          <span className="flex items-center gap-2.5">
+            <span className="flex h-8 w-8 items-center justify-center rounded-[10px] bg-gradient-to-br from-agent-ved-from to-agent-ved-to text-xs font-extrabold text-white">
+              V
+            </span>
+            Research · Ved
+          </span>
+        }
+        description={
+          <>
+            Reads the whole internet on your category, then tells you only what changes a
+            post. Showing data for:{" "}
+            <strong className="font-medium text-slate-700">
+              {selectedBrand ? selectedBrand.name : "no brand selected"}
+            </strong>
+          </>
+        }
+        action={
+          <Button onClick={handleRun} isLoading={isRunning} disabled={!selectedBrand}>
+            Run new research →
+          </Button>
+        }
+      />
+
+      {error && (
+        <p role="alert" className="mb-4 rounded-lg bg-red-50 px-3 py-2 text-sm font-medium text-red-700">
+          {error}
+        </p>
+      )}
+
+      {!selectedBrand ? (
+        <EmptyState title="No brand selected" description="Select a brand to run research for it." />
+      ) : isLoading ? (
+        <div role="status" aria-live="polite" className="space-y-3">
+          <span className="sr-only">Loading research…</span>
+          {[0, 1, 2].map((i) => (
+            <Card key={i} className="space-y-2 p-5">
+              <Skeleton className="h-4 w-24" />
+              <Skeleton className="h-3 w-48" />
+              <Skeleton className="h-16 w-full" />
+            </Card>
+          ))}
+        </div>
+      ) : !run || trendItems.length === 0 ? (
+        <EmptyState
+          title="No research yet"
+          description="Run research to see trend cards drawn from live search results for this brand's category."
+          action={
+            <Button onClick={handleRun} isLoading={isRunning}>
+              Run new research →
+            </Button>
+          }
+        />
+      ) : (
+        <div className="grid grid-cols-1 gap-4 lg:grid-cols-[minmax(0,1fr)_300px]">
+          <ul className="flex flex-col gap-3">
+            {trendItems.map((item, index) => (
+              <li key={`${item.url}-${index}`}>
+                <Card className="p-4">
+                  <div className="mb-1.5 flex items-center gap-2">
+                    {item.platform ? (
+                      <Badge tone="blue">{item.platform}</Badge>
+                    ) : (
+                      <Badge tone="slate">industry</Badge>
+                    )}
+                    <span className="text-xs text-ink-300">{domainOf(item.url)}</span>
+                  </div>
+                  <h3 className="mb-1.5 text-base font-bold tracking-tight text-ink-950">
+                    {item.title}
+                  </h3>
+                  <p className="mb-3 text-sm leading-relaxed text-ink-500">{item.content}</p>
+                  <a
+                    href={item.url}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="text-xs font-semibold text-brand-600 hover:underline"
+                  >
+                    View source
+                  </a>
+                </Card>
+              </li>
+            ))}
+          </ul>
+
+          <div className="flex flex-col gap-3">
+            <Card className="bg-ink-950 text-white">
+              <CardBody>
+                <div className="mb-2 text-[10.5px] font-extrabold tracking-[0.12em] text-agent-ved-to">
+                  TRENDING TOPICS
+                </div>
+                {run.brief.timing_signal.trending_topics.length > 0 ? (
+                  <ul className="flex flex-col gap-1.5">
+                    {run.brief.timing_signal.trending_topics.map((topic) => (
+                      <li key={topic} className="text-sm leading-relaxed text-white/90">
+                        {topic}
+                      </li>
+                    ))}
+                  </ul>
+                ) : (
+                  <p className="text-sm text-white/70">No standout trending topics this run.</p>
+                )}
+              </CardBody>
+            </Card>
+            <Card>
+              <CardBody>
+                <div className="mb-2.5 text-[11.5px] font-extrabold tracking-[0.1em] text-ink-300">
+                  RESEARCHED
+                </div>
+                <p className="text-sm text-ink-600">
+                  {new Date(run.brief.timing_signal.researched_at).toLocaleString()}
+                </p>
+                <div className="mt-3 flex flex-wrap gap-1.5">
+                  {run.brief.timing_signal.platforms.map((platform) => (
+                    <Badge key={platform} tone="blue">
+                      {platform}
+                    </Badge>
+                  ))}
+                </div>
+              </CardBody>
+            </Card>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/app/review-queue/page.tsx
+++ b/apps/web/app/review-queue/page.tsx
@@ -126,16 +126,27 @@ export default function ReviewQueuePage() {
   return (
     <div>
       <PageHeader
-        title="Review Queue"
+        title={
+          <span className="inline-flex items-center gap-2.5">
+            <span
+              aria-hidden="true"
+              className="flex h-8 w-8 shrink-0 items-center justify-center rounded-xl bg-gradient-to-br from-agent-neer-from to-agent-neer-to text-sm font-extrabold text-white"
+            >
+              N
+            </span>
+            Review Queue &middot; Neer
+          </span>
+        }
         description={
           <>
-            Showing data for: <strong className="font-medium text-slate-700">{selectedBrand ? selectedBrand.name : "no brand selected"}</strong>
+            Neer screens every draft for brand voice, compliance, and platform fit before it reaches you. Showing
+            data for: <strong className="font-medium text-ink-700">{selectedBrand ? selectedBrand.name : "no brand selected"}</strong>
           </>
         }
       />
 
       {error && (
-        <p role="alert" className="mb-4 rounded-lg bg-red-50 px-3 py-2 text-sm font-medium text-red-700">
+        <p role="alert" className="mb-4 rounded-lg bg-danger-bg px-3 py-2 text-sm font-medium text-danger">
           {error}
         </p>
       )}

--- a/apps/web/app/review-queue/review-card.tsx
+++ b/apps/web/app/review-queue/review-card.tsx
@@ -29,30 +29,57 @@ function verdictTone(verdict: string | undefined): BadgeTone {
 
 // The 0-100 score is the headline signal on this page, so it gets a colour
 // band rather than being buried in prose: the same thresholds drive both the
-// badge tone and the meter fill.
+// badge tone and every score-bar fill below. Mirrors the reviewer engine's
+// own approve (>=80) / revise (50-79) / reject (<50) thresholds
+// (packages/agents/pipeline/nodes/reviewer_engine.py::_build_prompt).
 function scoreTone(score: number): BadgeTone {
   if (score >= 80) return "green";
-  if (score >= 60) return "amber";
+  if (score >= 50) return "amber";
   return "red";
 }
 
 const SCORE_BAR_CLASSES: Record<BadgeTone, string> = {
-  green: "bg-emerald-500",
-  amber: "bg-amber-500",
-  red: "bg-red-500",
-  slate: "bg-slate-400",
+  green: "bg-success",
+  amber: "bg-warning",
+  red: "bg-danger",
+  slate: "bg-ink-200",
   brand: "bg-brand-500",
-  blue: "bg-blue-500",
+  blue: "bg-brand-500",
 };
 
-function ScoreMeter({ score }: { score: number }) {
-  const clamped = Math.max(0, Math.min(100, score));
+// The mockup's "Review · Neer" screen shows each draft with a stack of
+// labeled score bars (Brand fit / Platform fit / Sentiment — see
+// "Raindeer Social Startup Onboarding/Raindeer Social.dc.html"'s `r.bars`).
+// The Reviewer Engine doesn't hand back those three as separate sub-scores
+// though — it produces a single 0-100 alignment score per platform that
+// already folds brand voice, compliance, and platform fit together (see
+// reviewer_engine.py's prompt), plus one overall score for the post. So
+// this reuses the mockup's bar visual, but keys each bar by real signal
+// (the overall score, then one row per platform) instead of fabricating
+// sub-metrics that don't exist in the data.
+//
+// `score` is deliberately nullable: an older review row, or a platform the
+// LLM output didn't parse cleanly, can leave this missing — this renders a
+// flat, neutral bar rather than crashing on it.
+function ScoreBar({ label, score }: { label: string; score: number | null | undefined }) {
+  const hasScore = typeof score === "number" && Number.isFinite(score);
+  const clamped = hasScore ? Math.max(0, Math.min(100, score)) : 0;
+  const tone = hasScore ? scoreTone(score) : "slate";
+
   return (
-    <div className="h-1.5 w-full overflow-hidden rounded-full bg-slate-200" aria-hidden="true">
-      <div
-        className={cn("h-full rounded-full transition-all", SCORE_BAR_CLASSES[scoreTone(score)])}
-        style={{ width: `${clamped}%` }}
-      />
+    <div className="flex items-center gap-2">
+      <span className="w-20 shrink-0 truncate text-xs text-ink-300" title={label}>
+        {label}
+      </span>
+      <div className="h-1.5 flex-1 overflow-hidden rounded-full bg-line-soft" aria-hidden="true">
+        <div
+          className={cn("h-full rounded-full transition-all", SCORE_BAR_CLASSES[tone])}
+          style={{ width: `${clamped}%` }}
+        />
+      </div>
+      <span className="w-9 shrink-0 text-right text-xs font-semibold text-ink-700">
+        {hasScore ? score.toFixed(0) : "—"}
+      </span>
     </div>
   );
 }
@@ -94,6 +121,7 @@ export function ReviewCard({ post, onApprove, onReject, onEdit, onReschedule }: 
   const aiReview = latestAiReview(post);
   const humanHistory = humanReviews(post);
   const platforms = Object.keys(post.body_text ?? {});
+  const aiPlatformEntries = aiReview ? Object.entries(platformReviews(aiReview)) : [];
 
   async function run(action: () => Promise<void>) {
     setIsSubmitting(true);
@@ -131,7 +159,7 @@ export function ReviewCard({ post, onApprove, onReject, onEdit, onReschedule }: 
 
   return (
     <Card aria-label={`Review post ${post.id}`} className="overflow-hidden">
-      <header className="flex flex-wrap items-start justify-between gap-4 border-b border-slate-100 p-5">
+      <header className="flex flex-wrap items-start justify-between gap-4 border-b border-line-faint p-5">
         <div className="min-w-0">
           <div className="flex flex-wrap items-center gap-1.5">
             {platforms.length > 0 ? (
@@ -144,7 +172,7 @@ export function ReviewCard({ post, onApprove, onReject, onEdit, onReschedule }: 
               <Badge tone="slate">no platforms</Badge>
             )}
           </div>
-          <p className="mt-2 text-xs text-slate-500">
+          <p className="mt-2 text-xs text-ink-300">
             Paused for review since {new Date(post.created_at).toLocaleString()}
           </p>
         </div>
@@ -152,29 +180,42 @@ export function ReviewCard({ post, onApprove, onReject, onEdit, onReschedule }: 
         {aiReview ? (
           <div className="w-40 shrink-0">
             <div className="flex items-center justify-between gap-2">
-              <Badge tone={scoreTone(aiReview.score)}>{aiReview.score.toFixed(0)}/100</Badge>
+              <span className="flex items-center gap-1.5">
+                <span
+                  aria-hidden="true"
+                  className="flex h-4 w-4 items-center justify-center rounded-[5px] bg-gradient-to-br from-agent-neer-from to-agent-neer-to text-[9px] font-extrabold text-white"
+                >
+                  N
+                </span>
+                <Badge tone={scoreTone(aiReview.score)}>{aiReview.score.toFixed(0)}/100</Badge>
+              </span>
               <Badge tone={verdictTone(aiReview.verdict)} dot>
                 {aiReview.verdict}
               </Badge>
             </div>
             <div className="mt-2">
-              <ScoreMeter score={aiReview.score} />
+              <div className="h-1.5 w-full overflow-hidden rounded-full bg-line-soft" aria-hidden="true">
+                <div
+                  className={cn("h-full rounded-full transition-all", SCORE_BAR_CLASSES[scoreTone(aiReview.score)])}
+                  style={{ width: `${Math.max(0, Math.min(100, aiReview.score))}%` }}
+                />
+              </div>
             </div>
           </div>
         ) : null}
       </header>
 
-      <section className="border-b border-slate-100 p-5">
-        <h3 className="text-sm font-semibold text-slate-900">Draft</h3>
+      <section className="border-b border-line-faint p-5">
+        <h3 className="text-sm font-semibold text-ink-950">Draft</h3>
 
-        {platforms.length === 0 && <p className="mt-2 text-sm text-slate-500">No generated copy yet.</p>}
+        {platforms.length === 0 && <p className="mt-2 text-sm text-ink-400">No generated copy yet.</p>}
 
         {!isEditing && (
           <div className="mt-3 space-y-3">
             {platforms.map((platform) => (
-              <div key={platform} className="rounded-lg bg-slate-50 p-3">
-                <span className="text-xs font-semibold uppercase tracking-wide text-slate-500">{platform}</span>
-                <p className="mt-1 whitespace-pre-wrap text-sm text-slate-800">{post.body_text?.[platform]}</p>
+              <div key={platform} className="rounded-lg bg-canvas p-3">
+                <span className="text-xs font-semibold uppercase tracking-wide text-ink-400">{platform}</span>
+                <p className="mt-1 whitespace-pre-wrap text-sm text-ink-800">{post.body_text?.[platform]}</p>
               </div>
             ))}
           </div>
@@ -205,24 +246,38 @@ export function ReviewCard({ post, onApprove, onReject, onEdit, onReschedule }: 
       </section>
 
       {aiReview && (
-        <section className="border-b border-slate-100 bg-brand-50/40 p-5">
-          <h3 className="text-sm font-semibold text-slate-900">
-            AI reviewer score: {aiReview.score.toFixed(0)}/100
-          </h3>
+        <section className="border-b border-line-faint bg-gradient-to-b from-agent-neer-to/10 to-transparent p-5">
+          <div className="flex items-center gap-2">
+            <span
+              aria-hidden="true"
+              className="flex h-5 w-5 shrink-0 items-center justify-center rounded-md bg-gradient-to-br from-agent-neer-from to-agent-neer-to text-[10px] font-extrabold text-white"
+            >
+              N
+            </span>
+            <h3 className="text-sm font-semibold text-ink-950">
+              AI reviewer score: {aiReview.score.toFixed(0)}/100
+            </h3>
+          </div>
+
+          {aiPlatformEntries.length > 0 && (
+            <div className="mt-3 space-y-2 rounded-lg border border-line-soft bg-white/70 p-3">
+              <ScoreBar label="Overall" score={aiReview.score} />
+              {aiPlatformEntries.map(([platform, review]) => (
+                <ScoreBar key={platform} label={platform} score={review.score} />
+              ))}
+            </div>
+          )}
 
           <ul className="mt-3 space-y-3">
-            {Object.entries(platformReviews(aiReview)).map(([platform, review]) => (
-              <li key={platform} className="rounded-lg border border-slate-200 bg-white p-3">
+            {aiPlatformEntries.map(([platform, review]) => (
+              <li key={platform} className="rounded-lg border border-line-soft bg-white p-3">
                 <div className="flex flex-wrap items-center gap-2">
-                  <span className="text-xs font-semibold uppercase tracking-wide text-slate-500">{platform}</span>
-                  {review.score !== undefined && (
-                    <Badge tone={scoreTone(review.score)}>{review.score.toFixed(0)}/100</Badge>
-                  )}
+                  <span className="text-xs font-semibold uppercase tracking-wide text-ink-400">{platform}</span>
                   {review.verdict && <Badge tone={verdictTone(review.verdict)}>{review.verdict}</Badge>}
                 </div>
 
                 {review.issues && review.issues.length > 0 && (
-                  <ul className="mt-2 list-disc space-y-1 pl-5 text-sm text-slate-700">
+                  <ul className="mt-2 list-disc space-y-1 pl-5 text-sm text-ink-700">
                     {review.issues.map((issue, i) => (
                       <li key={i}>{issue}</li>
                     ))}
@@ -230,9 +285,10 @@ export function ReviewCard({ post, onApprove, onReject, onEdit, onReschedule }: 
                 )}
 
                 {review.suggested_edits && (
-                  <p className="mt-2 rounded-md bg-amber-50 px-3 py-2 text-sm text-amber-900">
-                    {review.suggested_edits}
-                  </p>
+                  <div className="mt-2 rounded-md border border-warning/20 bg-warning-bg px-3 py-2">
+                    <div className="text-[10px] font-bold uppercase tracking-wider text-warning">Neer&apos;s note</div>
+                    <p className="mt-0.5 text-sm text-ink-800">{review.suggested_edits}</p>
+                  </div>
                 )}
               </li>
             ))}
@@ -241,11 +297,11 @@ export function ReviewCard({ post, onApprove, onReject, onEdit, onReschedule }: 
       )}
 
       {humanHistory.length > 0 && (
-        <section className="border-b border-slate-100 p-5">
-          <h3 className="text-sm font-semibold text-slate-900">Human review history</h3>
+        <section className="border-b border-line-faint p-5">
+          <h3 className="text-sm font-semibold text-ink-950">Human review history</h3>
           <ul className="mt-3 space-y-2">
             {humanHistory.map((feedback) => (
-              <li key={feedback.id} className="flex flex-wrap items-center gap-2 text-sm text-slate-600">
+              <li key={feedback.id} className="flex flex-wrap items-center gap-2 text-sm text-ink-600">
                 <Badge tone={verdictTone(feedback.verdict)}>{feedback.verdict}</Badge>
                 {typeof feedback.comments?.comments === "string" && (
                   <span>{feedback.comments.comments as string}</span>
@@ -257,7 +313,7 @@ export function ReviewCard({ post, onApprove, onReject, onEdit, onReschedule }: 
       )}
 
       {isRescheduling && (
-        <section className="border-b border-slate-100 p-5">
+        <section className="border-b border-line-faint p-5">
           <Field label="New date and time" htmlFor={`reschedule-${post.id}`}>
             <Input
               id={`reschedule-${post.id}`}
@@ -289,13 +345,13 @@ export function ReviewCard({ post, onApprove, onReject, onEdit, onReschedule }: 
         </Field>
 
         {error && (
-          <p role="alert" className="mt-3 rounded-lg bg-red-50 px-3 py-2 text-sm font-medium text-red-700">
+          <p role="alert" className="mt-3 rounded-lg bg-danger-bg px-3 py-2 text-sm font-medium text-danger">
             {error}
           </p>
         )}
       </div>
 
-      <div className="flex flex-wrap items-center justify-end gap-2 border-t border-slate-100 bg-slate-50 px-5 py-4">
+      <div className="flex flex-wrap items-center justify-end gap-2 border-t border-line-faint bg-canvas px-5 py-4">
         {!isEditing && (
           <Button
             type="button"

--- a/apps/web/components/auth-gate.tsx
+++ b/apps/web/components/auth-gate.tsx
@@ -34,7 +34,7 @@ export function AuthGate({ children }: { children: ReactNode }) {
 
   if (isLoading) {
     return (
-      <div className="flex min-h-screen items-center justify-center text-sm text-slate-500" role="status">
+      <div className="flex min-h-screen items-center justify-center text-sm text-ink-400" role="status">
         Loading…
       </div>
     );
@@ -46,7 +46,7 @@ export function AuthGate({ children }: { children: ReactNode }) {
   }
 
   return (
-    <div className="flex min-h-screen bg-slate-50">
+    <div className="flex min-h-screen bg-canvas">
       <Nav />
       <main className="min-w-0 flex-1 px-6 py-8 lg:px-10">
         <div className="mx-auto max-w-6xl">{children}</div>

--- a/apps/web/components/auth-gate.tsx
+++ b/apps/web/components/auth-gate.tsx
@@ -9,16 +9,26 @@ import { Nav } from "@/components/nav";
 // Routes reachable without a token. Everything else is gated.
 const PUBLIC_PATHS = ["/login"];
 
+// Routes that render their own full-height shell instead of the light
+// Nav sidebar + padded <main> every other authenticated route gets. The
+// Content Arena (Issue #124, apps/web/app/arena/page.tsx) is a
+// deliberately separate dark visual world from the rest of the app — see
+// tailwind.config.ts's `arenadark` tokens — so it needs the full viewport
+// to itself, not squeezed into the app shell's max-w-6xl column.
+const FULL_BLEED_PATHS = ["/arena"];
+
 /**
  * Wraps the whole app (mounted from app/layout.tsx). Redirects
  * unauthenticated visitors to /login on every protected route, and renders
- * the shell nav once a session is present.
+ * the shell nav once a session is present (except on FULL_BLEED_PATHS,
+ * which render directly — still gated by the same redirect logic below).
  */
 export function AuthGate({ children }: { children: ReactNode }) {
   const { token, isLoading } = useAuth();
   const pathname = usePathname();
   const router = useRouter();
   const isPublicPath = PUBLIC_PATHS.includes(pathname);
+  const isFullBleed = FULL_BLEED_PATHS.some((path) => pathname.startsWith(path));
 
   useEffect(() => {
     if (isLoading || isPublicPath) return;
@@ -43,6 +53,10 @@ export function AuthGate({ children }: { children: ReactNode }) {
   if (!token) {
     // Redirect kicked off above; render nothing while it lands.
     return null;
+  }
+
+  if (isFullBleed) {
+    return <>{children}</>;
   }
 
   return (

--- a/apps/web/components/brand-switcher.tsx
+++ b/apps/web/components/brand-switcher.tsx
@@ -25,14 +25,14 @@ export function BrandSwitcher() {
 
   if (error) {
     return (
-      <p className="px-1 text-xs font-medium text-red-600" role="alert">
+      <p className="px-1 text-xs font-medium text-danger" role="alert">
         {error}
       </p>
     );
   }
 
   if (brands.length === 0) {
-    return <p className="px-1 text-xs text-slate-500">No brands yet</p>;
+    return <p className="px-1 text-xs text-ink-400">No brands yet</p>;
   }
 
   return (
@@ -44,7 +44,7 @@ export function BrandSwitcher() {
         aria-label="Select brand"
         value={selectedBrandId ?? ""}
         onChange={(event) => setSelectedBrandId(event.target.value)}
-        className="w-full appearance-none rounded-lg border border-slate-200 bg-slate-50 py-2 pl-10 pr-8 text-sm font-medium text-slate-800 hover:bg-slate-100 focus:border-brand-500 focus:outline-none focus:ring-2 focus:ring-brand-500/20"
+        className="w-full appearance-none rounded-[11px] border border-line-soft bg-canvas py-2.5 pl-10 pr-8 text-[13px] font-bold text-ink-950 hover:bg-brand-50/60 focus:border-brand-500 focus:outline-none focus:ring-2 focus:ring-brand-500/20"
       >
         {brands.map((brand) => (
           <option key={brand.id} value={brand.id}>
@@ -52,7 +52,7 @@ export function BrandSwitcher() {
           </option>
         ))}
       </select>
-      <div className="pointer-events-none absolute inset-y-0 right-2.5 flex items-center text-slate-400">
+      <div className="pointer-events-none absolute inset-y-0 right-2.5 flex items-center text-ink-200">
         <svg width="14" height="14" viewBox="0 0 24 24" fill="none" aria-hidden="true">
           <path d="M6 9l6 6 6-6" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
         </svg>

--- a/apps/web/components/nav.tsx
+++ b/apps/web/components/nav.tsx
@@ -66,6 +66,16 @@ function IconSocial() {
     </svg>
   );
 }
+function IconArena() {
+  return (
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+      <circle cx="6" cy="6" r="2.2" stroke="currentColor" strokeWidth="1.8" />
+      <circle cx="18" cy="6" r="2.2" stroke="currentColor" strokeWidth="1.8" />
+      <circle cx="12" cy="18" r="2.2" stroke="currentColor" strokeWidth="1.8" />
+      <path d="M7.7 7.4L11 16M16.3 7.4L13 16M8.2 6h7.6" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" />
+    </svg>
+  );
+}
 function IconAnalytics() {
   return (
     <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden="true">
@@ -101,13 +111,14 @@ function IconSettings() {
 }
 
 // Every route here already exists as a real page. Screens still landing
-// from the mockup migration (Arena, Research, Creative, Create Post,
-// Content AI, Settings) add their own nav entry in their own PR once the
-// page itself exists — keeps this list from linking to 404s in the
-// meantime.
+// from the mockup migration (Research, Creative, Create Post, Content AI,
+// Settings) add their own nav entry in their own PR once the page itself
+// exists — keeps this list from linking to 404s in the meantime. Arena
+// (Issue #124) is the first of those to land.
 const NAV_LINKS: { href: string; label: string; icon: () => ReactNode }[] = [
   { href: "/", label: "Dashboard", icon: IconDashboard },
   { href: "/calendar", label: "Calendar", icon: IconCalendar },
+  { href: "/arena", label: "Content Arena", icon: IconArena },
   { href: "/review-queue", label: "Review Queue", icon: IconReview },
   { href: "/brands", label: "Brands", icon: IconBrand },
   { href: "/onboarding", label: "Onboarding", icon: IconOnboarding },

--- a/apps/web/components/nav.tsx
+++ b/apps/web/components/nav.tsx
@@ -86,7 +86,25 @@ function IconReport() {
     </svg>
   );
 }
+function IconSettings() {
+  return (
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+      <circle cx="12" cy="12" r="3" stroke="currentColor" strokeWidth="1.8" />
+      <path
+        d="M19.4 13.5a1.7 1.7 0 000-3l1.2-1.6-1.7-1.7-1.7 1.1a1.7 1.7 0 00-3-1.2L14 4.6h-2.4l-.2 1.9a1.7 1.7 0 00-3 1.2L6.7 6.6 5 8.3l1.1 1.6a1.7 1.7 0 000 3L5 14.5l1.7 1.7 1.6-1.1a1.7 1.7 0 003 1.2l.2 1.9H14l.2-1.9a1.7 1.7 0 003-1.2l1.6 1.1 1.7-1.7-1.1-1.6Z"
+        stroke="currentColor"
+        strokeWidth="1.4"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
 
+// Every route here already exists as a real page. Screens still landing
+// from the mockup migration (Arena, Research, Creative, Create Post,
+// Content AI, Settings) add their own nav entry in their own PR once the
+// page itself exists — keeps this list from linking to 404s in the
+// meantime.
 const NAV_LINKS: { href: string; label: string; icon: () => ReactNode }[] = [
   { href: "/", label: "Dashboard", icon: IconDashboard },
   { href: "/calendar", label: "Calendar", icon: IconCalendar },
@@ -103,22 +121,20 @@ export function Nav() {
   const { logout } = useAuth();
 
   return (
-    <aside className="sticky top-0 flex h-screen w-64 shrink-0 flex-col border-r border-slate-200 bg-white">
-      <div className="flex h-16 items-center gap-2 border-b border-slate-100 px-5">
-        <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-brand-600 text-sm font-bold text-white">
+    <aside className="sticky top-0 flex h-screen w-[236px] shrink-0 flex-col gap-3.5 border-r border-line-soft bg-white px-3.5 py-4">
+      <Link href="/" className="flex items-center gap-2.5 px-1.5">
+        <div className="flex h-[29px] w-[29px] items-center justify-center rounded-[9px] bg-gradient-to-br from-brand-600 to-brand-300 text-[13px] font-extrabold text-white">
           R
         </div>
-        <Link href="/" className="text-[15px] font-semibold text-slate-900">
-          Raindeer Social
-        </Link>
-      </div>
+        <span className="text-[15px] font-bold tracking-tight text-ink-950">
+          raindeer<span className="text-brand-600">.</span>
+        </span>
+      </Link>
 
-      <div className="border-b border-slate-100 px-4 py-3">
-        <BrandSwitcher />
-      </div>
+      <BrandSwitcher />
 
-      <nav aria-label="Main navigation" className="flex-1 overflow-y-auto scrollbar-thin px-3 py-4">
-        <ul className="space-y-0.5">
+      <nav aria-label="Main navigation" className="flex-1 overflow-y-auto scrollbar-thin">
+        <ul className="flex flex-col gap-0.5">
           {NAV_LINKS.map((link) => {
             const isActive = link.href === "/" ? pathname === "/" : pathname.startsWith(link.href);
             const Icon = link.icon;
@@ -128,13 +144,13 @@ export function Nav() {
                   href={link.href}
                   aria-current={isActive ? "page" : undefined}
                   className={cn(
-                    "flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition-colors",
-                    isActive
-                      ? "bg-brand-50 text-brand-700"
-                      : "text-slate-600 hover:bg-slate-100 hover:text-slate-900",
+                    "flex items-center gap-2.5 rounded-[10px] px-2.5 py-[9px] text-[13.5px] transition-colors",
+                    isActive ? "bg-brand-50 font-bold text-ink-950" : "font-medium text-ink-500 hover:bg-canvas hover:text-ink-950",
                   )}
                 >
-                  <Icon />
+                  <span className="w-[18px] text-center">
+                    <Icon />
+                  </span>
                   {link.label}
                 </Link>
               </li>
@@ -143,24 +159,30 @@ export function Nav() {
         </ul>
       </nav>
 
-      <div className="border-t border-slate-100 p-3">
+      <div className="mt-auto flex flex-col gap-2.5">
         <button
           type="button"
           onClick={logout}
-          className="flex w-full items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium text-slate-600 hover:bg-slate-100 hover:text-slate-900"
+          className="flex w-full items-center gap-2.5 rounded-[10px] px-2.5 py-2 text-[13.5px] font-medium text-ink-500 hover:bg-canvas hover:text-ink-950"
         >
-          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden="true">
-            <path
-              d="M15 17l5-5-5-5M20 12H9M12 19H6a2 2 0 01-2-2V7a2 2 0 012-2h6"
-              stroke="currentColor"
-              strokeWidth="1.8"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            />
-          </svg>
+          <span className="w-[18px] text-center">
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+              <path
+                d="M15 17l5-5-5-5M20 12H9M12 19H6a2 2 0 01-2-2V7a2 2 0 012-2h6"
+                stroke="currentColor"
+                strokeWidth="1.8"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+            </svg>
+          </span>
           Log out
         </button>
       </div>
     </aside>
   );
 }
+
+// Exported so future pages (Settings) can reuse the exact same icon without
+// redefining it.
+export { IconSettings };

--- a/apps/web/components/nav.tsx
+++ b/apps/web/components/nav.tsx
@@ -86,6 +86,47 @@ function IconReport() {
     </svg>
   );
 }
+function IconResearch() {
+  return (
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+      <circle cx="11" cy="11" r="6.5" stroke="currentColor" strokeWidth="1.8" />
+      <path d="M20 20l-4.8-4.8" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" />
+    </svg>
+  );
+}
+function IconCreative() {
+  return (
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+      <path
+        d="M12 3l2.2 5.4L20 10l-5.4 2.2L12 18l-2.2-5.8L4 10l5.8-1.6L12 3Z"
+        stroke="currentColor"
+        strokeWidth="1.6"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+function IconCreatePost() {
+  return (
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+      <path
+        d="M4 20l1.2-4.6L16.6 3.9a1.6 1.6 0 012.3 0l1.2 1.2a1.6 1.6 0 010 2.3L8.6 18.8 4 20Z"
+        stroke="currentColor"
+        strokeWidth="1.8"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+function IconContentAI() {
+  return (
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+      <rect x="4" y="5" width="16" height="14" rx="2" stroke="currentColor" strokeWidth="1.8" />
+      <circle cx="9" cy="10" r="1.6" stroke="currentColor" strokeWidth="1.6" />
+      <path d="M4 16l5-4 4 3 3-2.5 4 3.5" stroke="currentColor" strokeWidth="1.8" strokeLinejoin="round" />
+    </svg>
+  );
+}
 function IconSettings() {
   return (
     <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden="true">
@@ -101,13 +142,18 @@ function IconSettings() {
 }
 
 // Every route here already exists as a real page. Screens still landing
-// from the mockup migration (Arena, Research, Creative, Create Post,
-// Content AI, Settings) add their own nav entry in their own PR once the
-// page itself exists — keeps this list from linking to 404s in the
-// meantime.
+// from the mockup migration (Arena, Settings) add their own nav entry in
+// their own PR once the page itself exists — keeps this list from linking
+// to 404s in the meantime. Research/Creative/Create Post/Content AI
+// (Issue #126) are the first of those standalone agent-workspace pages to
+// land.
 const NAV_LINKS: { href: string; label: string; icon: () => ReactNode }[] = [
   { href: "/", label: "Dashboard", icon: IconDashboard },
   { href: "/calendar", label: "Calendar", icon: IconCalendar },
+  { href: "/research", label: "Research · Ved", icon: IconResearch },
+  { href: "/creative", label: "Creative · Keshav", icon: IconCreative },
+  { href: "/create-post", label: "Create Post", icon: IconCreatePost },
+  { href: "/content-ai", label: "Content AI", icon: IconContentAI },
   { href: "/review-queue", label: "Review Queue", icon: IconReview },
   { href: "/brands", label: "Brands", icon: IconBrand },
   { href: "/onboarding", label: "Onboarding", icon: IconOnboarding },

--- a/apps/web/components/ui/Badge.tsx
+++ b/apps/web/components/ui/Badge.tsx
@@ -4,12 +4,12 @@ import { cn } from "./cn";
 export type BadgeTone = "slate" | "brand" | "green" | "amber" | "red" | "blue";
 
 const TONE_CLASSES: Record<BadgeTone, string> = {
-  slate: "bg-slate-100 text-slate-700 ring-slate-200",
-  brand: "bg-brand-100 text-brand-700 ring-brand-200",
-  green: "bg-emerald-100 text-emerald-700 ring-emerald-200",
-  amber: "bg-amber-100 text-amber-800 ring-amber-200",
-  red: "bg-red-100 text-red-700 ring-red-200",
-  blue: "bg-blue-100 text-blue-700 ring-blue-200",
+  slate: "bg-canvas text-ink-600 ring-line-soft",
+  brand: "bg-brand-50 text-brand-700 ring-brand-100",
+  green: "bg-success-bg text-success ring-success/20",
+  amber: "bg-warning-bg text-warning ring-warning/20",
+  red: "bg-danger-bg text-danger ring-danger/20",
+  blue: "bg-brand-50 text-brand-700 ring-brand-100",
 };
 
 export function Badge({

--- a/apps/web/components/ui/Button.tsx
+++ b/apps/web/components/ui/Button.tsx
@@ -9,15 +9,15 @@ type Size = "sm" | "md" | "lg";
 
 const VARIANT_CLASSES: Record<Variant, string> = {
   primary:
-    "bg-brand-600 text-white shadow-card hover:bg-brand-700 focus-visible:outline-brand-600 disabled:bg-brand-300",
+    "bg-brand-600 text-white shadow-glow hover:bg-brand-700 focus-visible:outline-brand-600 disabled:bg-brand-300 disabled:shadow-none",
   secondary:
-    "bg-slate-900 text-white shadow-card hover:bg-slate-800 focus-visible:outline-slate-900 disabled:bg-slate-400",
+    "bg-ink-950 text-white shadow-card hover:bg-ink-900 focus-visible:outline-ink-950 disabled:bg-ink-300",
   outline:
-    "border border-slate-300 bg-white text-slate-700 shadow-sm hover:bg-slate-50 focus-visible:outline-slate-400 disabled:text-slate-400",
+    "border border-line bg-white text-ink-800 shadow-sm hover:bg-canvas focus-visible:outline-ink-200 disabled:text-ink-200",
   ghost:
-    "text-slate-600 hover:bg-slate-100 hover:text-slate-900 focus-visible:outline-slate-400 disabled:text-slate-300",
+    "text-ink-600 hover:bg-canvas hover:text-ink-950 focus-visible:outline-ink-200 disabled:text-ink-200",
   danger:
-    "bg-red-600 text-white shadow-card hover:bg-red-700 focus-visible:outline-red-600 disabled:bg-red-300",
+    "bg-danger text-white shadow-card hover:bg-danger/90 focus-visible:outline-danger disabled:bg-danger/40",
 };
 
 const SIZE_CLASSES: Record<Size, string> = {
@@ -39,7 +39,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
       <button
         ref={ref}
         className={cn(
-          "inline-flex items-center justify-center rounded-lg font-medium transition-colors duration-150",
+          "inline-flex items-center justify-center rounded-[11px] font-semibold transition-colors duration-150",
           "focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2",
           "disabled:cursor-not-allowed",
           VARIANT_CLASSES[variant],

--- a/apps/web/components/ui/Card.tsx
+++ b/apps/web/components/ui/Card.tsx
@@ -4,7 +4,7 @@ import { cn } from "./cn";
 export function Card({ className, children, ...props }: HTMLAttributes<HTMLDivElement>) {
   return (
     <div
-      className={cn("rounded-xl border border-slate-200 bg-white shadow-card", className)}
+      className={cn("rounded-2xl border border-line-soft bg-white shadow-card", className)}
       {...props}
     >
       {children}
@@ -24,10 +24,10 @@ export function CardHeader({
   className?: string;
 }) {
   return (
-    <div className={cn("flex items-start justify-between gap-4 border-b border-slate-100 p-5", className)}>
+    <div className={cn("flex items-start justify-between gap-4 border-b border-line-faint p-5", className)}>
       <div>
-        <h3 className="text-sm font-semibold text-slate-900">{title}</h3>
-        {description ? <p className="mt-0.5 text-sm text-slate-500">{description}</p> : null}
+        <h3 className="text-sm font-semibold text-ink-950">{title}</h3>
+        {description ? <p className="mt-0.5 text-sm text-ink-400">{description}</p> : null}
       </div>
       {action ? <div className="shrink-0">{action}</div> : null}
     </div>

--- a/apps/web/components/ui/EmptyState.tsx
+++ b/apps/web/components/ui/EmptyState.tsx
@@ -12,14 +12,14 @@ export function EmptyState({
   action?: ReactNode;
 }) {
   return (
-    <div className="flex flex-col items-center justify-center rounded-xl border border-dashed border-slate-300 px-6 py-14 text-center">
+    <div className="flex flex-col items-center justify-center rounded-2xl border border-dashed border-ink-100 bg-white/60 px-6 py-14 text-center">
       {icon ? (
-        <div className="mb-3 flex h-11 w-11 items-center justify-center rounded-full bg-slate-100 text-slate-400">
+        <div className="mb-3 flex h-11 w-11 items-center justify-center rounded-full bg-canvas text-ink-200">
           {icon}
         </div>
       ) : null}
-      <h3 className="text-sm font-semibold text-slate-900">{title}</h3>
-      {description ? <p className="mt-1 max-w-sm text-sm text-slate-500">{description}</p> : null}
+      <h3 className="text-sm font-semibold text-ink-950">{title}</h3>
+      {description ? <p className="mt-1 max-w-sm text-sm text-ink-400">{description}</p> : null}
       {action ? <div className="mt-4">{action}</div> : null}
     </div>
   );

--- a/apps/web/components/ui/Input.tsx
+++ b/apps/web/components/ui/Input.tsx
@@ -3,9 +3,9 @@ import { forwardRef } from "react";
 import { cn } from "./cn";
 
 const FIELD_CLASSES =
-  "block w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm " +
-  "placeholder:text-slate-400 focus:border-brand-500 focus:outline-none focus:ring-2 focus:ring-brand-500/20 " +
-  "disabled:bg-slate-50 disabled:text-slate-400";
+  "block w-full rounded-[11px] border border-line bg-white px-3.5 py-2.5 text-sm text-ink-950 " +
+  "placeholder:text-ink-200 focus:border-brand-500 focus:outline-none focus:ring-2 focus:ring-brand-500/20 " +
+  "disabled:bg-canvas disabled:text-ink-200";
 
 export const Input = forwardRef<HTMLInputElement, InputHTMLAttributes<HTMLInputElement>>(
   ({ className, ...props }, ref) => (
@@ -47,15 +47,15 @@ export function Field({
 } & Partial<LabelHTMLAttributes<HTMLLabelElement>>) {
   return (
     <div className="space-y-1.5">
-      <label htmlFor={htmlFor} className="block text-sm font-medium text-slate-700">
+      <label htmlFor={htmlFor} className="block text-xs font-semibold text-ink-600">
         {label}
-        {required ? <span className="ml-0.5 text-red-500">*</span> : null}
+        {required ? <span className="ml-0.5 text-danger">*</span> : null}
       </label>
       {children}
       {error ? (
-        <p className="text-sm text-red-600">{error}</p>
+        <p className="text-sm text-danger">{error}</p>
       ) : hint ? (
-        <p className="text-sm text-slate-500">{hint}</p>
+        <p className="text-sm text-ink-400">{hint}</p>
       ) : null}
     </div>
   );

--- a/apps/web/components/ui/Modal.tsx
+++ b/apps/web/components/ui/Modal.tsx
@@ -38,7 +38,7 @@ export function Modal({
   return createPortal(
     <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
       <div
-        className="fixed inset-0 bg-slate-900/40 animate-fade-in"
+        className="fixed inset-0 bg-ink-950/40 animate-fade-in"
         onClick={onClose}
         aria-hidden="true"
       />
@@ -47,20 +47,20 @@ export function Modal({
         aria-modal="true"
         aria-labelledby={title ? titleId : undefined}
         className={cn(
-          "relative w-full animate-slide-up rounded-xl bg-white shadow-popover",
+          "relative w-full animate-slide-up rounded-2xl bg-white shadow-modal",
           sizeClass,
         )}
       >
         {title ? (
-          <div className="flex items-center justify-between border-b border-slate-100 px-5 py-4">
-            <h2 id={titleId} className="text-base font-semibold text-slate-900">
+          <div className="flex items-center justify-between border-b border-line-faint px-5 py-4">
+            <h2 id={titleId} className="text-base font-semibold text-ink-950">
               {title}
             </h2>
             <button
               type="button"
               onClick={onClose}
               aria-label="Close"
-              className="rounded-md p-1 text-slate-400 hover:bg-slate-100 hover:text-slate-600"
+              className="rounded-md p-1 text-ink-300 hover:bg-canvas hover:text-ink-600"
             >
               <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden="true">
                 <path
@@ -75,7 +75,7 @@ export function Modal({
         ) : null}
         <div className="max-h-[70vh] overflow-y-auto scrollbar-thin px-5 py-4">{children}</div>
         {footer ? (
-          <div className="flex justify-end gap-2 border-t border-slate-100 px-5 py-4">{footer}</div>
+          <div className="flex justify-end gap-2 border-t border-line-faint px-5 py-4">{footer}</div>
         ) : null}
       </div>
     </div>,

--- a/apps/web/components/ui/PageHeader.tsx
+++ b/apps/web/components/ui/PageHeader.tsx
@@ -12,8 +12,8 @@ export function PageHeader({
   return (
     <div className="mb-6 flex flex-wrap items-start justify-between gap-4">
       <div>
-        <h1 className="text-2xl font-semibold tracking-tight text-slate-900">{title}</h1>
-        {description ? <p className="mt-1 text-sm text-slate-500">{description}</p> : null}
+        <h1 className="text-2xl font-bold tracking-tight text-ink-950">{title}</h1>
+        {description ? <p className="mt-1 text-sm text-ink-400">{description}</p> : null}
       </div>
       {action ? <div className="flex shrink-0 items-center gap-2">{action}</div> : null}
     </div>

--- a/apps/web/components/ui/Skeleton.tsx
+++ b/apps/web/components/ui/Skeleton.tsx
@@ -1,5 +1,5 @@
 import { cn } from "./cn";
 
 export function Skeleton({ className }: { className?: string }) {
-  return <div className={cn("animate-pulse rounded-md bg-slate-200", className)} />;
+  return <div className={cn("animate-pulse rounded-md bg-ink-50", className)} />;
 }

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -114,7 +114,12 @@ export interface ReviewFeedback {
   created_at: string;
 }
 
-// Mirrors apps/api/models/post.py::PipelineStage.
+// Mirrors apps/api/models/post.py::PipelineStage. "failed" is set
+// out-of-band by the publish queue (apps/api/services/publish_queue.py)
+// once a publish permanently exhausts its retries — added here alongside
+// Issue #126's Create Post "Recent runs" list (apps/api/schemas/post.py::
+// PostRead), the first place in the web app that surfaces every stage
+// rather than just the ones review-queue/calendar already covered.
 export type PipelineStage =
   | "research"
   | "creative"
@@ -125,7 +130,8 @@ export type PipelineStage =
   | "publisher"
   | "analytics_collector"
   | "completed"
-  | "rejected";
+  | "rejected"
+  | "failed";
 
 // Mirrors apps/api/schemas/review.py::ReviewQueuePostRead.
 export interface ReviewQueuePost {
@@ -841,6 +847,160 @@ export async function fetchPostAnalyticsTrend(
   const query = params.toString();
 
   const res = await fetch(analyticsUrl(brandId, `/posts/${postId}/trend${query ? `?${query}` : ""}`), {
+    headers: authHeaders(token),
+  });
+
+  if (!res.ok) {
+    throw new ApiError(await parseErrorDetail(res), res.status);
+  }
+
+  return res.json();
+}
+
+// --- Research · Ved (Issue #126) ---
+
+// Mirrors apps/api/schemas/research.py::ResearchRunRead. `brief` is
+// exactly what packages/agents/pipeline/nodes/research_engine.py's
+// _research_brief produces: brand_context, platform_trends,
+// industry_trends, timing_signal.
+export interface ResearchRun {
+  id: string;
+  post_id: string;
+  brand_id: string;
+  created_at: string;
+  brief: {
+    post_id: string;
+    brand_context: Array<Record<string, unknown>>;
+    platform_trends: Record<string, Array<{ title: string; url: string; content: string }>>;
+    industry_trends: Array<{ title: string; url: string; content: string }>;
+    timing_signal: {
+      researched_at: string;
+      platforms: string[];
+      trending_topics: string[];
+      target_datetime: string | null;
+    };
+  };
+}
+
+// apps/api/routers/research.py mounts these under /brands/{brand_id}/research
+// — same brand-scoping convention as calendarEventsUrl/reviewQueueUrl above.
+function researchUrl(brandId: string, suffix = ""): string {
+  return `${API_URL}/brands/${brandId}/research${suffix}`;
+}
+
+export async function runResearch(token: string, brandId: string): Promise<ResearchRun> {
+  const res = await fetch(researchUrl(brandId, "/run"), {
+    method: "POST",
+    headers: authHeaders(token),
+  });
+
+  if (!res.ok) {
+    throw new ApiError(await parseErrorDetail(res), res.status);
+  }
+
+  return res.json();
+}
+
+// Returns null (rather than throwing) when no research has been run yet —
+// apps/api/routers/research.py::latest_research 404s in that case, which
+// the Research page treats as its "nothing yet, run one" state.
+export async function fetchLatestResearch(token: string, brandId: string): Promise<ResearchRun | null> {
+  const res = await fetch(researchUrl(brandId, "/latest"), {
+    headers: authHeaders(token),
+  });
+
+  if (res.status === 404) return null;
+  if (!res.ok) {
+    throw new ApiError(await parseErrorDetail(res), res.status);
+  }
+
+  return res.json();
+}
+
+// --- Creative · Keshav (Issue #126) ---
+
+// Mirrors apps/api/schemas/creative.py::CreativeAngleRead.
+export interface CreativeAngle {
+  format: string;
+  angle: string;
+  hook: string;
+  why: string;
+  cta: string;
+  score: number;
+}
+
+export async function generateCreativeAngles(
+  token: string,
+  brandId: string,
+  brief: string
+): Promise<CreativeAngle[]> {
+  const res = await fetch(`${API_URL}/brands/${brandId}/creative/angles`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", ...authHeaders(token) },
+    body: JSON.stringify({ brief }),
+  });
+
+  if (!res.ok) {
+    throw new ApiError(await parseErrorDetail(res), res.status);
+  }
+
+  const data: { angles: CreativeAngle[] } = await res.json();
+  return data.angles;
+}
+
+// --- Content AI (Issue #126) ---
+
+// Mirrors apps/api/schemas/content_ai.py::ContentAIVariantRead.
+export interface ContentAIVariant {
+  status: "generated" | "failed";
+  url: string | null;
+}
+
+// Mirrors apps/api/schemas/content_ai.py::ContentAIGenerateRequest.
+export interface ContentAIGenerateInput {
+  prompt: string;
+  aspect_ratio?: string | null;
+  style?: string | null;
+  lock_brand_colors?: boolean;
+  count?: number;
+}
+
+export async function generateContentAIImages(
+  token: string,
+  brandId: string,
+  payload: ContentAIGenerateInput
+): Promise<ContentAIVariant[]> {
+  const res = await fetch(`${API_URL}/brands/${brandId}/content-ai/generate`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", ...authHeaders(token) },
+    body: JSON.stringify(payload),
+  });
+
+  if (!res.ok) {
+    throw new ApiError(await parseErrorDetail(res), res.status);
+  }
+
+  const data: { variants: ContentAIVariant[] } = await res.json();
+  return data.variants;
+}
+
+// --- Posts / recent runs (Issue #126) ---
+
+// Mirrors apps/api/schemas/post.py::PostRead.
+export interface PostSummary {
+  id: string;
+  brand_id: string;
+  calendar_event_id: string | null;
+  current_pipeline_stage: PipelineStage;
+  body_text: Record<string, string> | null;
+  created_at: string;
+  updated_at: string;
+}
+
+// apps/api/routers/posts.py mounts this under /brands/{brand_id}/posts —
+// same brand-scoping convention as calendarEventsUrl above.
+export async function fetchRecentPosts(token: string, brandId: string, limit = 20): Promise<PostSummary[]> {
+  const res = await fetch(`${API_URL}/brands/${brandId}/posts?limit=${limit}`, {
     headers: authHeaders(token),
   });
 

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -356,6 +356,106 @@ export async function rescheduleReviewPost(
   return res.json();
 }
 
+// --- Content Arena (Issue #124) ---
+
+// Mirrors apps/api/models/agent_run.py::AgentType — only the eight
+// per-post pipeline stages can appear here (onboarding/weekly_report runs
+// never carry a post_id, so the arena endpoints below can never surface
+// them).
+export type AgentType =
+  | "research"
+  | "creative"
+  | "generation"
+  | "reviewer"
+  | "human_review"
+  | "scheduler"
+  | "publisher"
+  | "analytics_collector";
+
+// Mirrors apps/api/schemas/arena.py::ArenaAgentRunRead. `output` is
+// whatever structured dict that stage's node returned (e.g.
+// research_brief/creative_brief/generation_output/review_output) —
+// rendered defensively, never assumed to have every key. `input` is not
+// exposed: run_pipeline only ever writes {"post_id": ...} into it, never
+// a real prompt.
+export interface ArenaAgentRun {
+  id: string;
+  agent_type: AgentType;
+  output: Record<string, unknown> | null;
+  model: string | null;
+  tokens: number | null;
+  cost: number | null;
+  latency_ms: number | null;
+  created_at: string;
+}
+
+// Mirrors apps/api/schemas/arena.py::ArenaReviewFeedbackRead.
+export interface ArenaReviewFeedback {
+  id: string;
+  source: ReviewSource;
+  score: number;
+  verdict: ReviewVerdict;
+  comments: Record<string, unknown>;
+  created_at: string;
+}
+
+// Mirrors apps/api/schemas/arena.py::ArenaPostRead — a thin Post
+// projection, not the full row.
+export interface ArenaPost {
+  id: string;
+  calendar_event_id: string | null;
+  current_pipeline_stage: PipelineStage;
+  body_text: Record<string, string> | null;
+  media: { platform: string; format: string; url: string }[] | null;
+  created_at: string;
+  updated_at: string;
+}
+
+// Mirrors apps/api/schemas/arena.py::ArenaRunRead. `post` is null when the
+// calendar event hasn't been triggered into a Post yet (or the brand has
+// no posts at all, for fetchLatestArenaRun) — agent_runs/review_feedback
+// are always empty in that case too.
+export interface ArenaRun {
+  calendar_event_id: string | null;
+  post: ArenaPost | null;
+  agent_runs: ArenaAgentRun[];
+  review_feedback: ArenaReviewFeedback[];
+}
+
+// apps/api/routers/arena.py mounts these under /brands/{brand_id}/arena —
+// same brand-scoping convention as calendarEventsUrl/reviewQueueUrl above.
+function arenaUrl(brandId: string, suffix: string): string {
+  return `${API_URL}/brands/${brandId}/arena${suffix}`;
+}
+
+export async function fetchArenaRunForEvent(
+  token: string,
+  brandId: string,
+  eventId: string
+): Promise<ArenaRun> {
+  const res = await fetch(arenaUrl(brandId, `/by-event/${eventId}`), {
+    headers: authHeaders(token),
+  });
+
+  if (!res.ok) {
+    throw new ApiError(await parseErrorDetail(res), res.status);
+  }
+
+  return res.json();
+}
+
+export async function fetchLatestArenaRun(token: string, brandId: string): Promise<ArenaRun> {
+  const res = await fetch(arenaUrl(brandId, "/latest"), {
+    headers: authHeaders(token),
+  });
+
+  if (!res.ok) {
+    throw new ApiError(await parseErrorDetail(res), res.status);
+  }
+
+  return res.json();
+}
+
 // --- Social accounts (Issue #91) ---
 
 // Mirrors apps/api/models/social_account.py::SocialPlatform. "linkedin" is

--- a/apps/web/tailwind.config.ts
+++ b/apps/web/tailwind.config.ts
@@ -1,30 +1,99 @@
 import type { Config } from "tailwindcss";
 
+// Design tokens sourced 1:1 from "Raindeer Social Startup Onboarding/Raindeer
+// Social.dc.html" (the product's canonical design mockup). This is the one
+// visual language for the whole app — the earlier n8n-style dark "ink" shell
+// is superseded; dark is reserved only for the Content Arena screen, which
+// keeps its own literal hex values inline since it's visually a separate
+// world from the rest of the app (see app/arena/page.tsx once built).
 const config: Config = {
   content: ["./app/**/*.{ts,tsx}", "./components/**/*.{ts,tsx}"],
   theme: {
     extend: {
       colors: {
+        // Primary blue scale — 600 (#1B4DFF) is the mockup's exact primary;
+        // the rest of the ramp is interpolated so utilities like
+        // bg-brand-50/border-brand-200 keep working across the app.
         brand: {
-          50: "#f5f3ff",
-          100: "#ede9fe",
-          200: "#ddd6fe",
-          300: "#c4b5fd",
-          400: "#a78bfa",
-          500: "#8b5cf6",
-          600: "#7c3aed",
-          700: "#6d28d9",
-          800: "#5b21b6",
-          900: "#4c1d95",
+          50: "#F0F4FF",
+          100: "#E1EAFF",
+          200: "#C7D7FF",
+          300: "#A3BCFF",
+          400: "#7194FF",
+          500: "#3D6BFF",
+          600: "#1B4DFF",
+          700: "#0A2FCC",
+          800: "#0A29A6",
+          900: "#0B2A6B",
+        },
+        // Neutral ink/slate scale for text and chrome, matching the
+        // mockup's exact greys rather than Tailwind's default slate.
+        ink: {
+          950: "#0A1633",
+          900: "#12203F",
+          800: "#22304F",
+          700: "#33436B",
+          600: "#4A5678",
+          500: "#5B6784",
+          400: "#6A7691",
+          300: "#8B96B2",
+          200: "#98A2BC",
+          100: "#C7D2EC",
+          50: "#E3E8F5",
+        },
+        // Borders/backgrounds used throughout the mockup that don't fit a
+        // simple numeric ramp — kept as named tokens for exact fidelity.
+        canvas: "#F6F8FE",
+        line: {
+          DEFAULT: "#DFE5F3",
+          soft: "#E3E8F5",
+          faint: "#E7EBF6",
+        },
+        // Per-agent identity colors — used for avatars, badges, node
+        // headers, and anywhere an agent's output needs to read as "theirs"
+        // at a glance. `from`/`to` are the two stops of that agent's
+        // gradient in the mockup.
+        agent: {
+          aarav: { from: "#1B4DFF", to: "#8FC4FF", solid: "#1B4DFF" },
+          ved: { from: "#0B2A6B", to: "#3C7BFF", solid: "#0B2A6B" },
+          keshav: { from: "#6B32C9", to: "#B58BFF", solid: "#6B32C9" },
+          kavi: { from: "#0E7A4E", to: "#5AD1A6", solid: "#0E7A4E" },
+          neer: { from: "#B46A00", to: "#FFC46B", solid: "#B46A00" },
+        },
+        success: { DEFAULT: "#0E7A4E", bg: "#E7F7EF" },
+        warning: { DEFAULT: "#B46A00", bg: "#FFF3E2" },
+        danger: { DEFAULT: "#C9295A", bg: "#FDECEF" },
+        violet: { DEFAULT: "#6B32C9", bg: "#F3EBFF" },
+        // The Content Arena's own dark theme — namespaced so it never
+        // collides with the light app shell's tokens above.
+        arenadark: {
+          bg: "#080D1E",
+          panel: "#0C1330",
+          panel2: "#0F1731",
+          panel3: "#101838",
+          border: "#1B2440",
+          border2: "#22305C",
+          border3: "#253358",
+          text: "#EAF0FF",
+          text2: "#C6D2F2",
+          text3: "#93A2CC",
+          muted: "#5B6A96",
+          muted2: "#7C8AB4",
+          running: "#6BE3B0",
         },
       },
       fontFamily: {
-        sans: ["var(--font-inter)", "system-ui", "sans-serif"],
+        sans: ["var(--font-jakarta)", "system-ui", "sans-serif"],
+        serif: ["var(--font-instrument-serif)", "serif"],
+        mono: ["var(--font-jetbrains-mono)", "ui-monospace", "SFMono-Regular", "Menlo", "monospace"],
       },
       boxShadow: {
         card: "0 1px 2px 0 rgb(0 0 0 / 0.03), 0 1px 3px 0 rgb(0 0 0 / 0.06)",
         "card-hover": "0 4px 6px -1px rgb(0 0 0 / 0.05), 0 2px 4px -2px rgb(0 0 0 / 0.05)",
         popover: "0 10px 15px -3px rgb(0 0 0 / 0.08), 0 4px 6px -4px rgb(0 0 0 / 0.08)",
+        // Colored "glow" shadow the mockup puts under every primary button.
+        glow: "0 8px 20px -8px rgba(27,77,255,.7)",
+        modal: "0 12px 34px -26px rgba(10,22,51,.5)",
       },
       borderRadius: {
         xl2: "1rem",
@@ -35,10 +104,29 @@ const config: Config = {
           from: { opacity: "0", transform: "translateY(4px)" },
           to: { opacity: "1", transform: "translateY(0)" },
         },
+        // --- mockup-native keyframes, kept under their original rd- names
+        // so screens built against the mockup can reference them directly ---
+        "rd-blink": { "0%,60%,100%": { opacity: ".25" }, "30%": { opacity: "1" } },
+        "rd-spin": { to: { transform: "rotate(360deg)" } },
+        "rd-pulse": {
+          "0%,100%": { boxShadow: "0 0 0 0 rgba(27,77,255,.35)" },
+          "50%": { boxShadow: "0 0 0 10px rgba(27,77,255,0)" },
+        },
+        "rd-dash": { to: { strokeDashoffset: "-32" } },
+        "rd-aurora": { "0%": { transform: "rotate(0deg) scale(1.4)" }, "100%": { transform: "rotate(360deg) scale(1.4)" } },
+        "rd-wave": { "0%,100%": { transform: "scaleY(.35)" }, "50%": { transform: "scaleY(1)" } },
+        "rd-rise": { from: { opacity: "0", transform: "translateY(6px)" }, to: { opacity: "1", transform: "none" } },
       },
       animation: {
         "fade-in": "fade-in 0.15s ease-out",
         "slide-up": "slide-up 0.2s ease-out",
+        "rd-blink": "rd-blink 1.3s infinite",
+        "rd-spin": "rd-spin 1s linear infinite",
+        "rd-pulse": "rd-pulse 2.6s infinite",
+        "rd-dash": "rd-dash 1.4s linear infinite",
+        "rd-aurora": "rd-aurora 7s linear infinite",
+        "rd-wave": "rd-wave 1.1s ease-in-out infinite",
+        "rd-rise": "rd-rise 0.4s ease both",
       },
     },
   },

--- a/packages/agents/pipeline/nodes/creative_engine.py
+++ b/packages/agents/pipeline/nodes/creative_engine.py
@@ -218,6 +218,149 @@ def _creative_brief(db: Session, post: Post, research_brief: dict[str, Any]) -> 
     }
 
 
+ANGLE_COUNT = 6
+REQUIRED_ANGLE_KEYS = ("format", "angle", "hook", "why", "cta", "score")
+
+# Used only when the LLM call/parse fails (see _generate_angles below) —
+# six fixed, still-differentiated angle templates so a degraded "Generate
+# all 6" call still hands the Creative page six distinct cards instead of
+# an error or duplicates.
+_FALLBACK_ANGLES: list[dict[str, Any]] = [
+    {
+        "format": "Text post",
+        "angle": "Thought leadership",
+        "hook": "Open with a counterintuitive insight from the brief.",
+        "why": "Positions the brand as the one that noticed first.",
+        "cta": "Invite readers to share their own take.",
+        "score": 82,
+    },
+    {
+        "format": "Carousel",
+        "angle": "Before / after",
+        "hook": "Lead with the number that changed.",
+        "why": "Concrete before/after numbers outperform generic claims.",
+        "cta": "Prompt a save or share.",
+        "score": 80,
+    },
+    {
+        "format": "Short thread",
+        "angle": "Timely reaction",
+        "hook": "React to the trend named in the brief with a punchy take.",
+        "why": "Rides an existing conversation instead of starting a cold one.",
+        "cta": "Ask a quick, reply-provoking question.",
+        "score": 78,
+    },
+    {
+        "format": "Single image",
+        "angle": "Customer story",
+        "hook": "Open with a real customer's moment of friction.",
+        "why": "Specific stories read as credible, not promotional.",
+        "cta": "Invite readers to learn more.",
+        "score": 77,
+    },
+    {
+        "format": "Video",
+        "angle": "Behind the scenes",
+        "hook": "Show the work, not just the result.",
+        "why": "Process content builds trust competitors' polished posts don't.",
+        "cta": "Encourage comments with questions.",
+        "score": 75,
+    },
+    {
+        "format": "Text post",
+        "angle": "Contrarian take",
+        "hook": "Challenge a common assumption in the industry.",
+        "why": "Disagreement drives more comments than agreement.",
+        "cta": "Ask readers if they agree.",
+        "score": 73,
+    },
+]
+
+
+class CreativeAnglesError(Exception):
+    """Raised when angle generation is asked to run for a Brand that
+    can't be resolved — a programming/data error, not a transient
+    LLM-provider failure, so unlike LLM failures this is not swallowed."""
+
+
+def _fallback_angles(count: int) -> list[dict[str, Any]]:
+    return [dict(angle) for angle in _FALLBACK_ANGLES[:count]]
+
+
+def _build_angles_prompt(brand: Brand, brief_text: str, count: int) -> str:
+    industry = brand.industry or brand.name
+    return f"""You are a senior social media creative strategist. A brand
+has given you a free-form creative brief. Produce {count} genuinely
+distinct content angles for it — different formats, different hooks,
+different strategies — so the brand's team can pick whichever lands best.
+Respond with strict JSON only — no markdown, no commentary, no code fences.
+
+## Brand
+{brand.name} ({industry})
+
+## Creative brief
+{brief_text}
+
+## Task
+Produce a JSON array of exactly {count} objects. Each object must have
+these string keys:
+- "format": the post format (e.g. text post, carousel, short thread, video)
+- "angle": the creative angle/strategy in a few words
+- "hook": the opening line/hook to grab attention
+- "why": one sentence on why this angle should work for this brief
+- "cta": the call to action
+- "score": an integer 0-100 estimating how strong this angle is
+
+No two objects may share the same format+angle combination. Respond with
+ONLY the JSON array. No markdown code fences, no extra text.
+"""
+
+
+def _parse_angles(text: str, count: int) -> list[dict[str, Any]]:
+    parsed = json.loads(_strip_code_fence(text))
+    if not isinstance(parsed, list) or not parsed:
+        raise ValueError("Creative Engine angle output was valid JSON but not a non-empty array")
+
+    result: list[dict[str, Any]] = []
+    for entry in parsed[:count]:
+        if not isinstance(entry, dict):
+            raise ValueError("Creative Engine angle output contained a non-object entry")
+        missing = [key for key in REQUIRED_ANGLE_KEYS if key not in entry]
+        if missing:
+            raise ValueError(f"Creative Engine angle output missing keys: {missing}")
+        result.append(
+            {
+                "format": str(entry["format"]),
+                "angle": str(entry["angle"]),
+                "hook": str(entry["hook"]),
+                "why": str(entry["why"]),
+                "cta": str(entry["cta"]),
+                "score": int(entry["score"]),
+            }
+        )
+    return result
+
+
+def generate_creative_angles(
+    brand: Brand, brief_text: str, count: int = ANGLE_COUNT
+) -> list[dict[str, Any]]:
+    """Issue #126 — the Creative workspace page's "Generate all 6" action.
+    Turns a free-form creative brief straight into `count` distinct angle
+    cards, reusing this module's exact LLMProvider-only, degrade-on-
+    failure contract (see module docstring / _generate_platform_briefs
+    above) rather than a second, client-side implementation. Unlike
+    _creative_brief above, this doesn't require a Post or an upstream
+    research_brief — the Creative page's brief textarea is the only input.
+    """
+    prompt = _build_angles_prompt(brand, brief_text, count)
+    try:
+        response = get_llm_provider().complete(prompt=prompt, model=_default_model(), temperature=0.8)
+        return _parse_angles(response.text, count)
+    except Exception:
+        logger.warning("Creative Engine angle generation failed; using fallback angles", exc_info=True)
+        return _fallback_angles(count)
+
+
 def build_creative_node(db: Session | None):
     """Builds the real "creative" stage node function, closing over `db`.
     Mirrors research_engine.py's build_research_node factory shape/

--- a/packages/agents/pipeline/nodes/generation_engine.py
+++ b/packages/agents/pipeline/nodes/generation_engine.py
@@ -183,6 +183,40 @@ def _generate_image_media(post_id: str, platform: str, platform_brief: dict[str,
     return {"status": "generated", "platform": platform, "format": fmt, "url": stored_url}
 
 
+def generate_standalone_images(
+    prompt: str, count: int = 4, *, path_prefix: str = "adhoc"
+) -> list[dict[str, Any]]:
+    """Issue #126 — the Content AI workspace page's image-first fast path.
+    Generates `count` standalone image variants straight from a free-form
+    prompt, reusing the exact same ImageProvider (Issue #22) +
+    StorageProvider (Issue #11) interface calls _generate_image_media uses
+    for the per-post pipeline — just without a Post/creative-brief
+    context, since Content AI skips copywriting entirely. Same
+    interface-only, degrade-on-failure contract as the rest of this
+    module: a failed variant becomes a {"status": "failed"} entry rather
+    than aborting the whole batch, so one bad call doesn't cost the other
+    variants."""
+    results: list[dict[str, Any]] = []
+    for _ in range(count):
+        try:
+            result = get_image_provider().generate(prompt=prompt)
+            content, content_type = _download_image_bytes(result.url)
+            extension = "png" if "png" in content_type else content_type.split("/")[-1] or "png"
+            path = f"generated/{path_prefix}/{uuid.uuid4().hex}.{extension}"
+            stored_url = get_storage_provider().upload(path, content, content_type)
+        except Exception:
+            logger.warning(
+                "Generation Engine: standalone image generation failed; "
+                "degrading gracefully (variant omitted)",
+                exc_info=True,
+            )
+            results.append({"status": "failed", "url": None})
+            continue
+
+        results.append({"status": "generated", "url": stored_url})
+    return results
+
+
 def _is_video_or_carousel_format(fmt: str) -> bool:
     return any(keyword in fmt for keyword in VIDEO_FORMAT_KEYWORDS)
 

--- a/packages/agents/pipeline/nodes/research_engine.py
+++ b/packages/agents/pipeline/nodes/research_engine.py
@@ -168,6 +168,25 @@ def _research_brief(db: Session, post: Post) -> dict[str, Any]:
     }
 
 
+def run_standalone_research(db: Session, post: Post) -> dict[str, Any]:
+    """Issue #126 — the Research workspace page's "Run new research"
+    action. Runs exactly the same research brief the pipeline node above
+    produces, but for a standalone Post created ad hoc (no calendar event,
+    no downstream Creative/Generation stages) rather than one advancing
+    through the full pipeline graph — so a brand can see fresh trend
+    results without paying for the other four stages just to view them.
+
+    A thin wrapper around _research_brief rather than a second
+    implementation: same search/brand-context logic, same degrade-on-
+    failure behavior, same output shape. The caller (apps/api/routers/
+    research.py) is responsible for creating the ad hoc Post and logging
+    the AgentRun row — this function only produces the brief, same
+    division of responsibility build_research_node's node function has
+    with run_pipeline's AgentRun-logging (see graph.py).
+    """
+    return _research_brief(db, post)
+
+
 def build_research_node(db: Session | None):
     """Builds the real "research" stage node function, closing over `db`.
     Mirrors graph.py's _make_stub_node factory shape/conventions, but for


### PR DESCRIPTION
Closes #122

Foundation PR — every other screen-migration issue (#123-128) depends on this landing first.

## Summary
- New Tailwind tokens matching "Raindeer Social Startup Onboarding/Raindeer Social.dc.html" 1:1: primary blue #1B4DFF scale, ink/line neutrals, 5 named agent gradient colors, semantic success/warning/danger, and a namespaced `arenadark` palette reserved for the Content Arena screen (#124).
- Fonts: Plus Jakarta Sans / Instrument Serif / JetBrains Mono via next/font/google, replacing Inter.
- Ported the mockup's `rd-*` keyframes/animations directly so later screens can reference them without redefining.
- Restyled `components/ui/*` — every prop/API unchanged, pure reskin.
- Restyled the app shell (nav/auth-gate/brand-switcher) to the mockup's light sidebar. Existing nav routes preserved as-is; new routes land with their own page in follow-up PRs.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run` — 57/57 pass
- [x] `npm run build` clean
- [x] Manually verified in a real browser (login, dashboard, calendar) — screenshots match the mockup's shell, no visual regressions