### PR TITLE
feat(web): add standalone Research, Creative, Create Post, and Content AI pages

### DIFF
--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -10,7 +10,11 @@ from apps.api.observability import init_sentry
 from apps.api.routers.analytics import router as analytics_router
 from apps.api.routers.brands import router as brands_router
 from apps.api.routers.calendar import router as calendar_router
+from apps.api.routers.content_ai import router as content_ai_router
+from apps.api.routers.creative import router as creative_router
 from apps.api.routers.onboarding import router as onboarding_router
+from apps.api.routers.posts import router as posts_router
+from apps.api.routers.research import router as research_router
 from apps.api.routers.review import router as review_router
 from apps.api.routers.social_accounts import router as social_accounts_router
 
@@ -39,7 +43,11 @@ app.include_router(auth_router)
 app.include_router(analytics_router)
 app.include_router(brands_router)
 app.include_router(calendar_router)
+app.include_router(content_ai_router)
+app.include_router(creative_router)
 app.include_router(onboarding_router)
+app.include_router(posts_router)
+app.include_router(research_router)
 app.include_router(review_router)
 app.include_router(social_accounts_router)
 

--- a/apps/api/routers/content_ai.py
+++ b/apps/api/routers/content_ai.py
@@ -1,0 +1,98 @@
+"""Issue #126 — the Content AI workspace page's API surface: the
+image-first fast path that skips copywriting entirely and goes straight
+to visuals.
+
+Generation Engine's media hook (packages/agents/pipeline/nodes/
+generation_engine.py) already calls the real fal.ai-backed adapter
+(Issue #22, packages/integrations/image_gen/fal_provider.py) through
+ImageProvider — but only ever as a step of the per-post pipeline, driven
+by a creative brief's `format` field. This endpoint calls a sibling
+function, generate_standalone_images (added alongside that hook), which
+reuses the exact same ImageProvider + StorageProvider interface calls
+without requiring a Post or creative brief — just a free-form prompt plus
+the aspect-ratio/style/brand-lock choices the Content AI page collects.
+
+Logged as an AgentRun(agent_type=GENERATION, post_id=None) — same
+"no Post exists for a standalone call" convention apps/api/routers/
+creative.py's angle endpoint uses.
+"""
+
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from apps.api.auth.dependencies import CurrentUser
+from apps.api.config.database import get_db
+from apps.api.middleware.rbac import require_role
+from apps.api.models import AgentRun, AgentType, Brand, UserRole
+from apps.api.schemas.content_ai import ContentAIGenerateRequest, ContentAIGenerateResponse
+from packages.agents.pipeline.nodes.generation_engine import generate_standalone_images
+
+router = APIRouter(prefix="/brands/{brand_id}/content-ai", tags=["content-ai"])
+
+WRITE_ROLES = (UserRole.OWNER, UserRole.ADMIN, UserRole.EDITOR)
+
+
+def _get_org_brand(db: Session, brand_id: uuid.UUID, org_id: str) -> Brand:
+    brand = (
+        db.query(Brand)
+        .filter(Brand.id == brand_id, Brand.organization_id == uuid.UUID(org_id))
+        .first()
+    )
+    if brand is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Brand not found")
+    return brand
+
+
+def _compose_prompt(brand: Brand, payload: ContentAIGenerateRequest) -> str:
+    """Folds the page's aspect-ratio/style/brand-lock choices into the
+    prompt handed to ImageProvider — no client-side image manipulation,
+    just richer prompt text, same "reshape what's already decided, don't
+    invent a second code path" spirit as generation_engine.py's own
+    _build_image_prompt."""
+    parts = [payload.prompt.strip()]
+    if payload.style:
+        parts.append(f"Style: {payload.style}.")
+    if payload.aspect_ratio:
+        parts.append(f"Aspect ratio: {payload.aspect_ratio}.")
+    if payload.lock_brand_colors:
+        colors = ", ".join(brand.colors) if brand.colors else None
+        brand_hint = f"Use {brand.name}'s brand colors"
+        if colors:
+            brand_hint += f" ({colors})"
+        brand_hint += " and logo; no off-brand palettes."
+        parts.append(brand_hint)
+    return " ".join(parts)
+
+
+@router.post("/generate", response_model=ContentAIGenerateResponse, status_code=status.HTTP_201_CREATED)
+def generate_images(
+    brand_id: uuid.UUID,
+    payload: ContentAIGenerateRequest,
+    db: Session = Depends(get_db),
+    current_user: CurrentUser = Depends(require_role(*WRITE_ROLES)),
+) -> ContentAIGenerateResponse:
+    brand = _get_org_brand(db, brand_id, current_user.org_id)
+
+    prompt = _compose_prompt(brand, payload)
+    variants = generate_standalone_images(prompt, count=payload.count, path_prefix=str(brand.id))
+
+    db.add(
+        AgentRun(
+            post_id=None,
+            agent_type=AgentType.GENERATION,
+            input={
+                "brand_id": str(brand.id),
+                "prompt": payload.prompt,
+                "aspect_ratio": payload.aspect_ratio,
+                "style": payload.style,
+                "lock_brand_colors": payload.lock_brand_colors,
+                "count": payload.count,
+            },
+            output={"variants": variants},
+        )
+    )
+    db.flush()
+
+    return ContentAIGenerateResponse(variants=variants)

--- a/apps/api/routers/creative.py
+++ b/apps/api/routers/creative.py
@@ -1,0 +1,68 @@
+"""Issue #126 — the standalone Creative workspace page's API surface.
+
+Creative Engine (Issue #20) previously only ran as the pipeline's second
+stage, turning an upstream Research brief into one per-platform brief.
+The Creative page instead takes a free-form brief typed directly by the
+user and wants six distinct angle/format cards to choose from — a
+different shape (many candidate angles, not one brief per platform), so
+this calls a sibling function, generate_creative_angles (added alongside
+_creative_brief in packages/agents/pipeline/nodes/creative_engine.py),
+rather than the existing per-post node. Same LLMProvider-only,
+degrade-on-failure contract as the rest of that module.
+
+Logged as an AgentRun(agent_type=CREATIVE, post_id=None) — no Post exists
+for a standalone angle-generation call, same "post_id null, context in
+input" convention apps/api/models/agent_run.py documents for
+weekly_report.py.
+"""
+
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from apps.api.auth.dependencies import CurrentUser
+from apps.api.config.database import get_db
+from apps.api.middleware.rbac import require_role
+from apps.api.models import AgentRun, AgentType, Brand, UserRole
+from apps.api.schemas.creative import CreativeAnglesRequest, CreativeAnglesResponse
+from packages.agents.pipeline.nodes.creative_engine import generate_creative_angles
+
+router = APIRouter(prefix="/brands/{brand_id}/creative", tags=["creative"])
+
+WRITE_ROLES = (UserRole.OWNER, UserRole.ADMIN, UserRole.EDITOR)
+
+
+def _get_org_brand(db: Session, brand_id: uuid.UUID, org_id: str) -> Brand:
+    brand = (
+        db.query(Brand)
+        .filter(Brand.id == brand_id, Brand.organization_id == uuid.UUID(org_id))
+        .first()
+    )
+    if brand is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Brand not found")
+    return brand
+
+
+@router.post("/angles", response_model=CreativeAnglesResponse, status_code=status.HTTP_201_CREATED)
+def generate_angles(
+    brand_id: uuid.UUID,
+    payload: CreativeAnglesRequest,
+    db: Session = Depends(get_db),
+    current_user: CurrentUser = Depends(require_role(*WRITE_ROLES)),
+) -> CreativeAnglesResponse:
+    brand = _get_org_brand(db, brand_id, current_user.org_id)
+
+    angles = generate_creative_angles(brand, payload.brief, count=payload.count)
+
+    db.add(
+        AgentRun(
+            post_id=None,
+            agent_type=AgentType.CREATIVE,
+            input={"brand_id": str(brand.id), "brief": payload.brief, "count": payload.count},
+            output={"angles": angles},
+        )
+    )
+    db.flush()
+
+    return CreativeAnglesResponse(angles=angles)

--- a/apps/api/routers/posts.py
+++ b/apps/api/routers/posts.py
@@ -1,0 +1,59 @@
+"""Issue #126 — a general, read-only Post listing for a brand.
+
+Every existing Post-reading endpoint is scoped to one pipeline stage:
+apps/api/routers/review.py's review-queue only lists Posts paused at
+human_review, and apps/api/routers/calendar.py returns
+ContentCalendarEvent rows, whose own status field a rejection never
+updates (see packages/agents/pipeline/graph.py — rejecting only ever sets
+Post.current_pipeline_stage to REJECTED). The Create Post page's "Recent
+runs" list needs every Post regardless of stage — including terminal
+REJECTED/FAILED ones — so it can show a real "Blocked" status rather than
+one invented for the UI. This router adds exactly that: one additive,
+read-only endpoint over the existing Post table.
+"""
+
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from apps.api.auth.dependencies import CurrentUser, get_current_user
+from apps.api.config.database import get_db
+from apps.api.models import Brand, Post
+from apps.api.schemas.post import PostRead
+
+router = APIRouter(prefix="/brands/{brand_id}/posts", tags=["posts"])
+
+DEFAULT_LIMIT = 20
+MAX_LIMIT = 100
+
+
+def _get_org_brand(db: Session, brand_id: uuid.UUID, org_id: str) -> Brand:
+    brand = (
+        db.query(Brand)
+        .filter(Brand.id == brand_id, Brand.organization_id == uuid.UUID(org_id))
+        .first()
+    )
+    if brand is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Brand not found")
+    return brand
+
+
+@router.get("", response_model=list[PostRead])
+def list_posts(
+    brand_id: uuid.UUID,
+    limit: int = DEFAULT_LIMIT,
+    db: Session = Depends(get_db),
+    current_user: CurrentUser = Depends(get_current_user),
+) -> list[Post]:
+    """Every Post for this brand, newest first, regardless of pipeline
+    stage — for the Create Post page's "Recent runs" list."""
+    brand = _get_org_brand(db, brand_id, current_user.org_id)
+    capped_limit = max(1, min(limit, MAX_LIMIT))
+    return (
+        db.query(Post)
+        .filter(Post.brand_id == brand.id)
+        .order_by(Post.created_at.desc())
+        .limit(capped_limit)
+        .all()
+    )

--- a/apps/api/routers/research.py
+++ b/apps/api/routers/research.py
@@ -1,0 +1,119 @@
+"""Issue #126 — the standalone Research workspace page's API surface.
+
+Before this, Research Engine (Issue #19) only ran as one stage of the
+per-post pipeline (packages/agents/pipeline/graph.py) — there was no way
+to see fresh trend results without paying for Creative/Generation/
+Reviewer/Human Review too. This router exposes exactly the Research
+Engine's own logic (packages/agents/pipeline/nodes/research_engine.py's
+run_standalone_research, a thin wrapper around the same _research_brief
+the pipeline node uses) through two endpoints:
+
+  * POST .../research/run    — runs a fresh standalone research brief for
+                                the brand right now.
+  * GET  .../research/latest — returns the most recent standalone (or
+                                pipeline) research brief for the brand
+                                without re-running anything, for the page
+                                to render on load.
+
+A standalone run is stored the same way every other AgentRun is (Issue
+#18's convention): as an AgentRun(agent_type=RESEARCH) row. Since
+AgentRun has no brand_id column, it's tied to an ad hoc Post (brand_id
+set, calendar_event_id left null) — the same "a post can be generated ad
+hoc" case apps/api/models/post.py already documents, rather than a
+one-off schema change to AgentRun.
+"""
+
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from apps.api.auth.dependencies import CurrentUser, get_current_user
+from apps.api.config.database import get_db
+from apps.api.middleware.rbac import require_role
+from apps.api.models import AgentRun, AgentType, Brand, Post, UserRole
+from apps.api.schemas.research import ResearchRunRead
+from packages.agents.pipeline.nodes.research_engine import run_standalone_research
+
+router = APIRouter(prefix="/brands/{brand_id}/research", tags=["research"])
+
+WRITE_ROLES = (UserRole.OWNER, UserRole.ADMIN, UserRole.EDITOR)
+
+
+def _get_org_brand(db: Session, brand_id: uuid.UUID, org_id: str) -> Brand:
+    brand = (
+        db.query(Brand)
+        .filter(Brand.id == brand_id, Brand.organization_id == uuid.UUID(org_id))
+        .first()
+    )
+    if brand is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Brand not found")
+    return brand
+
+
+def _to_read(run: AgentRun, brand_id: uuid.UUID) -> ResearchRunRead:
+    return ResearchRunRead(
+        id=run.id,
+        post_id=run.post_id,
+        brand_id=brand_id,
+        created_at=run.created_at,
+        brief=run.output or {},
+    )
+
+
+@router.post("/run", response_model=ResearchRunRead, status_code=status.HTTP_201_CREATED)
+def run_research(
+    brand_id: uuid.UUID,
+    db: Session = Depends(get_db),
+    current_user: CurrentUser = Depends(require_role(*WRITE_ROLES)),
+) -> ResearchRunRead:
+    """Runs a fresh standalone research brief for this brand and logs it
+    as an AgentRun, same as the pipeline's own research stage does — just
+    without a full pipeline run around it."""
+    brand = _get_org_brand(db, brand_id, current_user.org_id)
+
+    post = Post(brand_id=brand.id)
+    db.add(post)
+    db.flush()
+    db.refresh(post)
+
+    brief = run_standalone_research(db, post)
+
+    run = AgentRun(
+        post_id=post.id,
+        agent_type=AgentType.RESEARCH,
+        input={"post_id": str(post.id), "trigger": "standalone"},
+        output=brief,
+    )
+    db.add(run)
+    db.flush()
+    db.refresh(run)
+
+    return _to_read(run, brand.id)
+
+
+@router.get("/latest", response_model=ResearchRunRead)
+def latest_research(
+    brand_id: uuid.UUID,
+    db: Session = Depends(get_db),
+    current_user: CurrentUser = Depends(get_current_user),
+) -> ResearchRunRead:
+    """The most recent research brief for this brand (standalone or from
+    a per-post pipeline run) — lets the page show what's already known
+    without triggering a new run just to view it."""
+    brand = _get_org_brand(db, brand_id, current_user.org_id)
+
+    run = (
+        db.query(AgentRun)
+        .join(Post, AgentRun.post_id == Post.id)
+        .filter(Post.brand_id == brand.id, AgentRun.agent_type == AgentType.RESEARCH)
+        .order_by(AgentRun.created_at.desc())
+        .first()
+    )
+    if run is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="No research has been run yet for this brand",
+        )
+
+    return _to_read(run, brand.id)

--- a/apps/api/schemas/content_ai.py
+++ b/apps/api/schemas/content_ai.py
@@ -1,0 +1,28 @@
+from pydantic import BaseModel, Field
+
+DEFAULT_VARIANT_COUNT = 4
+MAX_VARIANT_COUNT = 4
+
+
+class ContentAIGenerateRequest(BaseModel):
+    """Body for POST .../content-ai/generate — the Content AI page's
+    image-first fast path. `prompt` is the free-form image description;
+    `aspect_ratio`/`style` are folded into the composed prompt handed to
+    ImageProvider, and `lock_brand_colors` appends an instruction to stay
+    within the brand's palette/logo rather than doing any client-side
+    color manipulation."""
+
+    prompt: str = Field(min_length=1)
+    aspect_ratio: str | None = None
+    style: str | None = None
+    lock_brand_colors: bool = True
+    count: int = Field(default=DEFAULT_VARIANT_COUNT, ge=1, le=MAX_VARIANT_COUNT)
+
+
+class ContentAIVariantRead(BaseModel):
+    status: str
+    url: str | None
+
+
+class ContentAIGenerateResponse(BaseModel):
+    variants: list[ContentAIVariantRead]

--- a/apps/api/schemas/creative.py
+++ b/apps/api/schemas/creative.py
@@ -1,0 +1,24 @@
+from pydantic import BaseModel, Field
+
+from packages.agents.pipeline.nodes.creative_engine import ANGLE_COUNT
+
+
+class CreativeAnglesRequest(BaseModel):
+    """Body for POST .../creative/angles. `brief` is the Creative page's
+    free-form textarea — the only input generate_creative_angles needs."""
+
+    brief: str = Field(min_length=1)
+    count: int = Field(default=ANGLE_COUNT, ge=1, le=ANGLE_COUNT)
+
+
+class CreativeAngleRead(BaseModel):
+    format: str
+    angle: str
+    hook: str
+    why: str
+    cta: str
+    score: int
+
+
+class CreativeAnglesResponse(BaseModel):
+    angles: list[CreativeAngleRead]

--- a/apps/api/schemas/post.py
+++ b/apps/api/schemas/post.py
@@ -1,0 +1,28 @@
+import uuid
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict
+
+from apps.api.models.post import PipelineStage
+
+
+class PostRead(BaseModel):
+    """Issue #126 — the Create Post page's "Recent runs" list needs every
+    Post for a brand regardless of pipeline stage (including the terminal
+    REJECTED/FAILED stages), which no existing endpoint returns: the
+    review-queue (apps/api/routers/review.py) only lists Posts paused at
+    human_review, and calendar events (apps/api/routers/calendar.py)
+    track a separate, coarser status that a rejection never updates (see
+    packages/agents/pipeline/graph.py — REJECTED only ever sets
+    Post.current_pipeline_stage). This mirrors ReviewQueuePostRead's shape
+    minus the review-history join, which "recent runs" doesn't need."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    brand_id: uuid.UUID
+    calendar_event_id: uuid.UUID | None
+    current_pipeline_stage: PipelineStage
+    body_text: dict | None
+    created_at: datetime
+    updated_at: datetime

--- a/apps/api/schemas/research.py
+++ b/apps/api/schemas/research.py
@@ -1,0 +1,20 @@
+import uuid
+from datetime import datetime
+from typing import Any
+
+from pydantic import BaseModel
+
+
+class ResearchRunRead(BaseModel):
+    """Issue #126 — one standalone Research Engine run (see
+    packages/agents/pipeline/nodes/research_engine.py::run_standalone_research),
+    surfaced outside the per-post pipeline so the Research workspace page
+    can render trend cards without a full 5-stage run. `brief` is exactly
+    the dict _research_brief produces: brand_context, platform_trends,
+    industry_trends, timing_signal."""
+
+    id: uuid.UUID
+    post_id: uuid.UUID
+    brand_id: uuid.UUID
+    created_at: datetime
+    brief: dict[str, Any]

--- a/apps/api/tests/test_content_ai.py
+++ b/apps/api/tests/test_content_ai.py
@@ -1,0 +1,147 @@
+"""Tests for Issue #126's Content AI workspace page (the image-first fast
+path):
+  1. packages/agents/pipeline/nodes/generation_engine.py::generate_standalone_images
+     calls ImageProvider + StorageProvider only through their interfaces —
+     the same real fal.ai-backed adapter (Issue #22) the per-post pipeline
+     uses — and returns `count` variants.
+  2. A failed variant degrades to {"status": "failed"} without aborting
+     the rest of the batch.
+  3. apps/api/routers/content_ai.py's POST .../content-ai/generate folds
+     aspect-ratio/style/brand-lock into the prompt and logs an
+     AgentRun(agent_type=generation, post_id=None).
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from apps.api.auth.jwt import create_access_token, hash_password
+from apps.api.main import app
+from apps.api.models import AgentRun, AgentType, Brand, Organization, User, UserRole
+from packages.agents.pipeline.nodes.generation_engine import generate_standalone_images
+from packages.integrations.image_gen.base import ImageResult
+
+client = TestClient(app)
+uses_test_session = pytest.mark.usefixtures("override_get_db")
+
+IMAGE_PATCH_TARGET = "packages.agents.pipeline.nodes.generation_engine.get_image_provider"
+STORAGE_PATCH_TARGET = "packages.agents.pipeline.nodes.generation_engine.get_storage_provider"
+
+
+def _setup_brand(db_session, role: UserRole = UserRole.EDITOR) -> tuple[Brand, User]:
+    org = Organization(name="Acme Agency")
+    db_session.add(org)
+    db_session.flush()
+
+    user = User(
+        organization_id=org.id,
+        email=f"{role.value}@acme.test",
+        password_hash=hash_password("test-password"),
+        role=role,
+    )
+    brand = Brand(
+        organization_id=org.id, name="Acme Widgets", industry="Outdoor gear", colors=["#1B4DFF", "#0A1633"]
+    )
+    db_session.add_all([user, brand])
+    db_session.flush()
+    return brand, user
+
+
+def _auth_headers(user: User) -> dict[str, str]:
+    token = create_access_token(
+        user_id=str(user.id), org_id=str(user.organization_id), role=user.role.value
+    )
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _mock_image_provider() -> MagicMock:
+    provider = MagicMock()
+    provider.generate.return_value = ImageResult(url="https://fal.media/files/generated-abc.png")
+    return provider
+
+
+def _mock_download():
+    return (b"fake-bytes", "image/png")
+
+
+# --- engine -------------------------------------------------------------
+
+
+def test_generate_standalone_images_returns_requested_count() -> None:
+    with patch(IMAGE_PATCH_TARGET, return_value=_mock_image_provider()), patch(
+        STORAGE_PATCH_TARGET
+    ) as mock_storage, patch(
+        "packages.agents.pipeline.nodes.generation_engine._download_image_bytes",
+        return_value=_mock_download(),
+    ):
+        mock_storage.return_value.upload.return_value = "https://storage.example/img.png"
+        results = generate_standalone_images("editorial navy card", count=4)
+
+    assert len(results) == 4
+    assert all(r["status"] == "generated" for r in results)
+    assert all(r["url"] == "https://storage.example/img.png" for r in results)
+
+
+def test_generate_standalone_images_degrades_a_failed_variant() -> None:
+    with patch(IMAGE_PATCH_TARGET, side_effect=Exception("fal.ai unreachable")):
+        results = generate_standalone_images("editorial navy card", count=2)
+
+    assert len(results) == 2
+    assert all(r == {"status": "failed", "url": None} for r in results)
+
+
+# --- router --------------------------------------------------------------
+
+
+@uses_test_session
+def test_generate_images_endpoint_logs_agent_run(db_session) -> None:
+    brand, user = _setup_brand(db_session)
+
+    with patch(IMAGE_PATCH_TARGET, return_value=_mock_image_provider()), patch(
+        STORAGE_PATCH_TARGET
+    ) as mock_storage, patch(
+        "packages.agents.pipeline.nodes.generation_engine._download_image_bytes",
+        return_value=_mock_download(),
+    ):
+        mock_storage.return_value.upload.return_value = "https://storage.example/img.png"
+        response = client.post(
+            f"/brands/{brand.id}/content-ai/generate",
+            headers=_auth_headers(user),
+            json={
+                "prompt": "Editorial typographic card, deep navy",
+                "aspect_ratio": "1:1",
+                "style": "editorial",
+                "lock_brand_colors": True,
+                "count": 4,
+            },
+        )
+
+    assert response.status_code == 201
+    body = response.json()
+    assert len(body["variants"]) == 4
+    assert all(v["status"] == "generated" for v in body["variants"])
+
+    run = (
+        db_session.query(AgentRun)
+        .filter(AgentRun.agent_type == AgentType.GENERATION, AgentRun.post_id.is_(None))
+        .order_by(AgentRun.created_at.desc())
+        .first()
+    )
+    assert run is not None
+    assert run.input["brand_id"] == str(brand.id)
+    assert run.input["aspect_ratio"] == "1:1"
+    assert len(run.output["variants"]) == 4
+
+
+@uses_test_session
+def test_generate_images_endpoint_rejects_viewer_role(db_session) -> None:
+    brand, _ = _setup_brand(db_session, role=UserRole.EDITOR)
+    _, viewer = _setup_brand(db_session, role=UserRole.VIEWER)
+
+    response = client.post(
+        f"/brands/{brand.id}/content-ai/generate",
+        headers=_auth_headers(viewer),
+        json={"prompt": "A mountain at sunrise"},
+    )
+    assert response.status_code == 403

--- a/apps/api/tests/test_creative_workspace.py
+++ b/apps/api/tests/test_creative_workspace.py
@@ -1,0 +1,144 @@
+"""Tests for Issue #126's standalone Creative workspace page:
+  1. packages/agents/pipeline/nodes/creative_engine.py::generate_creative_angles
+     calls LLMProvider only through its interface and returns exactly
+     `count` distinct angle cards.
+  2. It degrades to the fixed fallback angles (not an error) when the LLM
+     call/parse fails — same contract as _generate_platform_briefs.
+  3. apps/api/routers/creative.py's POST .../creative/angles logs an
+     AgentRun(agent_type=creative, post_id=None).
+"""
+
+import json
+import uuid
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from apps.api.auth.jwt import create_access_token, hash_password
+from apps.api.main import app
+from apps.api.models import AgentRun, AgentType, Brand, Organization, User, UserRole
+from packages.agents.pipeline.nodes.creative_engine import (
+    ANGLE_COUNT,
+    REQUIRED_ANGLE_KEYS,
+    generate_creative_angles,
+)
+from packages.integrations.llm.base import LLMResponse
+
+client = TestClient(app)
+uses_test_session = pytest.mark.usefixtures("override_get_db")
+
+LLM_PATCH_TARGET = "packages.agents.pipeline.nodes.creative_engine.get_llm_provider"
+
+
+def _setup_brand(db_session, role: UserRole = UserRole.EDITOR) -> tuple[Brand, User]:
+    org = Organization(name="Acme Agency")
+    db_session.add(org)
+    db_session.flush()
+
+    user = User(
+        organization_id=org.id,
+        email=f"{role.value}@acme.test",
+        password_hash=hash_password("test-password"),
+        role=role,
+    )
+    brand = Brand(organization_id=org.id, name="Acme Widgets", industry="Outdoor gear")
+    db_session.add_all([user, brand])
+    db_session.flush()
+    return brand, user
+
+
+def _auth_headers(user: User) -> dict[str, str]:
+    token = create_access_token(
+        user_id=str(user.id), org_id=str(user.organization_id), role=user.role.value
+    )
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _angle(i: int) -> dict:
+    return {
+        "format": f"format-{i}",
+        "angle": f"angle-{i}",
+        "hook": f"hook-{i}",
+        "why": f"why-{i}",
+        "cta": f"cta-{i}",
+        "score": 90 - i,
+    }
+
+
+def _llm_angles_response(count: int) -> LLMResponse:
+    return LLMResponse(
+        text=json.dumps([_angle(i) for i in range(count)]),
+        model="openrouter/free",
+        input_tokens=100,
+        output_tokens=50,
+    )
+
+
+# --- engine ---------------------------------------------------------
+
+
+def test_generate_creative_angles_returns_six_distinct_cards() -> None:
+    brand = Brand(organization_id=uuid.uuid4(), name="Acme", industry="Outdoor gear")
+    with patch(LLM_PATCH_TARGET) as mock_llm:
+        mock_llm.return_value.complete.return_value = _llm_angles_response(ANGLE_COUNT)
+        angles = generate_creative_angles(brand, "Post about our new product launch")
+
+    assert len(angles) == ANGLE_COUNT
+    for angle in angles:
+        assert all(key in angle for key in REQUIRED_ANGLE_KEYS)
+    formats = {a["format"] for a in angles}
+    assert len(formats) == ANGLE_COUNT
+
+
+def test_generate_creative_angles_falls_back_on_llm_failure() -> None:
+    brand = Brand(organization_id=uuid.uuid4(), name="Acme", industry="Outdoor gear")
+    with patch(LLM_PATCH_TARGET, side_effect=Exception("LLM unreachable")):
+        angles = generate_creative_angles(brand, "Post about our new product launch")
+
+    assert len(angles) == ANGLE_COUNT
+    for angle in angles:
+        assert all(key in angle for key in REQUIRED_ANGLE_KEYS)
+
+
+# --- router -----------------------------------------------------------
+
+
+@uses_test_session
+def test_generate_angles_endpoint_logs_agent_run(db_session) -> None:
+    brand, user = _setup_brand(db_session)
+
+    with patch(LLM_PATCH_TARGET) as mock_llm:
+        mock_llm.return_value.complete.return_value = _llm_angles_response(ANGLE_COUNT)
+        response = client.post(
+            f"/brands/{brand.id}/creative/angles",
+            headers=_auth_headers(user),
+            json={"brief": "Launch our new contract-review turnaround feature"},
+        )
+
+    assert response.status_code == 201
+    body = response.json()
+    assert len(body["angles"]) == ANGLE_COUNT
+
+    run = (
+        db_session.query(AgentRun)
+        .filter(AgentRun.agent_type == AgentType.CREATIVE, AgentRun.post_id.is_(None))
+        .order_by(AgentRun.created_at.desc())
+        .first()
+    )
+    assert run is not None
+    assert run.input["brand_id"] == str(brand.id)
+    assert len(run.output["angles"]) == ANGLE_COUNT
+
+
+@uses_test_session
+def test_generate_angles_endpoint_rejects_viewer_role(db_session) -> None:
+    brand, _ = _setup_brand(db_session, role=UserRole.EDITOR)
+    _, viewer = _setup_brand(db_session, role=UserRole.VIEWER)
+
+    response = client.post(
+        f"/brands/{brand.id}/creative/angles",
+        headers=_auth_headers(viewer),
+        json={"brief": "Launch our new feature"},
+    )
+    assert response.status_code == 403

--- a/apps/api/tests/test_posts_list.py
+++ b/apps/api/tests/test_posts_list.py
@@ -1,0 +1,94 @@
+"""Tests for Issue #126's GET /brands/{brand_id}/posts — the general,
+read-only Post listing the Create Post page's "Recent runs" list needs
+(no existing endpoint returns Posts across every pipeline stage; see
+apps/api/routers/posts.py's module docstring)."""
+
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from fastapi.testclient import TestClient
+
+from apps.api.auth.jwt import create_access_token, hash_password
+from apps.api.main import app
+from apps.api.models import Brand, Organization, PipelineStage, Post, User, UserRole
+
+client = TestClient(app)
+uses_test_session = pytest.mark.usefixtures("override_get_db")
+
+
+def _setup_brand(db_session, role: UserRole = UserRole.EDITOR, suffix: str = "") -> tuple[Brand, User]:
+    org = Organization(name="Acme Agency")
+    db_session.add(org)
+    db_session.flush()
+
+    user = User(
+        organization_id=org.id,
+        email=f"{role.value}{suffix}@acme.test",
+        password_hash=hash_password("test-password"),
+        role=role,
+    )
+    brand = Brand(organization_id=org.id, name="Acme Widgets")
+    db_session.add_all([user, brand])
+    db_session.flush()
+    return brand, user
+
+
+def _auth_headers(user: User) -> dict[str, str]:
+    token = create_access_token(
+        user_id=str(user.id), org_id=str(user.organization_id), role=user.role.value
+    )
+    return {"Authorization": f"Bearer {token}"}
+
+
+@uses_test_session
+def test_list_posts_returns_every_stage_newest_first(db_session) -> None:
+    brand, user = _setup_brand(db_session)
+
+    base = datetime.now(timezone.utc)
+    rejected = Post(
+        brand_id=brand.id, current_pipeline_stage=PipelineStage.REJECTED, created_at=base
+    )
+    research = Post(
+        brand_id=brand.id,
+        current_pipeline_stage=PipelineStage.RESEARCH,
+        created_at=base + timedelta(seconds=1),
+    )
+    completed = Post(
+        brand_id=brand.id,
+        current_pipeline_stage=PipelineStage.COMPLETED,
+        created_at=base + timedelta(seconds=2),
+    )
+    db_session.add_all([rejected, research, completed])
+    db_session.flush()
+
+    response = client.get(f"/brands/{brand.id}/posts", headers=_auth_headers(user))
+
+    assert response.status_code == 200
+    body = response.json()
+    assert len(body) == 3
+    stages = {p["current_pipeline_stage"] for p in body}
+    assert stages == {"rejected", "research", "completed"}
+    # Newest first.
+    assert body[0]["id"] == str(completed.id)
+
+
+@uses_test_session
+def test_list_posts_scoped_to_brand_and_org(db_session) -> None:
+    brand, user = _setup_brand(db_session)
+    other_brand, _ = _setup_brand(db_session, suffix="-2")
+
+    db_session.add(Post(brand_id=other_brand.id))
+    db_session.flush()
+
+    response = client.get(f"/brands/{brand.id}/posts", headers=_auth_headers(user))
+    assert response.status_code == 200
+    assert response.json() == []
+
+
+@uses_test_session
+def test_list_posts_404s_for_unknown_brand(db_session) -> None:
+    _, user = _setup_brand(db_session)
+
+    response = client.get(f"/brands/{uuid.uuid4()}/posts", headers=_auth_headers(user))
+    assert response.status_code == 404

--- a/apps/api/tests/test_research_workspace.py
+++ b/apps/api/tests/test_research_workspace.py
@@ -1,0 +1,145 @@
+"""Tests for Issue #126's standalone Research workspace page:
+  1. packages/agents/pipeline/nodes/research_engine.py::run_standalone_research
+     reuses _research_brief exactly (same shape, same degrade-on-failure
+     behavior) for an ad hoc Post.
+  2. apps/api/routers/research.py's POST .../research/run creates the ad
+     hoc Post, runs the brief, and logs an AgentRun(agent_type=research).
+  3. GET .../research/latest returns the most recent one without
+     triggering a new run, and 404s when none exists yet.
+"""
+
+import uuid
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from apps.api.auth.jwt import create_access_token, hash_password
+from apps.api.main import app
+from apps.api.models import AgentRun, AgentType, Brand, Organization, Post, User, UserRole
+from packages.agents.pipeline.nodes.research_engine import run_standalone_research
+from packages.integrations.search.base import SearchResult
+
+client = TestClient(app)
+uses_test_session = pytest.mark.usefixtures("override_get_db")
+
+SEARCH_PATCH_TARGET = "packages.agents.pipeline.nodes.research_engine.get_search_provider"
+EMBED_PATCH_TARGET = "apps.api.services.brand_retrieval.get_embedding_provider"
+
+
+def _setup_brand(db_session, role: UserRole = UserRole.EDITOR) -> tuple[Brand, User]:
+    org = Organization(name="Acme Agency")
+    db_session.add(org)
+    db_session.flush()
+
+    user = User(
+        organization_id=org.id,
+        email=f"{role.value}@acme.test",
+        password_hash=hash_password("test-password"),
+        role=role,
+    )
+    brand = Brand(organization_id=org.id, name="Acme Widgets", industry="Outdoor gear")
+    db_session.add_all([user, brand])
+    db_session.flush()
+    return brand, user
+
+
+def _auth_headers(user: User) -> dict[str, str]:
+    token = create_access_token(
+        user_id=str(user.id), org_id=str(user.organization_id), role=user.role.value
+    )
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _mock_search_provider():
+    provider = type(
+        "StubSearch",
+        (),
+        {"search": lambda self, query, max_results=5: [SearchResult(title=f"Result for {query}", url="https://example.com", content="c")]},
+    )()
+    return provider
+
+
+# --- engine wrapper ---------------------------------------------------
+
+
+def test_run_standalone_research_reuses_research_brief_shape(db_session) -> None:
+    brand, _ = _setup_brand(db_session)
+    post = Post(brand_id=brand.id)
+    db_session.add(post)
+    db_session.flush()
+
+    with patch(SEARCH_PATCH_TARGET, return_value=_mock_search_provider()), patch(
+        EMBED_PATCH_TARGET, side_effect=Exception("no embedding provider configured")
+    ):
+        brief = run_standalone_research(db_session, post)
+
+    assert brief["post_id"] == str(post.id)
+    assert "platform_trends" in brief
+    assert "industry_trends" in brief
+    assert "timing_signal" in brief
+
+
+# --- router: POST /run -------------------------------------------------
+
+
+@uses_test_session
+def test_run_research_endpoint_creates_ad_hoc_post_and_agent_run(db_session) -> None:
+    brand, user = _setup_brand(db_session)
+
+    with patch(SEARCH_PATCH_TARGET, return_value=_mock_search_provider()), patch(
+        EMBED_PATCH_TARGET, side_effect=Exception("no embedding provider configured")
+    ):
+        response = client.post(
+            f"/brands/{brand.id}/research/run", headers=_auth_headers(user)
+        )
+
+    assert response.status_code == 201
+    body = response.json()
+    assert body["brand_id"] == str(brand.id)
+    assert "platform_trends" in body["brief"]
+
+    post = db_session.query(Post).filter(Post.id == uuid.UUID(body["post_id"])).first()
+    assert post is not None
+    assert post.brand_id == brand.id
+    assert post.calendar_event_id is None
+
+    run = db_session.query(AgentRun).filter(AgentRun.post_id == post.id).first()
+    assert run is not None
+    assert run.agent_type == AgentType.RESEARCH
+    assert run.output == body["brief"]
+
+
+@uses_test_session
+def test_run_research_endpoint_rejects_viewer_role(db_session) -> None:
+    brand, _ = _setup_brand(db_session, role=UserRole.EDITOR)
+    _, viewer = _setup_brand(db_session, role=UserRole.VIEWER)
+
+    response = client.post(f"/brands/{brand.id}/research/run", headers=_auth_headers(viewer))
+    assert response.status_code == 403
+
+
+# --- router: GET /latest ------------------------------------------------
+
+
+@uses_test_session
+def test_latest_research_returns_404_when_none_exists(db_session) -> None:
+    brand, user = _setup_brand(db_session)
+
+    response = client.get(f"/brands/{brand.id}/research/latest", headers=_auth_headers(user))
+    assert response.status_code == 404
+
+
+@uses_test_session
+def test_latest_research_returns_most_recent_run(db_session) -> None:
+    brand, user = _setup_brand(db_session)
+
+    with patch(SEARCH_PATCH_TARGET, return_value=_mock_search_provider()), patch(
+        EMBED_PATCH_TARGET, side_effect=Exception("no embedding provider configured")
+    ):
+        run_response = client.post(f"/brands/{brand.id}/research/run", headers=_auth_headers(user))
+    assert run_response.status_code == 201
+
+    latest_response = client.get(f"/brands/{brand.id}/research/latest", headers=_auth_headers(user))
+    assert latest_response.status_code == 200
+    assert latest_response.json()["post_id"] == run_response.json()["post_id"]

--- a/apps/web/__tests__/content-ai-page.test.tsx
+++ b/apps/web/__tests__/content-ai-page.test.tsx
@@ -1,0 +1,124 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { act, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import ContentAIPage from "@/app/content-ai/page";
+import { AuthProvider } from "@/lib/auth-context";
+import { BrandProvider } from "@/lib/brand-context";
+import { ToastProvider } from "@/components/ui/Toast";
+import type { ContentAIVariant } from "@/lib/api";
+
+const fetchBrandsMock = vi.fn();
+const generateContentAIImagesMock = vi.fn();
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return {
+    ...actual,
+    fetchBrands: (...args: unknown[]) => fetchBrandsMock(...args),
+    generateContentAIImages: (...args: unknown[]) => generateContentAIImagesMock(...args),
+  };
+});
+
+const BRANDS = [
+  {
+    id: "brand-1",
+    organization_id: "org-1",
+    name: "Acme Co",
+    industry: null,
+    logo_url: null,
+    target_audience: null,
+    colors: null,
+    tone_descriptors: null,
+    product_catalog: null,
+    brand_report: null,
+    created_at: "2026-01-01",
+    updated_at: "2026-01-01",
+  },
+];
+
+function makeVariants(): ContentAIVariant[] {
+  return [
+    { status: "generated", url: "https://storage.example/1.png" },
+    { status: "generated", url: "https://storage.example/2.png" },
+    { status: "failed", url: null },
+    { status: "generated", url: "https://storage.example/4.png" },
+  ];
+}
+
+function renderPage() {
+  return render(
+    <ToastProvider>
+      <AuthProvider>
+        <BrandProvider>
+          <ContentAIPage />
+        </BrandProvider>
+      </AuthProvider>
+    </ToastProvider>
+  );
+}
+
+describe("ContentAIPage", () => {
+  beforeEach(() => {
+    fetchBrandsMock.mockReset();
+    generateContentAIImagesMock.mockReset();
+
+    window.localStorage.clear();
+    window.localStorage.setItem("raindeer.auth.token", "test-token");
+
+    fetchBrandsMock.mockResolvedValue(BRANDS);
+  });
+
+  it("generates variants with the chosen aspect ratio, style, and brand lock", async () => {
+    generateContentAIImagesMock.mockResolvedValue(makeVariants());
+    const user = userEvent.setup();
+
+    renderPage();
+    await waitFor(() => expect(fetchBrandsMock).toHaveBeenCalled());
+    await screen.findByLabelText("Describe the image");
+
+    await user.click(screen.getByRole("button", { name: "Portrait 4:5" }));
+    await user.click(screen.getByRole("button", { name: "Bold" }));
+
+    await act(async () => {
+      await user.click(screen.getByRole("button", { name: /Generate 4 variants/ }));
+    });
+
+    await waitFor(() =>
+      expect(generateContentAIImagesMock).toHaveBeenCalledWith(
+        "test-token",
+        "brand-1",
+        expect.objectContaining({
+          aspect_ratio: "4:5",
+          style: "bold",
+          lock_brand_colors: true,
+          count: 4,
+        })
+      )
+    );
+
+    const images = await screen.findAllByRole("img");
+    expect(images).toHaveLength(3);
+    expect(screen.getByText("Generation failed")).toBeInTheDocument();
+  });
+
+  it("unchecks brand lock and passes it through", async () => {
+    generateContentAIImagesMock.mockResolvedValue(makeVariants());
+    const user = userEvent.setup();
+
+    renderPage();
+    await screen.findByLabelText("Describe the image");
+
+    await user.click(screen.getByLabelText("Lock to brand colours and logo"));
+    await act(async () => {
+      await user.click(screen.getByRole("button", { name: /Generate 4 variants/ }));
+    });
+
+    await waitFor(() =>
+      expect(generateContentAIImagesMock).toHaveBeenCalledWith(
+        "test-token",
+        "brand-1",
+        expect.objectContaining({ lock_brand_colors: false })
+      )
+    );
+  });
+});

--- a/apps/web/__tests__/create-post-page.test.tsx
+++ b/apps/web/__tests__/create-post-page.test.tsx
@@ -1,0 +1,130 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { act, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import CreatePostPage from "@/app/create-post/page";
+import { AuthProvider } from "@/lib/auth-context";
+import { BrandProvider } from "@/lib/brand-context";
+import { ToastProvider } from "@/components/ui/Toast";
+import type { PostSummary } from "@/lib/api";
+
+const fetchBrandsMock = vi.fn();
+const fetchRecentPostsMock = vi.fn();
+const createCalendarEventMock = vi.fn();
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return {
+    ...actual,
+    fetchBrands: (...args: unknown[]) => fetchBrandsMock(...args),
+    fetchRecentPosts: (...args: unknown[]) => fetchRecentPostsMock(...args),
+    createCalendarEvent: (...args: unknown[]) => createCalendarEventMock(...args),
+  };
+});
+
+const BRANDS = [
+  {
+    id: "brand-1",
+    organization_id: "org-1",
+    name: "Acme Co",
+    industry: null,
+    logo_url: null,
+    target_audience: null,
+    colors: null,
+    tone_descriptors: null,
+    product_catalog: null,
+    brand_report: null,
+    created_at: "2026-01-01",
+    updated_at: "2026-01-01",
+  },
+];
+
+function makePost(overrides: Partial<PostSummary> = {}): PostSummary {
+  return {
+    id: "post-1",
+    brand_id: "brand-1",
+    calendar_event_id: "event-1",
+    current_pipeline_stage: "completed",
+    body_text: { linkedin: "Check out our new widget line!" },
+    created_at: "2026-08-20T10:00:00Z",
+    updated_at: "2026-08-20T10:00:00Z",
+    ...overrides,
+  };
+}
+
+function renderPage() {
+  return render(
+    <ToastProvider>
+      <AuthProvider>
+        <BrandProvider>
+          <CreatePostPage />
+        </BrandProvider>
+      </AuthProvider>
+    </ToastProvider>
+  );
+}
+
+describe("CreatePostPage", () => {
+  beforeEach(() => {
+    fetchBrandsMock.mockReset();
+    fetchRecentPostsMock.mockReset();
+    createCalendarEventMock.mockReset();
+
+    window.localStorage.clear();
+    window.localStorage.setItem("raindeer.auth.token", "test-token");
+
+    fetchBrandsMock.mockResolvedValue(BRANDS);
+    fetchRecentPostsMock.mockResolvedValue([]);
+  });
+
+  it("shows a real Blocked status for a rejected post in recent runs", async () => {
+    fetchRecentPostsMock.mockResolvedValue([
+      makePost({ id: "post-rejected", current_pipeline_stage: "rejected" }),
+      makePost({ id: "post-done", current_pipeline_stage: "completed" }),
+    ]);
+
+    renderPage();
+
+    await waitFor(() => expect(fetchRecentPostsMock).toHaveBeenCalledWith("test-token", "brand-1"));
+    expect(await screen.findByText("Blocked")).toBeInTheDocument();
+    expect(screen.getByText("Completed")).toBeInTheDocument();
+  });
+
+  it("queues a post via the real calendar-event endpoint and refreshes recent runs", async () => {
+    createCalendarEventMock.mockResolvedValue({});
+    const user = userEvent.setup();
+
+    renderPage();
+    await waitFor(() => expect(fetchRecentPostsMock).toHaveBeenCalledTimes(1));
+
+    await user.click(screen.getByRole("button", { name: "X" }));
+
+    await act(async () => {
+      await user.click(screen.getByRole("button", { name: /Run all agents/ }));
+    });
+
+    await waitFor(() => expect(createCalendarEventMock).toHaveBeenCalledTimes(1));
+    const [token, brandId, payload] = createCalendarEventMock.mock.calls[0];
+    expect(token).toBe("test-token");
+    expect(brandId).toBe("brand-1");
+    expect(payload.target_platforms).toEqual(expect.arrayContaining(["linkedin", "x"]));
+    expect(typeof payload.target_datetime).toBe("string");
+
+    await waitFor(() => expect(fetchRecentPostsMock).toHaveBeenCalledTimes(2));
+  });
+
+  it("requires at least one platform before queuing", async () => {
+    const user = userEvent.setup();
+    renderPage();
+    await waitFor(() => expect(fetchRecentPostsMock).toHaveBeenCalled());
+
+    // LinkedIn starts selected by default — deselect it to leave none.
+    await user.click(screen.getByRole("button", { name: "LinkedIn" }));
+
+    await act(async () => {
+      await user.click(screen.getByRole("button", { name: /Run all agents/ }));
+    });
+
+    expect(await screen.findByText(/Select at least one platform/)).toBeInTheDocument();
+    expect(createCalendarEventMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/__tests__/creative-page.test.tsx
+++ b/apps/web/__tests__/creative-page.test.tsx
@@ -1,0 +1,113 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { act, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import CreativePage from "@/app/creative/page";
+import { AuthProvider } from "@/lib/auth-context";
+import { BrandProvider } from "@/lib/brand-context";
+import { ToastProvider } from "@/components/ui/Toast";
+import type { CreativeAngle } from "@/lib/api";
+
+const fetchBrandsMock = vi.fn();
+const generateCreativeAnglesMock = vi.fn();
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return {
+    ...actual,
+    fetchBrands: (...args: unknown[]) => fetchBrandsMock(...args),
+    generateCreativeAngles: (...args: unknown[]) => generateCreativeAnglesMock(...args),
+  };
+});
+
+const BRANDS = [
+  {
+    id: "brand-1",
+    organization_id: "org-1",
+    name: "Acme Co",
+    industry: null,
+    logo_url: null,
+    target_audience: null,
+    colors: null,
+    tone_descriptors: null,
+    product_catalog: null,
+    brand_report: null,
+    created_at: "2026-01-01",
+    updated_at: "2026-01-01",
+  },
+];
+
+function makeAngles(count = 6): CreativeAngle[] {
+  return Array.from({ length: count }, (_, i) => ({
+    format: `Format ${i}`,
+    angle: `Angle ${i}`,
+    hook: `Hook number ${i}`,
+    why: `Why this works ${i}`,
+    cta: `CTA ${i}`,
+    score: 90 - i,
+  }));
+}
+
+function renderPage() {
+  return render(
+    <ToastProvider>
+      <AuthProvider>
+        <BrandProvider>
+          <CreativePage />
+        </BrandProvider>
+      </AuthProvider>
+    </ToastProvider>
+  );
+}
+
+describe("CreativePage", () => {
+  beforeEach(() => {
+    fetchBrandsMock.mockReset();
+    generateCreativeAnglesMock.mockReset();
+
+    window.localStorage.clear();
+    window.localStorage.setItem("raindeer.auth.token", "test-token");
+
+    fetchBrandsMock.mockResolvedValue(BRANDS);
+  });
+
+  it("generates and renders 6 angle cards from the brief", async () => {
+    generateCreativeAnglesMock.mockResolvedValue(makeAngles());
+    const user = userEvent.setup();
+
+    renderPage();
+
+    await waitFor(() => expect(fetchBrandsMock).toHaveBeenCalled());
+    await screen.findByLabelText("Creative brief");
+
+    await act(async () => {
+      await user.click(screen.getByRole("button", { name: "Generate all 6 →" }));
+    });
+
+    await waitFor(() =>
+      expect(generateCreativeAnglesMock).toHaveBeenCalledWith(
+        "test-token",
+        "brand-1",
+        expect.any(String)
+      )
+    );
+
+    expect(await screen.findByText("Hook number 0")).toBeInTheDocument();
+    expect(screen.getByText("Hook number 5")).toBeInTheDocument();
+    expect(screen.getAllByText(/Why this works/).length).toBe(6);
+  });
+
+  it("shows an error and no cards when generation fails", async () => {
+    generateCreativeAnglesMock.mockRejectedValue(new Error("LLM unreachable"));
+    const user = userEvent.setup();
+
+    renderPage();
+    await screen.findByLabelText("Creative brief");
+
+    await act(async () => {
+      await user.click(screen.getByRole("button", { name: "Generate all 6 →" }));
+    });
+
+    expect(await screen.findByText("LLM unreachable")).toBeInTheDocument();
+    expect(screen.queryByText(/Hook number/)).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/__tests__/research-page.test.tsx
+++ b/apps/web/__tests__/research-page.test.tsx
@@ -1,0 +1,121 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { act, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import ResearchPage from "@/app/research/page";
+import { AuthProvider } from "@/lib/auth-context";
+import { BrandProvider } from "@/lib/brand-context";
+import { ToastProvider } from "@/components/ui/Toast";
+import type { ResearchRun } from "@/lib/api";
+
+const fetchBrandsMock = vi.fn();
+const fetchLatestResearchMock = vi.fn();
+const runResearchMock = vi.fn();
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return {
+    ...actual,
+    fetchBrands: (...args: unknown[]) => fetchBrandsMock(...args),
+    fetchLatestResearch: (...args: unknown[]) => fetchLatestResearchMock(...args),
+    runResearch: (...args: unknown[]) => runResearchMock(...args),
+  };
+});
+
+const BRANDS = [
+  {
+    id: "brand-1",
+    organization_id: "org-1",
+    name: "Acme Co",
+    industry: null,
+    logo_url: null,
+    target_audience: null,
+    colors: null,
+    tone_descriptors: null,
+    product_catalog: null,
+    brand_report: null,
+    created_at: "2026-01-01",
+    updated_at: "2026-01-01",
+  },
+];
+
+function makeRun(overrides: Partial<ResearchRun> = {}): ResearchRun {
+  return {
+    id: "run-1",
+    post_id: "post-1",
+    brand_id: "brand-1",
+    created_at: "2026-08-20T10:00:00Z",
+    brief: {
+      post_id: "post-1",
+      brand_context: [],
+      platform_trends: {
+        linkedin: [
+          { title: "DPDP deadline is reshaping compliance content", url: "https://example.com/a", content: "Founders are posting about it." },
+        ],
+      },
+      industry_trends: [
+        { title: "Legal tech funding up 40%", url: "https://news.example.com/b", content: "Investment trend." },
+      ],
+      timing_signal: {
+        researched_at: "2026-08-20T09:55:00Z",
+        platforms: ["linkedin"],
+        trending_topics: ["DPDP deadline", "diligence failure rate"],
+        target_datetime: null,
+      },
+    },
+    ...overrides,
+  };
+}
+
+function renderPage() {
+  return render(
+    <ToastProvider>
+      <AuthProvider>
+        <BrandProvider>
+          <ResearchPage />
+        </BrandProvider>
+      </AuthProvider>
+    </ToastProvider>
+  );
+}
+
+describe("ResearchPage", () => {
+  beforeEach(() => {
+    fetchBrandsMock.mockReset();
+    fetchLatestResearchMock.mockReset();
+    runResearchMock.mockReset();
+
+    window.localStorage.clear();
+    window.localStorage.setItem("raindeer.auth.token", "test-token");
+
+    fetchBrandsMock.mockResolvedValue(BRANDS);
+    fetchLatestResearchMock.mockResolvedValue(null);
+  });
+
+  it("shows an empty state and lets the user run research for the first time", async () => {
+    const user = userEvent.setup();
+    runResearchMock.mockResolvedValue(makeRun());
+
+    renderPage();
+
+    await waitFor(() => expect(fetchLatestResearchMock).toHaveBeenCalledWith("test-token", "brand-1"));
+    expect(await screen.findByText(/No research yet/)).toBeInTheDocument();
+
+    await act(async () => {
+      await user.click(screen.getAllByRole("button", { name: /Run new research/ })[0]);
+    });
+
+    await waitFor(() => expect(runResearchMock).toHaveBeenCalledWith("test-token", "brand-1"));
+    expect(await screen.findByText(/DPDP deadline is reshaping compliance content/)).toBeInTheDocument();
+    expect(screen.getByText(/Legal tech funding up 40%/)).toBeInTheDocument();
+    expect(screen.getByText("diligence failure rate")).toBeInTheDocument();
+  });
+
+  it("renders trend cards from the most recent research on load", async () => {
+    fetchLatestResearchMock.mockResolvedValue(makeRun());
+
+    renderPage();
+
+    expect(await screen.findByText(/DPDP deadline is reshaping compliance content/)).toBeInTheDocument();
+    expect(screen.getAllByText("linkedin").length).toBeGreaterThan(0);
+  });
+});

--- a/apps/web/app/content-ai/page.tsx
+++ b/apps/web/app/content-ai/page.tsx
@@ -1,0 +1,231 @@
+"use client";
+
+import { useState } from "react";
+import { generateContentAIImages, type ContentAIVariant } from "@/lib/api";
+import { useAuth } from "@/lib/auth-context";
+import { useBrand } from "@/lib/brand-context";
+import { Button } from "@/components/ui/Button";
+import { Card } from "@/components/ui/Card";
+import { cn } from "@/components/ui/cn";
+import { EmptyState } from "@/components/ui/EmptyState";
+import { Field, Textarea } from "@/components/ui/Input";
+import { PageHeader } from "@/components/ui/PageHeader";
+import { Skeleton } from "@/components/ui/Skeleton";
+import { useToast } from "@/components/ui/Toast";
+
+const ASPECT_RATIOS = [
+  { value: "1:1", label: "Square 1:1" },
+  { value: "4:5", label: "Portrait 4:5" },
+  { value: "9:16", label: "Story 9:16" },
+  { value: "16:9", label: "Landscape 16:9" },
+];
+
+const STYLES = [
+  { value: "editorial", label: "Editorial" },
+  { value: "minimal", label: "Minimal" },
+  { value: "bold", label: "Bold" },
+  { value: "photographic", label: "Photographic" },
+  { value: "illustrated", label: "Illustrated" },
+];
+
+const DEFAULT_PROMPT =
+  "Editorial typographic card, deep navy, one bold statistic, thin grid lines, no stock photography.";
+const VARIANT_COUNT = 4;
+
+function ChipButton({
+  active,
+  onClick,
+  children,
+}: {
+  active: boolean;
+  onClick: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        "rounded-[9px] border px-2.5 py-1.5 text-[12.5px] font-semibold transition-colors",
+        active
+          ? "border-brand-600 bg-brand-50 text-brand-700"
+          : "border-line bg-white text-ink-600 hover:bg-canvas",
+      )}
+    >
+      {children}
+    </button>
+  );
+}
+
+export default function ContentAIPage() {
+  const { token } = useAuth();
+  const { selectedBrand, selectedBrandId } = useBrand();
+  const { push } = useToast();
+
+  const [prompt, setPrompt] = useState(DEFAULT_PROMPT);
+  const [aspectRatio, setAspectRatio] = useState(ASPECT_RATIOS[0].value);
+  const [style, setStyle] = useState(STYLES[0].value);
+  const [lockBrandColors, setLockBrandColors] = useState(true);
+  const [variants, setVariants] = useState<ContentAIVariant[]>([]);
+  const [isGenerating, setIsGenerating] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleGenerate() {
+    if (!token || !selectedBrandId) return;
+    if (!prompt.trim()) {
+      setError("Describe the image first.");
+      return;
+    }
+
+    setIsGenerating(true);
+    setError(null);
+    try {
+      const result = await generateContentAIImages(token, selectedBrandId, {
+        prompt,
+        aspect_ratio: aspectRatio,
+        style,
+        lock_brand_colors: lockBrandColors,
+        count: VARIANT_COUNT,
+      });
+      setVariants(result);
+      const failed = result.filter((v) => v.status === "failed").length;
+      if (failed > 0) {
+        push(`${failed} of ${result.length} variants failed to generate`, "error");
+      } else {
+        push("Generated 4 variants", "success");
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Failed to generate images";
+      setError(message);
+      push(message, "error");
+    } finally {
+      setIsGenerating(false);
+    }
+  }
+
+  return (
+    <div>
+      <PageHeader
+        title="Content AI"
+        description="Straight to the visual. Pick a style, describe the image, get variants built around it."
+      />
+
+      {!selectedBrand ? (
+        <EmptyState title="No brand selected" description="Select a brand to generate images for it." />
+      ) : (
+        <div className="grid grid-cols-1 gap-4 lg:grid-cols-[320px_minmax(0,1fr)]">
+          <Card className="flex h-fit flex-col gap-4 p-4">
+            <div>
+              <div className="mb-2 text-xs font-bold text-ink-600">Aspect ratio</div>
+              <div className="flex flex-wrap gap-1.5">
+                {ASPECT_RATIOS.map((option) => (
+                  <ChipButton
+                    key={option.value}
+                    active={aspectRatio === option.value}
+                    onClick={() => setAspectRatio(option.value)}
+                  >
+                    {option.label}
+                  </ChipButton>
+                ))}
+              </div>
+            </div>
+
+            <Field label="Describe the image" htmlFor="content-ai-prompt">
+              <Textarea
+                id="content-ai-prompt"
+                value={prompt}
+                onChange={(event) => setPrompt(event.target.value)}
+                rows={4}
+              />
+            </Field>
+
+            <div>
+              <div className="mb-2 text-xs font-bold text-ink-600">Style</div>
+              <div className="flex flex-wrap gap-1.5">
+                {STYLES.map((option) => (
+                  <ChipButton
+                    key={option.value}
+                    active={style === option.value}
+                    onClick={() => setStyle(option.value)}
+                  >
+                    {option.label}
+                  </ChipButton>
+                ))}
+              </div>
+            </div>
+
+            <label className="flex items-center gap-2.5 rounded-[11px] border border-brand-100 bg-brand-50 px-3 py-2.5 text-[12.5px] text-ink-700">
+              <input
+                type="checkbox"
+                checked={lockBrandColors}
+                onChange={(event) => setLockBrandColors(event.target.checked)}
+                className="h-[15px] w-[15px] accent-brand-600"
+              />
+              Lock to brand colours and logo
+            </label>
+
+            {error && (
+              <p role="alert" className="text-sm font-medium text-danger">
+                {error}
+              </p>
+            )}
+
+            <Button onClick={handleGenerate} isLoading={isGenerating} className="h-11 w-full">
+              Generate {VARIANT_COUNT} variants
+            </Button>
+          </Card>
+
+          <div>
+            {isGenerating ? (
+              <div role="status" aria-live="polite" className="grid grid-cols-1 gap-3.5 sm:grid-cols-2">
+                <span className="sr-only">Generating images…</span>
+                {Array.from({ length: VARIANT_COUNT }).map((_, i) => (
+                  <Skeleton key={i} className="aspect-square w-full rounded-2xl" />
+                ))}
+              </div>
+            ) : variants.length === 0 ? (
+              <EmptyState
+                title="No variants yet"
+                description="Generate 4 variants to see real images produced by the image-generation pipeline."
+              />
+            ) : (
+              <ul className="grid grid-cols-1 gap-3.5 sm:grid-cols-2">
+                {variants.map((variant, index) => (
+                  <li key={index}>
+                    <Card className="overflow-hidden">
+                      {variant.status === "generated" && variant.url ? (
+                        // eslint-disable-next-line @next/next/no-img-element
+                        <img
+                          src={variant.url}
+                          alt={`Generated variant ${index + 1}`}
+                          className="aspect-square w-full object-cover"
+                        />
+                      ) : (
+                        <div className="flex aspect-square w-full items-center justify-center bg-canvas text-sm font-medium text-ink-300">
+                          Generation failed
+                        </div>
+                      )}
+                      <div className="flex items-center gap-2 p-3">
+                        <span className="text-[11.5px] text-ink-300">Variant {index + 1}</span>
+                        {variant.status === "generated" && variant.url ? (
+                          <a
+                            href={variant.url}
+                            target="_blank"
+                            rel="noreferrer"
+                            className="ml-auto text-[11.5px] font-bold text-brand-600 hover:underline"
+                          >
+                            Use this
+                          </a>
+                        ) : null}
+                      </div>
+                    </Card>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/app/create-post/page.tsx
+++ b/apps/web/app/create-post/page.tsx
@@ -1,0 +1,241 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import {
+  createCalendarEvent,
+  fetchRecentPosts,
+  type PipelineStage,
+  type PostSummary,
+} from "@/lib/api";
+import { useAuth } from "@/lib/auth-context";
+import { useBrand } from "@/lib/brand-context";
+import { Badge, type BadgeTone } from "@/components/ui/Badge";
+import { Button } from "@/components/ui/Button";
+import { Card } from "@/components/ui/Card";
+import { cn } from "@/components/ui/cn";
+import { EmptyState } from "@/components/ui/EmptyState";
+import { Field, Select, Textarea } from "@/components/ui/Input";
+import { PageHeader } from "@/components/ui/PageHeader";
+import { Skeleton } from "@/components/ui/Skeleton";
+import { useToast } from "@/components/ui/Toast";
+
+// Kept in sync with apps/api/models/content_calendar_event.py::SUPPORTED_PLATFORMS
+// — same list apps/web/app/calendar/event-form.tsx uses.
+const PLATFORM_OPTIONS: { value: string; label: string }[] = [
+  { value: "linkedin", label: "LinkedIn" },
+  { value: "x", label: "X" },
+];
+
+const FORMAT_OPTIONS = ["text", "image", "video", "carousel"];
+
+const DEFAULT_BRIEF =
+  "Post about our new contract-review turnaround — 11 days to 40 minutes. Founder voice, not corporate.";
+
+// current_pipeline_stage -> what the Create Post page shows. "rejected" is
+// the real terminal stage a human reviewer's rejection sets (Issue #25,
+// apps/api/routers/review.py::reject_post) — "Blocked" is just this page's
+// label for it, not an invented backend status.
+const STAGE_DISPLAY: Record<PipelineStage, { label: string; tone: BadgeTone }> = {
+  research: { label: "Researching", tone: "blue" },
+  creative: { label: "Writing angles", tone: "blue" },
+  generation: { label: "Generating", tone: "blue" },
+  reviewer: { label: "AI review", tone: "blue" },
+  human_review: { label: "Awaiting review", tone: "amber" },
+  scheduler: { label: "Scheduling", tone: "blue" },
+  publisher: { label: "Publishing", tone: "blue" },
+  analytics_collector: { label: "Publishing", tone: "blue" },
+  completed: { label: "Completed", tone: "green" },
+  rejected: { label: "Blocked", tone: "red" },
+  failed: { label: "Failed", tone: "red" },
+};
+
+function summaryTitle(post: PostSummary): string {
+  const firstPlatform = post.body_text ? Object.values(post.body_text)[0] : null;
+  if (firstPlatform) return firstPlatform.slice(0, 80);
+  return `Post ${post.id.slice(0, 8)}`;
+}
+
+export default function CreatePostPage() {
+  const { token } = useAuth();
+  const { selectedBrand, selectedBrandId } = useBrand();
+  const { push } = useToast();
+
+  const [brief, setBrief] = useState(DEFAULT_BRIEF);
+  const [platforms, setPlatforms] = useState<string[]>(["linkedin"]);
+  const [format, setFormat] = useState(FORMAT_OPTIONS[0]);
+  const [isRunning, setIsRunning] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const [runs, setRuns] = useState<PostSummary[]>([]);
+  const [isLoadingRuns, setIsLoadingRuns] = useState(false);
+
+  const loadRuns = useCallback(async () => {
+    if (!token || !selectedBrandId) {
+      setRuns([]);
+      return;
+    }
+    setIsLoadingRuns(true);
+    try {
+      const result = await fetchRecentPosts(token, selectedBrandId);
+      setRuns(result);
+    } catch {
+      // Recent runs is a convenience list — a failed refresh shouldn't
+      // block the compose form above it.
+    } finally {
+      setIsLoadingRuns(false);
+    }
+  }, [token, selectedBrandId]);
+
+  useEffect(() => {
+    loadRuns();
+  }, [loadRuns]);
+
+  function togglePlatform(value: string) {
+    setPlatforms((current) => (current.includes(value) ? current.filter((p) => p !== value) : [...current, value]));
+  }
+
+  async function handleRunAllAgents() {
+    if (!token || !selectedBrandId) return;
+    if (platforms.length === 0) {
+      setError("Select at least one platform.");
+      return;
+    }
+    if (!brief.trim()) {
+      setError("Describe the post first.");
+      return;
+    }
+
+    setIsRunning(true);
+    setError(null);
+    try {
+      // Reuses the real calendar-event creation endpoint (Issue #26) with
+      // an immediate target_datetime — apps/api/services/pipeline
+      // trigger.py's Celery Beat poller (Issue #29) picks up any event
+      // within its lead time and starts the real 5-stage pipeline for it,
+      // the same path a normal scheduled post takes.
+      await createCalendarEvent(token, selectedBrandId, {
+        title: brief.slice(0, 120),
+        description: brief,
+        target_platforms: platforms,
+        desired_format: format,
+        target_datetime: new Date().toISOString(),
+      });
+      push("Queued — all agents will run shortly", "success");
+      loadRuns();
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Failed to queue post";
+      setError(message);
+      push(message, "error");
+    } finally {
+      setIsRunning(false);
+    }
+  }
+
+  return (
+    <div>
+      <PageHeader
+        title="Create a post"
+        description="Describe it, pick platforms, and all agents run together on the real pipeline."
+      />
+
+      {!selectedBrand ? (
+        <EmptyState title="No brand selected" description="Select a brand to create a post for it." />
+      ) : (
+        <>
+          <Card className="mb-6 p-5">
+            <Field label="Brief" htmlFor="create-post-brief">
+              <Textarea
+                id="create-post-brief"
+                value={brief}
+                onChange={(event) => setBrief(event.target.value)}
+                rows={4}
+              />
+            </Field>
+
+            <div className="mt-4 flex flex-wrap items-center gap-2.5 border-t border-line-faint pt-4">
+              {PLATFORM_OPTIONS.map((option) => {
+                const active = platforms.includes(option.value);
+                return (
+                  <button
+                    key={option.value}
+                    type="button"
+                    onClick={() => togglePlatform(option.value)}
+                    aria-pressed={active}
+                    className={cn(
+                      "rounded-[9px] border px-2.5 py-1.5 text-[12.5px] font-semibold transition-colors",
+                      active
+                        ? "border-brand-600 bg-brand-50 text-brand-700"
+                        : "border-line bg-white text-ink-600 hover:bg-canvas",
+                    )}
+                  >
+                    {option.label}
+                  </button>
+                );
+              })}
+
+              <Select
+                value={format}
+                onChange={(event) => setFormat(event.target.value)}
+                aria-label="Desired format"
+                className="ml-1 h-9 w-auto"
+              >
+                {FORMAT_OPTIONS.map((option) => (
+                  <option key={option} value={option}>
+                    {option}
+                  </option>
+                ))}
+              </Select>
+
+              <Button onClick={handleRunAllAgents} isLoading={isRunning} className="ml-auto">
+                ✧ Run all agents
+              </Button>
+            </div>
+
+            {error && (
+              <p role="alert" className="mt-3 text-sm font-medium text-danger">
+                {error}
+              </p>
+            )}
+          </Card>
+
+          <div className="mb-3 flex items-center gap-2.5">
+            <span className="text-[11.5px] font-extrabold tracking-[0.1em] text-ink-300">RECENT RUNS</span>
+            <div className="h-px flex-1 bg-line-faint" />
+          </div>
+
+          {isLoadingRuns && runs.length === 0 ? (
+            <div role="status" aria-live="polite" className="space-y-2.5">
+              <span className="sr-only">Loading recent runs…</span>
+              {[0, 1, 2].map((i) => (
+                <Skeleton key={i} className="h-16 w-full rounded-[13px]" />
+              ))}
+            </div>
+          ) : runs.length === 0 ? (
+            <EmptyState title="No runs yet" description="Posts you create will show up here." />
+          ) : (
+            <ul className="flex flex-col gap-2.5">
+              {runs.map((post) => {
+                const display = STAGE_DISPLAY[post.current_pipeline_stage];
+                return (
+                  <li key={post.id}>
+                    <Card className="flex items-center gap-3.5 p-3.5">
+                      <div className="min-w-0 flex-1">
+                        <div className="truncate text-[13.5px] font-semibold text-ink-950">
+                          {summaryTitle(post)}
+                        </div>
+                        <div className="mt-0.5 text-[11.5px] text-ink-300">
+                          {new Date(post.created_at).toLocaleString()}
+                        </div>
+                      </div>
+                      <Badge tone={display.tone}>{display.label}</Badge>
+                    </Card>
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/apps/web/app/creative/page.tsx
+++ b/apps/web/app/creative/page.tsx
@@ -1,0 +1,139 @@
+"use client";
+
+import { useState } from "react";
+import { generateCreativeAngles, type CreativeAngle } from "@/lib/api";
+import { useAuth } from "@/lib/auth-context";
+import { useBrand } from "@/lib/brand-context";
+import { Button } from "@/components/ui/Button";
+import { Card } from "@/components/ui/Card";
+import { EmptyState } from "@/components/ui/EmptyState";
+import { Field, Textarea } from "@/components/ui/Input";
+import { PageHeader } from "@/components/ui/PageHeader";
+import { Skeleton } from "@/components/ui/Skeleton";
+import { useToast } from "@/components/ui/Toast";
+
+const DEFAULT_BRIEF =
+  "Post about our new contract-review turnaround — 11 days to 40 minutes. Founder voice, not corporate.";
+
+export default function CreativePage() {
+  const { token } = useAuth();
+  const { selectedBrand, selectedBrandId } = useBrand();
+  const { push } = useToast();
+
+  const [brief, setBrief] = useState(DEFAULT_BRIEF);
+  const [angles, setAngles] = useState<CreativeAngle[]>([]);
+  const [isGenerating, setIsGenerating] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleGenerate() {
+    if (!token || !selectedBrandId) return;
+    if (!brief.trim()) {
+      setError("Describe what this post should be about first.");
+      return;
+    }
+
+    setIsGenerating(true);
+    setError(null);
+    try {
+      const result = await generateCreativeAngles(token, selectedBrandId, brief);
+      setAngles(result);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Failed to generate angles";
+      setError(message);
+      push(message, "error");
+    } finally {
+      setIsGenerating(false);
+    }
+  }
+
+  return (
+    <div>
+      <PageHeader
+        title={
+          <span className="flex items-center gap-2.5">
+            <span className="flex h-8 w-8 items-center justify-center rounded-[10px] bg-gradient-to-br from-agent-keshav-from to-agent-keshav-to text-xs font-extrabold text-white">
+              K
+            </span>
+            Creative · Keshav
+          </span>
+        }
+        description="Turns a brief into angles that sound like you. Pick one, or generate all six."
+        action={
+          <Button onClick={handleGenerate} isLoading={isGenerating} disabled={!selectedBrand}>
+            Generate all 6 →
+          </Button>
+        }
+      />
+
+      {!selectedBrand ? (
+        <EmptyState title="No brand selected" description="Select a brand to generate angles for it." />
+      ) : (
+        <>
+          <Card className="mb-5 p-5">
+            <Field label="Creative brief" htmlFor="creative-brief">
+              <Textarea
+                id="creative-brief"
+                value={brief}
+                onChange={(event) => setBrief(event.target.value)}
+                rows={4}
+              />
+            </Field>
+            {error && (
+              <p role="alert" className="mt-2 text-sm font-medium text-danger">
+                {error}
+              </p>
+            )}
+          </Card>
+
+          {isGenerating ? (
+            <div role="status" aria-live="polite" className="grid grid-cols-1 gap-3.5 sm:grid-cols-2 lg:grid-cols-3">
+              <span className="sr-only">Generating angles…</span>
+              {[0, 1, 2, 3, 4, 5].map((i) => (
+                <Card key={i} className="space-y-3 p-4">
+                  <Skeleton className="h-4 w-20" />
+                  <Skeleton className="h-10 w-full" />
+                  <Skeleton className="h-3 w-full" />
+                </Card>
+              ))}
+            </div>
+          ) : angles.length === 0 ? (
+            <EmptyState
+              title="No angles yet"
+              description="Generate all 6 to see distinct angle/format cards for this brief."
+            />
+          ) : (
+            <ul className="grid grid-cols-1 gap-3.5 sm:grid-cols-2 lg:grid-cols-3">
+              {angles.map((angle, index) => (
+                <li key={`${angle.format}-${index}`}>
+                  <Card className="flex h-full flex-col overflow-hidden">
+                    <div className="flex items-center gap-2 border-b border-line-faint px-4 py-3">
+                      <span className="rounded-[5px] bg-agent-keshav-solid px-1.5 py-0.5 text-[9.5px] font-extrabold text-white">
+                        K
+                      </span>
+                      <span className="text-[11.5px] font-semibold text-ink-500">{angle.format}</span>
+                      <span className="ml-auto text-[11.5px] font-extrabold text-agent-keshav-solid">
+                        {angle.score}
+                      </span>
+                    </div>
+                    <div className="flex flex-1 flex-col gap-2.5 p-4">
+                      <p className="font-serif text-[19px] italic leading-tight text-ink-950">
+                        {angle.hook}
+                      </p>
+                      <p className="text-[12.5px] leading-relaxed text-ink-500">{angle.why}</p>
+                      <div className="mt-auto flex items-center gap-1.5 pt-2">
+                        <span className="rounded-[6px] bg-violet-bg px-1.5 py-0.5 text-[11px] font-bold text-violet">
+                          {angle.cta}
+                        </span>
+                        <span className="ml-auto text-[11px] font-medium text-ink-300">{angle.angle}</span>
+                      </div>
+                    </div>
+                  </Card>
+                </li>
+              ))}
+            </ul>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/apps/web/app/research/page.tsx
+++ b/apps/web/app/research/page.tsx
@@ -1,0 +1,218 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { fetchLatestResearch, runResearch, type ResearchRun } from "@/lib/api";
+import { useAuth } from "@/lib/auth-context";
+import { useBrand } from "@/lib/brand-context";
+import { Badge } from "@/components/ui/Badge";
+import { Button } from "@/components/ui/Button";
+import { Card, CardBody } from "@/components/ui/Card";
+import { EmptyState } from "@/components/ui/EmptyState";
+import { PageHeader } from "@/components/ui/PageHeader";
+import { Skeleton } from "@/components/ui/Skeleton";
+import { useToast } from "@/components/ui/Toast";
+
+interface TrendItem {
+  platform: string | null;
+  title: string;
+  content: string;
+  url: string;
+}
+
+function domainOf(url: string): string {
+  try {
+    return new URL(url).hostname.replace(/^www\./, "");
+  } catch {
+    return url;
+  }
+}
+
+function trendItemsFrom(run: ResearchRun): TrendItem[] {
+  const items: TrendItem[] = [];
+  for (const [platform, results] of Object.entries(run.brief.platform_trends ?? {})) {
+    for (const result of results) {
+      items.push({ platform, ...result });
+    }
+  }
+  for (const result of run.brief.industry_trends ?? []) {
+    items.push({ platform: null, ...result });
+  }
+  return items;
+}
+
+export default function ResearchPage() {
+  const { token } = useAuth();
+  const { selectedBrand, selectedBrandId } = useBrand();
+  const { push } = useToast();
+
+  const [run, setRun] = useState<ResearchRun | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [isRunning, setIsRunning] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    if (!token || !selectedBrandId) {
+      setRun(null);
+      return;
+    }
+    setIsLoading(true);
+    setError(null);
+    try {
+      const result = await fetchLatestResearch(token, selectedBrandId);
+      setRun(result);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load research");
+    } finally {
+      setIsLoading(false);
+    }
+  }, [token, selectedBrandId]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  async function handleRun() {
+    if (!token || !selectedBrandId) return;
+    setIsRunning(true);
+    try {
+      const result = await runResearch(token, selectedBrandId);
+      setRun(result);
+      push("Research complete", "success");
+    } catch (err) {
+      push(err instanceof Error ? err.message : "Failed to run research", "error");
+    } finally {
+      setIsRunning(false);
+    }
+  }
+
+  const trendItems = run ? trendItemsFrom(run) : [];
+
+  return (
+    <div>
+      <PageHeader
+        title={
+          <span className="flex items-center gap-2.5">
+            <span className="flex h-8 w-8 items-center justify-center rounded-[10px] bg-gradient-to-br from-agent-ved-from to-agent-ved-to text-xs font-extrabold text-white">
+              V
+            </span>
+            Research · Ved
+          </span>
+        }
+        description={
+          <>
+            Reads the whole internet on your category, then tells you only what changes a
+            post. Showing data for:{" "}
+            <strong className="font-medium text-slate-700">
+              {selectedBrand ? selectedBrand.name : "no brand selected"}
+            </strong>
+          </>
+        }
+        action={
+          <Button onClick={handleRun} isLoading={isRunning} disabled={!selectedBrand}>
+            Run new research →
+          </Button>
+        }
+      />
+
+      {error && (
+        <p role="alert" className="mb-4 rounded-lg bg-red-50 px-3 py-2 text-sm font-medium text-red-700">
+          {error}
+        </p>
+      )}
+
+      {!selectedBrand ? (
+        <EmptyState title="No brand selected" description="Select a brand to run research for it." />
+      ) : isLoading ? (
+        <div role="status" aria-live="polite" className="space-y-3">
+          <span className="sr-only">Loading research…</span>
+          {[0, 1, 2].map((i) => (
+            <Card key={i} className="space-y-2 p-5">
+              <Skeleton className="h-4 w-24" />
+              <Skeleton className="h-3 w-48" />
+              <Skeleton className="h-16 w-full" />
+            </Card>
+          ))}
+        </div>
+      ) : !run || trendItems.length === 0 ? (
+        <EmptyState
+          title="No research yet"
+          description="Run research to see trend cards drawn from live search results for this brand's category."
+          action={
+            <Button onClick={handleRun} isLoading={isRunning}>
+              Run new research →
+            </Button>
+          }
+        />
+      ) : (
+        <div className="grid grid-cols-1 gap-4 lg:grid-cols-[minmax(0,1fr)_300px]">
+          <ul className="flex flex-col gap-3">
+            {trendItems.map((item, index) => (
+              <li key={`${item.url}-${index}`}>
+                <Card className="p-4">
+                  <div className="mb-1.5 flex items-center gap-2">
+                    {item.platform ? (
+                      <Badge tone="blue">{item.platform}</Badge>
+                    ) : (
+                      <Badge tone="slate">industry</Badge>
+                    )}
+                    <span className="text-xs text-ink-300">{domainOf(item.url)}</span>
+                  </div>
+                  <h3 className="mb-1.5 text-base font-bold tracking-tight text-ink-950">
+                    {item.title}
+                  </h3>
+                  <p className="mb-3 text-sm leading-relaxed text-ink-500">{item.content}</p>
+                  <a
+                    href={item.url}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="text-xs font-semibold text-brand-600 hover:underline"
+                  >
+                    View source
+                  </a>
+                </Card>
+              </li>
+            ))}
+          </ul>
+
+          <div className="flex flex-col gap-3">
+            <Card className="bg-ink-950 text-white">
+              <CardBody>
+                <div className="mb-2 text-[10.5px] font-extrabold tracking-[0.12em] text-agent-ved-to">
+                  TRENDING TOPICS
+                </div>
+                {run.brief.timing_signal.trending_topics.length > 0 ? (
+                  <ul className="flex flex-col gap-1.5">
+                    {run.brief.timing_signal.trending_topics.map((topic) => (
+                      <li key={topic} className="text-sm leading-relaxed text-white/90">
+                        {topic}
+                      </li>
+                    ))}
+                  </ul>
+                ) : (
+                  <p className="text-sm text-white/70">No standout trending topics this run.</p>
+                )}
+              </CardBody>
+            </Card>
+            <Card>
+              <CardBody>
+                <div className="mb-2.5 text-[11.5px] font-extrabold tracking-[0.1em] text-ink-300">
+                  RESEARCHED
+                </div>
+                <p className="text-sm text-ink-600">
+                  {new Date(run.brief.timing_signal.researched_at).toLocaleString()}
+                </p>
+                <div className="mt-3 flex flex-wrap gap-1.5">
+                  {run.brief.timing_signal.platforms.map((platform) => (
+                    <Badge key={platform} tone="blue">
+                      {platform}
+                    </Badge>
+                  ))}
+                </div>
+              </CardBody>
+            </Card>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/components/nav.tsx
+++ b/apps/web/components/nav.tsx
@@ -86,6 +86,47 @@ function IconReport() {
     </svg>
   );
 }
+function IconResearch() {
+  return (
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+      <circle cx="11" cy="11" r="6.5" stroke="currentColor" strokeWidth="1.8" />
+      <path d="M20 20l-4.8-4.8" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" />
+    </svg>
+  );
+}
+function IconCreative() {
+  return (
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+      <path
+        d="M12 3l2.2 5.4L20 10l-5.4 2.2L12 18l-2.2-5.8L4 10l5.8-1.6L12 3Z"
+        stroke="currentColor"
+        strokeWidth="1.6"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+function IconCreatePost() {
+  return (
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+      <path
+        d="M4 20l1.2-4.6L16.6 3.9a1.6 1.6 0 012.3 0l1.2 1.2a1.6 1.6 0 010 2.3L8.6 18.8 4 20Z"
+        stroke="currentColor"
+        strokeWidth="1.8"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+function IconContentAI() {
+  return (
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+      <rect x="4" y="5" width="16" height="14" rx="2" stroke="currentColor" strokeWidth="1.8" />
+      <circle cx="9" cy="10" r="1.6" stroke="currentColor" strokeWidth="1.6" />
+      <path d="M4 16l5-4 4 3 3-2.5 4 3.5" stroke="currentColor" strokeWidth="1.8" strokeLinejoin="round" />
+    </svg>
+  );
+}
 function IconSettings() {
   return (
     <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden="true">
@@ -101,13 +142,18 @@ function IconSettings() {
 }
 
 // Every route here already exists as a real page. Screens still landing
-// from the mockup migration (Arena, Research, Creative, Create Post,
-// Content AI, Settings) add their own nav entry in their own PR once the
-// page itself exists — keeps this list from linking to 404s in the
-// meantime.
+// from the mockup migration (Arena, Settings) add their own nav entry in
+// their own PR once the page itself exists — keeps this list from linking
+// to 404s in the meantime. Research/Creative/Create Post/Content AI
+// (Issue #126) are the first of those standalone agent-workspace pages to
+// land.
 const NAV_LINKS: { href: string; label: string; icon: () => ReactNode }[] = [
   { href: "/", label: "Dashboard", icon: IconDashboard },
   { href: "/calendar", label: "Calendar", icon: IconCalendar },
+  { href: "/research", label: "Research · Ved", icon: IconResearch },
+  { href: "/creative", label: "Creative · Keshav", icon: IconCreative },
+  { href: "/create-post", label: "Create Post", icon: IconCreatePost },
+  { href: "/content-ai", label: "Content AI", icon: IconContentAI },
   { href: "/review-queue", label: "Review Queue", icon: IconReview },
   { href: "/brands", label: "Brands", icon: IconBrand },
   { href: "/onboarding", label: "Onboarding", icon: IconOnboarding },

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -114,7 +114,12 @@ export interface ReviewFeedback {
   created_at: string;
 }
 
-// Mirrors apps/api/models/post.py::PipelineStage.
+// Mirrors apps/api/models/post.py::PipelineStage. "failed" is set
+// out-of-band by the publish queue (apps/api/services/publish_queue.py)
+// once a publish permanently exhausts its retries — added here alongside
+// Issue #126's Create Post "Recent runs" list (apps/api/schemas/post.py::
+// PostRead), the first place in the web app that surfaces every stage
+// rather than just the ones review-queue/calendar already covered.
 export type PipelineStage =
   | "research"
   | "creative"
@@ -125,7 +130,8 @@ export type PipelineStage =
   | "publisher"
   | "analytics_collector"
   | "completed"
-  | "rejected";
+  | "rejected"
+  | "failed";
 
 // Mirrors apps/api/schemas/review.py::ReviewQueuePostRead.
 export interface ReviewQueuePost {
@@ -841,6 +847,160 @@ export async function fetchPostAnalyticsTrend(
   const query = params.toString();
 
   const res = await fetch(analyticsUrl(brandId, `/posts/${postId}/trend${query ? `?${query}` : ""}`), {
+    headers: authHeaders(token),
+  });
+
+  if (!res.ok) {
+    throw new ApiError(await parseErrorDetail(res), res.status);
+  }
+
+  return res.json();
+}
+
+// --- Research · Ved (Issue #126) ---
+
+// Mirrors apps/api/schemas/research.py::ResearchRunRead. `brief` is
+// exactly what packages/agents/pipeline/nodes/research_engine.py's
+// _research_brief produces: brand_context, platform_trends,
+// industry_trends, timing_signal.
+export interface ResearchRun {
+  id: string;
+  post_id: string;
+  brand_id: string;
+  created_at: string;
+  brief: {
+    post_id: string;
+    brand_context: Array<Record<string, unknown>>;
+    platform_trends: Record<string, Array<{ title: string; url: string; content: string }>>;
+    industry_trends: Array<{ title: string; url: string; content: string }>;
+    timing_signal: {
+      researched_at: string;
+      platforms: string[];
+      trending_topics: string[];
+      target_datetime: string | null;
+    };
+  };
+}
+
+// apps/api/routers/research.py mounts these under /brands/{brand_id}/research
+// — same brand-scoping convention as calendarEventsUrl/reviewQueueUrl above.
+function researchUrl(brandId: string, suffix = ""): string {
+  return `${API_URL}/brands/${brandId}/research${suffix}`;
+}
+
+export async function runResearch(token: string, brandId: string): Promise<ResearchRun> {
+  const res = await fetch(researchUrl(brandId, "/run"), {
+    method: "POST",
+    headers: authHeaders(token),
+  });
+
+  if (!res.ok) {
+    throw new ApiError(await parseErrorDetail(res), res.status);
+  }
+
+  return res.json();
+}
+
+// Returns null (rather than throwing) when no research has been run yet —
+// apps/api/routers/research.py::latest_research 404s in that case, which
+// the Research page treats as its "nothing yet, run one" state.
+export async function fetchLatestResearch(token: string, brandId: string): Promise<ResearchRun | null> {
+  const res = await fetch(researchUrl(brandId, "/latest"), {
+    headers: authHeaders(token),
+  });
+
+  if (res.status === 404) return null;
+  if (!res.ok) {
+    throw new ApiError(await parseErrorDetail(res), res.status);
+  }
+
+  return res.json();
+}
+
+// --- Creative · Keshav (Issue #126) ---
+
+// Mirrors apps/api/schemas/creative.py::CreativeAngleRead.
+export interface CreativeAngle {
+  format: string;
+  angle: string;
+  hook: string;
+  why: string;
+  cta: string;
+  score: number;
+}
+
+export async function generateCreativeAngles(
+  token: string,
+  brandId: string,
+  brief: string
+): Promise<CreativeAngle[]> {
+  const res = await fetch(`${API_URL}/brands/${brandId}/creative/angles`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", ...authHeaders(token) },
+    body: JSON.stringify({ brief }),
+  });
+
+  if (!res.ok) {
+    throw new ApiError(await parseErrorDetail(res), res.status);
+  }
+
+  const data: { angles: CreativeAngle[] } = await res.json();
+  return data.angles;
+}
+
+// --- Content AI (Issue #126) ---
+
+// Mirrors apps/api/schemas/content_ai.py::ContentAIVariantRead.
+export interface ContentAIVariant {
+  status: "generated" | "failed";
+  url: string | null;
+}
+
+// Mirrors apps/api/schemas/content_ai.py::ContentAIGenerateRequest.
+export interface ContentAIGenerateInput {
+  prompt: string;
+  aspect_ratio?: string | null;
+  style?: string | null;
+  lock_brand_colors?: boolean;
+  count?: number;
+}
+
+export async function generateContentAIImages(
+  token: string,
+  brandId: string,
+  payload: ContentAIGenerateInput
+): Promise<ContentAIVariant[]> {
+  const res = await fetch(`${API_URL}/brands/${brandId}/content-ai/generate`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", ...authHeaders(token) },
+    body: JSON.stringify(payload),
+  });
+
+  if (!res.ok) {
+    throw new ApiError(await parseErrorDetail(res), res.status);
+  }
+
+  const data: { variants: ContentAIVariant[] } = await res.json();
+  return data.variants;
+}
+
+// --- Posts / recent runs (Issue #126) ---
+
+// Mirrors apps/api/schemas/post.py::PostRead.
+export interface PostSummary {
+  id: string;
+  brand_id: string;
+  calendar_event_id: string | null;
+  current_pipeline_stage: PipelineStage;
+  body_text: Record<string, string> | null;
+  created_at: string;
+  updated_at: string;
+}
+
+// apps/api/routers/posts.py mounts this under /brands/{brand_id}/posts —
+// same brand-scoping convention as calendarEventsUrl above.
+export async function fetchRecentPosts(token: string, brandId: string, limit = 20): Promise<PostSummary[]> {
+  const res = await fetch(`${API_URL}/brands/${brandId}/posts?limit=${limit}`, {
     headers: authHeaders(token),
   });
 

--- a/packages/agents/pipeline/nodes/creative_engine.py
+++ b/packages/agents/pipeline/nodes/creative_engine.py
@@ -218,6 +218,149 @@ def _creative_brief(db: Session, post: Post, research_brief: dict[str, Any]) -> 
     }
 
 
+ANGLE_COUNT = 6
+REQUIRED_ANGLE_KEYS = ("format", "angle", "hook", "why", "cta", "score")
+
+# Used only when the LLM call/parse fails (see _generate_angles below) —
+# six fixed, still-differentiated angle templates so a degraded "Generate
+# all 6" call still hands the Creative page six distinct cards instead of
+# an error or duplicates.
+_FALLBACK_ANGLES: list[dict[str, Any]] = [
+    {
+        "format": "Text post",
+        "angle": "Thought leadership",
+        "hook": "Open with a counterintuitive insight from the brief.",
+        "why": "Positions the brand as the one that noticed first.",
+        "cta": "Invite readers to share their own take.",
+        "score": 82,
+    },
+    {
+        "format": "Carousel",
+        "angle": "Before / after",
+        "hook": "Lead with the number that changed.",
+        "why": "Concrete before/after numbers outperform generic claims.",
+        "cta": "Prompt a save or share.",
+        "score": 80,
+    },
+    {
+        "format": "Short thread",
+        "angle": "Timely reaction",
+        "hook": "React to the trend named in the brief with a punchy take.",
+        "why": "Rides an existing conversation instead of starting a cold one.",
+        "cta": "Ask a quick, reply-provoking question.",
+        "score": 78,
+    },
+    {
+        "format": "Single image",
+        "angle": "Customer story",
+        "hook": "Open with a real customer's moment of friction.",
+        "why": "Specific stories read as credible, not promotional.",
+        "cta": "Invite readers to learn more.",
+        "score": 77,
+    },
+    {
+        "format": "Video",
+        "angle": "Behind the scenes",
+        "hook": "Show the work, not just the result.",
+        "why": "Process content builds trust competitors' polished posts don't.",
+        "cta": "Encourage comments with questions.",
+        "score": 75,
+    },
+    {
+        "format": "Text post",
+        "angle": "Contrarian take",
+        "hook": "Challenge a common assumption in the industry.",
+        "why": "Disagreement drives more comments than agreement.",
+        "cta": "Ask readers if they agree.",
+        "score": 73,
+    },
+]
+
+
+class CreativeAnglesError(Exception):
+    """Raised when angle generation is asked to run for a Brand that
+    can't be resolved — a programming/data error, not a transient
+    LLM-provider failure, so unlike LLM failures this is not swallowed."""
+
+
+def _fallback_angles(count: int) -> list[dict[str, Any]]:
+    return [dict(angle) for angle in _FALLBACK_ANGLES[:count]]
+
+
+def _build_angles_prompt(brand: Brand, brief_text: str, count: int) -> str:
+    industry = brand.industry or brand.name
+    return f"""You are a senior social media creative strategist. A brand
+has given you a free-form creative brief. Produce {count} genuinely
+distinct content angles for it — different formats, different hooks,
+different strategies — so the brand's team can pick whichever lands best.
+Respond with strict JSON only — no markdown, no commentary, no code fences.
+
+## Brand
+{brand.name} ({industry})
+
+## Creative brief
+{brief_text}
+
+## Task
+Produce a JSON array of exactly {count} objects. Each object must have
+these string keys:
+- "format": the post format (e.g. text post, carousel, short thread, video)
+- "angle": the creative angle/strategy in a few words
+- "hook": the opening line/hook to grab attention
+- "why": one sentence on why this angle should work for this brief
+- "cta": the call to action
+- "score": an integer 0-100 estimating how strong this angle is
+
+No two objects may share the same format+angle combination. Respond with
+ONLY the JSON array. No markdown code fences, no extra text.
+"""
+
+
+def _parse_angles(text: str, count: int) -> list[dict[str, Any]]:
+    parsed = json.loads(_strip_code_fence(text))
+    if not isinstance(parsed, list) or not parsed:
+        raise ValueError("Creative Engine angle output was valid JSON but not a non-empty array")
+
+    result: list[dict[str, Any]] = []
+    for entry in parsed[:count]:
+        if not isinstance(entry, dict):
+            raise ValueError("Creative Engine angle output contained a non-object entry")
+        missing = [key for key in REQUIRED_ANGLE_KEYS if key not in entry]
+        if missing:
+            raise ValueError(f"Creative Engine angle output missing keys: {missing}")
+        result.append(
+            {
+                "format": str(entry["format"]),
+                "angle": str(entry["angle"]),
+                "hook": str(entry["hook"]),
+                "why": str(entry["why"]),
+                "cta": str(entry["cta"]),
+                "score": int(entry["score"]),
+            }
+        )
+    return result
+
+
+def generate_creative_angles(
+    brand: Brand, brief_text: str, count: int = ANGLE_COUNT
+) -> list[dict[str, Any]]:
+    """Issue #126 — the Creative workspace page's "Generate all 6" action.
+    Turns a free-form creative brief straight into `count` distinct angle
+    cards, reusing this module's exact LLMProvider-only, degrade-on-
+    failure contract (see module docstring / _generate_platform_briefs
+    above) rather than a second, client-side implementation. Unlike
+    _creative_brief above, this doesn't require a Post or an upstream
+    research_brief — the Creative page's brief textarea is the only input.
+    """
+    prompt = _build_angles_prompt(brand, brief_text, count)
+    try:
+        response = get_llm_provider().complete(prompt=prompt, model=_default_model(), temperature=0.8)
+        return _parse_angles(response.text, count)
+    except Exception:
+        logger.warning("Creative Engine angle generation failed; using fallback angles", exc_info=True)
+        return _fallback_angles(count)
+
+
 def build_creative_node(db: Session | None):
     """Builds the real "creative" stage node function, closing over `db`.
     Mirrors research_engine.py's build_research_node factory shape/

--- a/packages/agents/pipeline/nodes/generation_engine.py
+++ b/packages/agents/pipeline/nodes/generation_engine.py
@@ -183,6 +183,40 @@ def _generate_image_media(post_id: str, platform: str, platform_brief: dict[str,
     return {"status": "generated", "platform": platform, "format": fmt, "url": stored_url}
 
 
+def generate_standalone_images(
+    prompt: str, count: int = 4, *, path_prefix: str = "adhoc"
+) -> list[dict[str, Any]]:
+    """Issue #126 — the Content AI workspace page's image-first fast path.
+    Generates `count` standalone image variants straight from a free-form
+    prompt, reusing the exact same ImageProvider (Issue #22) +
+    StorageProvider (Issue #11) interface calls _generate_image_media uses
+    for the per-post pipeline — just without a Post/creative-brief
+    context, since Content AI skips copywriting entirely. Same
+    interface-only, degrade-on-failure contract as the rest of this
+    module: a failed variant becomes a {"status": "failed"} entry rather
+    than aborting the whole batch, so one bad call doesn't cost the other
+    variants."""
+    results: list[dict[str, Any]] = []
+    for _ in range(count):
+        try:
+            result = get_image_provider().generate(prompt=prompt)
+            content, content_type = _download_image_bytes(result.url)
+            extension = "png" if "png" in content_type else content_type.split("/")[-1] or "png"
+            path = f"generated/{path_prefix}/{uuid.uuid4().hex}.{extension}"
+            stored_url = get_storage_provider().upload(path, content, content_type)
+        except Exception:
+            logger.warning(
+                "Generation Engine: standalone image generation failed; "
+                "degrading gracefully (variant omitted)",
+                exc_info=True,
+            )
+            results.append({"status": "failed", "url": None})
+            continue
+
+        results.append({"status": "generated", "url": stored_url})
+    return results
+
+
 def _is_video_or_carousel_format(fmt: str) -> bool:
     return any(keyword in fmt for keyword in VIDEO_FORMAT_KEYWORDS)
 

--- a/packages/agents/pipeline/nodes/research_engine.py
+++ b/packages/agents/pipeline/nodes/research_engine.py
@@ -168,6 +168,25 @@ def _research_brief(db: Session, post: Post) -> dict[str, Any]:
     }
 
 
+def run_standalone_research(db: Session, post: Post) -> dict[str, Any]:
+    """Issue #126 — the Research workspace page's "Run new research"
+    action. Runs exactly the same research brief the pipeline node above
+    produces, but for a standalone Post created ad hoc (no calendar event,
+    no downstream Creative/Generation stages) rather than one advancing
+    through the full pipeline graph — so a brand can see fresh trend
+    results without paying for the other four stages just to view them.
+
+    A thin wrapper around _research_brief rather than a second
+    implementation: same search/brand-context logic, same degrade-on-
+    failure behavior, same output shape. The caller (apps/api/routers/
+    research.py) is responsible for creating the ad hoc Post and logging
+    the AgentRun row — this function only produces the brief, same
+    division of responsibility build_research_node's node function has
+    with run_pipeline's AgentRun-logging (see graph.py).
+    """
+    return _research_brief(db, post)
+
+
 def build_research_node(db: Session | None):
     """Builds the real "research" stage node function, closing over `db`.
     Mirrors graph.py's _make_stub_node factory shape/conventions, but for


### PR DESCRIPTION
## Summary

Gives four pipeline stages their own standalone workspace pages instead of only surfacing inside a full 5-stage pipeline run:

- **Research (Ved)** — `app/research/page.tsx`: trend cards from a standalone research run.
- **Creative (Keshav)** — `app/creative/page.tsx`: free-form brief → "Generate all 6" angle/format cards.
- **Create Post** — `app/create-post/page.tsx`: manual trigger (brief + platform toggles) plus a "Recent runs" list sourced from real Post data, including a real "Blocked" status for rejected posts.
- **Content AI** — `app/content-ai/page.tsx`: image-first fast path (aspect ratio, style, "Lock to brand colours and logo") generating real image variants.

All four are linked from `components/nav.tsx`'s `NAV_LINKS`.

### Backend (additive only — no existing code removed/changed in behavior)

- `apps/api/routers/research.py` — `POST /brands/{brand_id}/research/run` and `GET /brands/{brand_id}/research/latest`. No endpoint previously exposed Research Engine output outside a full pipeline run. Backed by a new `run_standalone_research()` in `packages/agents/pipeline/nodes/research_engine.py` — a thin wrapper around the existing `_research_brief()`, run against an ad hoc `Post` (brand_id set, no calendar event), same "ad hoc post" case already documented on the `Post` model.
- `apps/api/routers/creative.py` — `POST /brands/{brand_id}/creative/angles`. Backed by a new `generate_creative_angles()` in `packages/agents/pipeline/nodes/creative_engine.py`, reusing the module's existing LLMProvider-only / degrade-on-failure contract to produce 6 distinct angle cards from a free-form brief (no Post or upstream research brief required).
- `apps/api/routers/content_ai.py` — `POST /brands/{brand_id}/content-ai/generate`. Backed by a new `generate_standalone_images()` in `packages/agents/pipeline/nodes/generation_engine.py`, which calls the exact same real fal.ai-backed `ImageProvider` + `StorageProvider` path the per-post pipeline's media hook already uses — no reimplementation, no faked API call.
- `apps/api/routers/posts.py` — `GET /brands/{brand_id}/posts`. A general, read-only Post listing: no existing endpoint returns Posts across every pipeline stage (review-queue only covers `human_review`, and calendar events never reflect a rejection). Powers Create Post's "Recent runs" list, including a "Blocked" label sourced from the real `Post.current_pipeline_stage == REJECTED` value (not an invented status).

Create Post's "Run all agents" reuses the **existing** calendar-event creation endpoint (`POST /brands/{brand_id}/calendar-events`) with an immediate `target_datetime`, so it enters the real pipeline through the existing Celery Beat trigger (`packages/agents/pipeline/trigger.py`) rather than adding a new "run now" endpoint.

No new database models/migrations — `alembic heads` unchanged (single head `5b29b584c4fa`).

## Test plan

- [x] `pytest apps/api/tests packages/agents/tests` — 415 passed (full suite, no regressions)
- [x] New backend tests: `test_research_workspace.py`, `test_creative_workspace.py`, `test_content_ai.py`, `test_posts_list.py`
- [x] `npx vitest run` (Node 18 via `fnm use 18`) — 66 passed across 15 files (new: `research-page`, `creative-page`, `create-post-page`, `content-ai-page` tests)
- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — clean (pre-existing unrelated warning in `Avatar.tsx` only)
- [x] `npm run build` — clean, all 4 new routes present in output

Closes #126