### PR TITLE
feat(web,api): add Content Arena DAG canvas for one pipeline run

### DIFF
--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -8,6 +8,7 @@ from apps.api.middleware.logging import RequestLoggingMiddleware, configure_json
 from apps.api.middleware.rate_limit import RateLimitMiddleware
 from apps.api.observability import init_sentry
 from apps.api.routers.analytics import router as analytics_router
+from apps.api.routers.arena import router as arena_router
 from apps.api.routers.brands import router as brands_router
 from apps.api.routers.calendar import router as calendar_router
 from apps.api.routers.onboarding import router as onboarding_router
@@ -37,6 +38,7 @@ app.add_middleware(
 )
 app.include_router(auth_router)
 app.include_router(analytics_router)
+app.include_router(arena_router)
 app.include_router(brands_router)
 app.include_router(calendar_router)
 app.include_router(onboarding_router)

--- a/apps/api/routers/arena.py
+++ b/apps/api/routers/arena.py
@@ -1,0 +1,123 @@
+"""Issue #124 — read-only endpoint composing one pipeline run's AgentRun
+history, Post, and ReviewFeedback rows for the Content Arena screen
+(apps/web/app/arena/page.tsx) to render as a DAG. Nothing here writes
+anything — see schemas/arena.py's docstring for why this exists as its own
+join rather than the frontend fetching three separate endpoints (one of
+which, AgentRun, doesn't have a list endpoint at all yet) and stitching
+them together itself.
+"""
+
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from apps.api.auth.dependencies import CurrentUser, get_current_user
+from apps.api.config.database import get_db
+from apps.api.models import AgentRun, Brand, ContentCalendarEvent, Post, ReviewFeedback
+from apps.api.schemas.arena import (
+    ArenaAgentRunRead,
+    ArenaPostRead,
+    ArenaReviewFeedbackRead,
+    ArenaRunRead,
+)
+from packages.agents.pipeline.graph import PIPELINE_STAGES
+
+router = APIRouter(prefix="/brands/{brand_id}/arena", tags=["arena"])
+
+# Every AgentRun row run_pipeline (packages/agents/pipeline/graph.py) logs
+# for a single run_pipeline() call is written inside that call's one open
+# transaction, and Postgres's now() (what AgentRun.created_at's
+# server_default resolves to) is constant for the whole transaction — so
+# rows from the same run can share an identical created_at and a plain
+# `ORDER BY created_at` can't tell them apart. Breaking ties by each row's
+# position in the pipeline's own stage order gives the correct sequence
+# for that common case while still respecting created_at across genuinely
+# separate runs/resumes (e.g. a human_review approval that resumes the
+# graph in a later request/transaction).
+_STAGE_ORDER = {stage: index for index, stage in enumerate(PIPELINE_STAGES)}
+
+
+def _agent_run_sort_key(run: AgentRun) -> tuple:
+    return (run.created_at, _STAGE_ORDER.get(run.agent_type.value, len(PIPELINE_STAGES)))
+
+
+def _get_org_brand(db: Session, brand_id: uuid.UUID, org_id: str) -> Brand:
+    brand = (
+        db.query(Brand)
+        .filter(Brand.id == brand_id, Brand.organization_id == uuid.UUID(org_id))
+        .first()
+    )
+    if brand is None:
+        # 404, not 403 — don't leak whether a brand with this id exists in
+        # another org. Same convention as review.py/calendar.py.
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Brand not found")
+    return brand
+
+
+def _run_for_post(db: Session, post: Post | None, calendar_event_id: uuid.UUID | None) -> ArenaRunRead:
+    if post is None:
+        return ArenaRunRead(
+            calendar_event_id=calendar_event_id, post=None, agent_runs=[], review_feedback=[]
+        )
+
+    agent_runs = sorted(
+        db.query(AgentRun).filter(AgentRun.post_id == post.id).all(),
+        key=_agent_run_sort_key,
+    )
+    review_feedback = (
+        db.query(ReviewFeedback)
+        .filter(ReviewFeedback.post_id == post.id)
+        .order_by(ReviewFeedback.created_at)
+        .all()
+    )
+    return ArenaRunRead(
+        calendar_event_id=post.calendar_event_id,
+        post=ArenaPostRead.model_validate(post),
+        agent_runs=[ArenaAgentRunRead.model_validate(run) for run in agent_runs],
+        review_feedback=[ArenaReviewFeedbackRead.model_validate(f) for f in review_feedback],
+    )
+
+
+@router.get("/by-event/{event_id}", response_model=ArenaRunRead)
+def get_arena_run_for_event(
+    brand_id: uuid.UUID,
+    event_id: uuid.UUID,
+    db: Session = Depends(get_db),
+    current_user: CurrentUser = Depends(get_current_user),
+) -> ArenaRunRead:
+    """The pipeline run for one calendar event. packages/agents/pipeline/
+    trigger.py's _get_or_create_post keeps a 1:1 ContentCalendarEvent:Post
+    relationship, so there is at most one Post to find here — None if the
+    event hasn't been triggered yet (still SCHEDULED)."""
+    brand = _get_org_brand(db, brand_id, current_user.org_id)
+    event = (
+        db.query(ContentCalendarEvent)
+        .filter(ContentCalendarEvent.id == event_id, ContentCalendarEvent.brand_id == brand.id)
+        .first()
+    )
+    if event is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Calendar event not found")
+
+    post = db.query(Post).filter(Post.calendar_event_id == event.id).first()
+    return _run_for_post(db, post, event.id)
+
+
+@router.get("/latest", response_model=ArenaRunRead)
+def get_latest_arena_run(
+    brand_id: uuid.UUID,
+    db: Session = Depends(get_db),
+    current_user: CurrentUser = Depends(get_current_user),
+) -> ArenaRunRead:
+    """The brand's most recently created Post — the run the Arena canvas
+    opens by default when it isn't deep-linked to a specific calendar
+    event. `post` is None (and agent_runs/review_feedback empty) when the
+    brand has no posts yet at all."""
+    brand = _get_org_brand(db, brand_id, current_user.org_id)
+    post = (
+        db.query(Post)
+        .filter(Post.brand_id == brand.id)
+        .order_by(Post.created_at.desc())
+        .first()
+    )
+    return _run_for_post(db, post, post.calendar_event_id if post else None)

--- a/apps/api/schemas/arena.py
+++ b/apps/api/schemas/arena.py
@@ -1,0 +1,86 @@
+"""Issue #124 — read-only composition of one pipeline run for the Content
+Arena screen (apps/web/app/arena/page.tsx) to render as a DAG: the
+ContentCalendarEvent it's for (if any), the Post it produced, every
+AgentRun row logged for that Post so far, and the Post's full
+ReviewFeedback history. Nothing here writes anything — it's a join over
+three tables the pipeline (packages/agents/pipeline/graph.py) already
+populates node-by-node, so the Arena canvas doesn't have to stitch
+together several existing endpoints (none of which currently expose
+AgentRun at all) itself.
+"""
+
+import uuid
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict
+
+from apps.api.models.agent_run import AgentType
+from apps.api.models.post import PipelineStage
+from apps.api.models.review_feedback import ReviewSource, ReviewVerdict
+
+
+class ArenaAgentRunRead(BaseModel):
+    """Mirrors apps/api/models/agent_run.py::AgentRun. `input` is
+    deliberately omitted: run_pipeline (packages/agents/pipeline/graph.py)
+    only ever writes {"post_id": ...} into it, never a real prompt, so it
+    has nothing an inspector panel could usefully show. `output` is kept
+    since it's the node's real structured result (research_brief /
+    creative_brief / generation_output / review_output, per stage)."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    agent_type: AgentType
+    output: dict | None
+    model: str | None
+    tokens: int | None
+    cost: float | None
+    latency_ms: float | None
+    created_at: datetime
+
+
+class ArenaReviewFeedbackRead(BaseModel):
+    """Same shape as apps/api/schemas/review.py::ReviewFeedbackRead, minus
+    post_id (redundant here — the whole payload is already scoped to one
+    post)."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    source: ReviewSource
+    score: float
+    verdict: ReviewVerdict
+    comments: dict
+    created_at: datetime
+
+
+class ArenaPostRead(BaseModel):
+    """A thin Post projection — just what the Arena canvas needs to know
+    where the run stands and what it produced, not the full Post row
+    (publish_results/publish_error are omitted; they're the publish
+    queue's concern, not this run's DAG)."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    calendar_event_id: uuid.UUID | None
+    current_pipeline_stage: PipelineStage
+    body_text: dict | None
+    media: list | None
+    created_at: datetime
+    updated_at: datetime
+
+
+class ArenaRunRead(BaseModel):
+    """One pipeline run, in a shape the Content Arena canvas (Issue #124)
+    can render directly: the calendar event it's for (if any), the Post it
+    produced (None if the event has no Post yet — e.g. still SCHEDULED),
+    every AgentRun row logged for that Post so far — oldest first, the
+    same order the pipeline graph actually executed them in — and the
+    Post's full review history (AI + human, same "one ordered log"
+    convention as apps/api/schemas/review.py::ReviewQueuePostRead)."""
+
+    calendar_event_id: uuid.UUID | None
+    post: ArenaPostRead | None
+    agent_runs: list[ArenaAgentRunRead]
+    review_feedback: list[ArenaReviewFeedbackRead]

--- a/apps/api/tests/test_arena.py
+++ b/apps/api/tests/test_arena.py
@@ -1,0 +1,270 @@
+"""Issue #124 — the Content Arena canvas's read-only run-composition
+endpoint (apps/api/routers/arena.py). Like test_review.py, this drives a
+real Post through packages.agents.pipeline.graph.run_pipeline (rather than
+hand-setting Post.current_pipeline_stage) so the AgentRun rows returned are
+the same ones the real pipeline logs, not a shortcut.
+"""
+
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+from fastapi.testclient import TestClient
+
+from apps.api.auth.jwt import create_access_token, hash_password
+from apps.api.main import app
+from apps.api.models import (
+    AgentRun,
+    AgentType,
+    Brand,
+    ContentCalendarEvent,
+    Organization,
+    Post,
+    User,
+    UserRole,
+)
+from packages.agents.pipeline.checkpointer import get_postgres_checkpointer
+from packages.agents.pipeline.graph import run_pipeline
+
+client = TestClient(app)
+uses_test_session = pytest.mark.usefixtures("override_get_db")
+
+
+@pytest.fixture()
+def thread_cleanup():
+    """Same reasoning as test_review.py's fixture of the same name:
+    pipeline checkpoint rows live in Postgres on a connection separate
+    from db_session's rolled-back transaction, so they need explicit
+    teardown."""
+    thread_ids: list[str] = []
+    yield thread_ids
+    if not thread_ids:
+        return
+    with get_postgres_checkpointer() as checkpointer:
+        for thread_id in thread_ids:
+            checkpointer.delete_thread(thread_id)
+
+
+def _setup_brand(db_session, suffix: str = "") -> tuple[Brand, User]:
+    org = Organization(name="Acme Agency")
+    db_session.add(org)
+    db_session.flush()
+
+    user = User(
+        organization_id=org.id,
+        email=f"editor{suffix}@acme.test",
+        password_hash=hash_password("test-password"),
+        role=UserRole.EDITOR,
+    )
+    brand = Brand(organization_id=org.id, name="Acme Widgets")
+    db_session.add_all([user, brand])
+    db_session.flush()
+    return brand, user
+
+
+def _auth_headers(user: User) -> dict[str, str]:
+    token = create_access_token(
+        user_id=str(user.id), org_id=str(user.organization_id), role=user.role.value
+    )
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _post_at_human_review(db_session, brand: Brand, thread_cleanup, calendar_event_id=None) -> Post:
+    """Runs a real Post through the pipeline graph up to (and pausing at)
+    the human_review interrupt, logging real AgentRun rows for research,
+    creative, generation and reviewer along the way — same mechanism
+    test_review.py uses."""
+    post = Post(brand_id=brand.id, calendar_event_id=calendar_event_id)
+    db_session.add(post)
+    db_session.flush()
+    thread_cleanup.append(str(post.id))
+
+    with get_postgres_checkpointer() as checkpointer:
+        list(run_pipeline(db_session, post, checkpointer))
+
+    db_session.refresh(post)
+    return post
+
+
+# --- by-event -------------------------------------------------------------
+
+
+@uses_test_session
+def test_get_run_for_event_returns_agent_runs_in_order(db_session, thread_cleanup) -> None:
+    brand, user = _setup_brand(db_session)
+    event = ContentCalendarEvent(
+        brand_id=brand.id,
+        title="Launch",
+        target_platforms=["linkedin"],
+        desired_format="image",
+        target_datetime=datetime(2026, 9, 1, 12, 0, tzinfo=timezone.utc),
+    )
+    db_session.add(event)
+    db_session.flush()
+
+    post = _post_at_human_review(db_session, brand, thread_cleanup, calendar_event_id=event.id)
+
+    response = client.get(
+        f"/brands/{brand.id}/arena/by-event/{event.id}", headers=_auth_headers(user)
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["calendar_event_id"] == str(event.id)
+    assert body["post"]["id"] == str(post.id)
+    assert body["post"]["current_pipeline_stage"] == "human_review"
+
+    stages = [run["agent_type"] for run in body["agent_runs"]]
+    assert stages == ["research", "creative", "generation", "reviewer"]
+    # Ordered oldest-first (pipeline execution order), not reversed.
+    timestamps = [run["created_at"] for run in body["agent_runs"]]
+    assert timestamps == sorted(timestamps)
+
+    # The AI reviewer's pass (Issue #24) is attached as review history.
+    sources = [f["source"] for f in body["review_feedback"]]
+    assert sources == ["ai_reviewer"]
+
+    # `input` is never exposed — see schemas/arena.py's docstring.
+    assert "input" not in body["agent_runs"][0]
+
+
+@uses_test_session
+def test_get_run_for_event_without_a_post_yet(db_session) -> None:
+    brand, user = _setup_brand(db_session)
+    event = ContentCalendarEvent(
+        brand_id=brand.id,
+        title="Not triggered yet",
+        target_platforms=["linkedin"],
+        desired_format="image",
+        target_datetime=datetime(2026, 9, 1, 12, 0, tzinfo=timezone.utc),
+    )
+    db_session.add(event)
+    db_session.flush()
+
+    response = client.get(
+        f"/brands/{brand.id}/arena/by-event/{event.id}", headers=_auth_headers(user)
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["calendar_event_id"] == str(event.id)
+    assert body["post"] is None
+    assert body["agent_runs"] == []
+    assert body["review_feedback"] == []
+
+
+@uses_test_session
+def test_get_run_for_unknown_event_is_404(db_session) -> None:
+    brand, user = _setup_brand(db_session)
+
+    response = client.get(
+        f"/brands/{brand.id}/arena/by-event/{uuid.uuid4()}", headers=_auth_headers(user)
+    )
+
+    assert response.status_code == 404
+
+
+@uses_test_session
+def test_cross_org_event_access_returns_404(db_session) -> None:
+    brand, _owner = _setup_brand(db_session, suffix="-1")
+    _brand2, other_user = _setup_brand(db_session, suffix="-2")
+    event = ContentCalendarEvent(
+        brand_id=brand.id,
+        title="Launch",
+        target_platforms=["linkedin"],
+        desired_format="image",
+        target_datetime=datetime(2026, 9, 1, 12, 0, tzinfo=timezone.utc),
+    )
+    db_session.add(event)
+    db_session.flush()
+
+    response = client.get(
+        f"/brands/{brand.id}/arena/by-event/{event.id}", headers=_auth_headers(other_user)
+    )
+
+    assert response.status_code == 404
+
+
+# --- latest -----------------------------------------------------------------
+
+
+@uses_test_session
+def test_get_latest_run_returns_most_recently_created_post(db_session, thread_cleanup) -> None:
+    brand, user = _setup_brand(db_session)
+    older = Post(brand_id=brand.id)
+    db_session.add(older)
+    db_session.flush()
+    # Postgres's now() is constant for the whole transaction, so both Posts
+    # would otherwise get an identical server-generated created_at within
+    # this one test transaction — force `older` to genuinely predate
+    # `newer` so the ORDER BY created_at DESC this endpoint relies on has
+    # something real to sort by.
+    older.created_at = datetime(2020, 1, 1, tzinfo=timezone.utc)
+    db_session.flush()
+
+    newer = _post_at_human_review(db_session, brand, thread_cleanup)
+
+    response = client.get(f"/brands/{brand.id}/arena/latest", headers=_auth_headers(user))
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["post"]["id"] == str(newer.id)
+    assert older.id != newer.id
+
+
+@uses_test_session
+def test_get_latest_run_with_no_posts_yet(db_session) -> None:
+    brand, user = _setup_brand(db_session)
+
+    response = client.get(f"/brands/{brand.id}/arena/latest", headers=_auth_headers(user))
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["post"] is None
+    assert body["calendar_event_id"] is None
+    assert body["agent_runs"] == []
+
+
+@uses_test_session
+def test_get_latest_run_unknown_brand_is_404(db_session, thread_cleanup) -> None:
+    brand, user = _setup_brand(db_session)
+    _post_at_human_review(db_session, brand, thread_cleanup)
+
+    response = client.get(f"/brands/{uuid.uuid4()}/arena/latest", headers=_auth_headers(user))
+
+    assert response.status_code == 404
+
+
+@uses_test_session
+def test_agent_runs_expose_real_cost_and_token_data(db_session) -> None:
+    """Confirms the endpoint passes through AgentRun's real
+    model/tokens/cost/latency columns rather than only the stage name —
+    the Arena inspector panel (Issue #124) needs these for real stats."""
+    brand, user = _setup_brand(db_session)
+    post = Post(brand_id=brand.id)
+    db_session.add(post)
+    db_session.flush()
+
+    db_session.add(
+        AgentRun(
+            post_id=post.id,
+            agent_type=AgentType.GENERATION,
+            input={"post_id": str(post.id)},
+            output={"generation_output": {"model": "sonnet", "tokens": 512, "cost": 0.12}},
+            model="sonnet",
+            tokens=512,
+            cost=0.12,
+            latency_ms=845.5,
+        )
+    )
+    db_session.flush()
+
+    response = client.get(f"/brands/{brand.id}/arena/latest", headers=_auth_headers(user))
+
+    assert response.status_code == 200
+    run = response.json()["agent_runs"][0]
+    assert run["model"] == "sonnet"
+    assert run["tokens"] == 512
+    assert run["cost"] == 0.12
+    assert run["latency_ms"] == 845.5
+    assert run["output"]["generation_output"]["model"] == "sonnet"

--- a/apps/web/__tests__/api.test.ts
+++ b/apps/web/__tests__/api.test.ts
@@ -1,5 +1,13 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
-import { ApiError, createBrand, fetchBrands, login, uploadBrandLogo } from "@/lib/api";
+import {
+  ApiError,
+  createBrand,
+  fetchArenaRunForEvent,
+  fetchBrands,
+  fetchLatestArenaRun,
+  login,
+  uploadBrandLogo,
+} from "@/lib/api";
 
 describe("api client", () => {
   const originalFetch = global.fetch;
@@ -95,5 +103,48 @@ describe("api client", () => {
     expect(options.headers.Authorization).toBe("Bearer test-token");
     expect(options.body).toBeInstanceOf(FormData);
     expect((options.body as FormData).get("file")).toBe(file);
+  });
+
+  it("fetchArenaRunForEvent hits the by-event endpoint with the bearer token", async () => {
+    const run = { calendar_event_id: "event-1", post: null, agent_runs: [], review_feedback: [] };
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: async () => run,
+    });
+
+    const result = await fetchArenaRunForEvent("test-token", "brand-1", "event-1");
+
+    expect(result).toEqual(run);
+    const [url, options] = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(url).toContain("/brands/brand-1/arena/by-event/event-1");
+    expect(options.headers.Authorization).toBe("Bearer test-token");
+  });
+
+  it("fetchArenaRunForEvent raises ApiError on non-OK responses", async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: false,
+      status: 404,
+      json: async () => ({ detail: "Calendar event not found" }),
+    });
+
+    await expect(fetchArenaRunForEvent("test-token", "brand-1", "missing")).rejects.toMatchObject({
+      message: "Calendar event not found",
+      status: 404,
+    });
+  });
+
+  it("fetchLatestArenaRun hits the latest endpoint with the bearer token", async () => {
+    const run = { calendar_event_id: null, post: null, agent_runs: [], review_feedback: [] };
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: async () => run,
+    });
+
+    const result = await fetchLatestArenaRun("test-token", "brand-1");
+
+    expect(result).toEqual(run);
+    const [url, options] = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(url).toContain("/brands/brand-1/arena/latest");
+    expect(options.headers.Authorization).toBe("Bearer test-token");
   });
 });

--- a/apps/web/__tests__/arena-build-nodes.test.ts
+++ b/apps/web/__tests__/arena-build-nodes.test.ts
@@ -1,0 +1,204 @@
+import { describe, expect, it } from "vitest";
+import { buildArenaNodes } from "@/app/arena/build-nodes";
+import type { ArenaAgentRun, ArenaReviewFeedback, ArenaRun, Brand, CalendarEvent } from "@/lib/api";
+
+function makeRun(overrides: Partial<ArenaRun> = {}): ArenaRun {
+  return {
+    calendar_event_id: null,
+    post: null,
+    agent_runs: [],
+    review_feedback: [],
+    ...overrides,
+  };
+}
+
+function makeAgentRun(overrides: Partial<ArenaAgentRun>): ArenaAgentRun {
+  return {
+    id: "run-1",
+    agent_type: "research",
+    output: null,
+    model: null,
+    tokens: null,
+    cost: null,
+    latency_ms: null,
+    created_at: "2026-08-20T10:00:00Z",
+    ...overrides,
+  };
+}
+
+function findNode(run: ArenaRun, event: CalendarEvent | null, brand: Brand | null, id: string) {
+  const nodes = buildArenaNodes(run, event, brand);
+  const node = nodes.find((n) => n.id === id);
+  if (!node) throw new Error(`node ${id} not found`);
+  return node;
+}
+
+describe("buildArenaNodes", () => {
+  it("marks a stage DONE and pulls real cost/tokens once an AgentRun exists", () => {
+    const run = makeRun({
+      post: {
+        id: "post-1",
+        calendar_event_id: null,
+        current_pipeline_stage: "generation",
+        body_text: null,
+        media: null,
+        created_at: "2026-08-20T10:00:00Z",
+        updated_at: "2026-08-20T10:00:00Z",
+      },
+      agent_runs: [
+        makeAgentRun({
+          agent_type: "generation",
+          model: "sonnet",
+          tokens: 512,
+          cost: 0.12,
+          latency_ms: 845,
+          output: { generation_output: { platforms: { linkedin: { body_text: "hi" } }, model: "sonnet" } },
+        }),
+      ],
+    });
+
+    const node = findNode(run, null, null, "generation");
+
+    expect(node.status).toBe("DONE");
+    expect(node.stats).toEqual(
+      expect.arrayContaining([
+        { label: "DRAFTS", value: "1" },
+        { label: "TOKENS", value: "512" },
+        { label: "COST", value: "$0.12" },
+      ])
+    );
+  });
+
+  it("marks a stage QUEUED (not fabricated as running) when it hasn't executed yet", () => {
+    const run = makeRun({
+      post: {
+        id: "post-1",
+        calendar_event_id: null,
+        current_pipeline_stage: "research",
+        body_text: null,
+        media: null,
+        created_at: "2026-08-20T10:00:00Z",
+        updated_at: "2026-08-20T10:00:00Z",
+      },
+      agent_runs: [],
+    });
+
+    const node = findNode(run, null, null, "generation");
+
+    expect(node.status).toBe("QUEUED");
+    expect(node.agentRun).toBeNull();
+    expect(node.lines).toContain("not run yet");
+  });
+
+  it("marks human_review WAITING when the post is durably paused there with no AgentRun yet", () => {
+    const run = makeRun({
+      post: {
+        id: "post-1",
+        calendar_event_id: null,
+        current_pipeline_stage: "human_review",
+        body_text: null,
+        media: null,
+        created_at: "2026-08-20T10:00:00Z",
+        updated_at: "2026-08-20T10:04:00Z",
+      },
+      agent_runs: [],
+    });
+
+    const node = findNode(run, null, null, "human_review");
+
+    expect(node.status).toBe("WAITING");
+    expect(node.lines[0]).toMatch(/waiting on a human decision/i);
+  });
+
+  it("marks downstream stages SKIPPED when the run was rejected at human_review", () => {
+    const run = makeRun({
+      post: {
+        id: "post-1",
+        calendar_event_id: null,
+        current_pipeline_stage: "rejected",
+        body_text: null,
+        media: null,
+        created_at: "2026-08-20T10:00:00Z",
+        updated_at: "2026-08-20T10:04:00Z",
+      },
+      agent_runs: [makeAgentRun({ agent_type: "human_review", output: {} })],
+      review_feedback: [
+        {
+          id: "fb-1",
+          source: "human",
+          score: 0,
+          verdict: "reject",
+          comments: {},
+          created_at: "2026-08-20T10:05:00Z",
+        },
+      ],
+    });
+
+    expect(findNode(run, null, null, "human_review").status).toBe("DONE");
+    expect(findNode(run, null, null, "scheduler").status).toBe("SKIPPED");
+    expect(findNode(run, null, null, "publisher").status).toBe("SKIPPED");
+    expect(findNode(run, null, null, "analytics_collector").status).toBe("SKIPPED");
+  });
+
+  it("surfaces the AI reviewer's real score/verdict on the reviewer node", () => {
+    const reviewFeedback: ArenaReviewFeedback[] = [
+      {
+        id: "fb-ai-1",
+        source: "ai_reviewer",
+        score: 84,
+        verdict: "approve",
+        comments: { platforms: {}, model: "openrouter/free" },
+        created_at: "2026-08-20T10:03:00Z",
+      },
+    ];
+    const run = makeRun({
+      post: {
+        id: "post-1",
+        calendar_event_id: null,
+        current_pipeline_stage: "human_review",
+        body_text: null,
+        media: null,
+        created_at: "2026-08-20T10:00:00Z",
+        updated_at: "2026-08-20T10:03:00Z",
+      },
+      agent_runs: [makeAgentRun({ agent_type: "reviewer", cost: 0.05, output: { review_output: {} } })],
+      review_feedback: reviewFeedback,
+    });
+
+    const node = findNode(run, null, null, "reviewer");
+
+    expect(node.status).toBe("DONE");
+    expect(node.lines[0]).toBe("score 84/100 · approve");
+  });
+
+  it("renders the campaign-brief context node from the real calendar event", () => {
+    const event: CalendarEvent = {
+      id: "event-1",
+      brand_id: "brand-1",
+      title: "DPDP launch carousel",
+      description: null,
+      target_platforms: ["linkedin", "x"],
+      desired_format: "carousel",
+      target_datetime: "2026-09-01T12:00:00Z",
+      status: "pipeline_running",
+      created_at: "2026-08-01T00:00:00Z",
+      updated_at: "2026-08-01T00:00:00Z",
+    };
+
+    const node = findNode(makeRun(), event, null, "brief");
+
+    expect(node.status).toBe("READ");
+    expect(node.lines[0]).toBe("DPDP launch carousel");
+    expect(node.stats).toEqual(
+      expect.arrayContaining([{ label: "PLATFORMS", value: "2" }, { label: "FORMAT", value: "carousel" }])
+    );
+  });
+
+  it("shows a clear placeholder for the brief node when there is no calendar event", () => {
+    const node = findNode(makeRun(), null, null, "brief");
+
+    expect(node.status).toBe("READ");
+    expect(node.lines).toEqual(["No calendar event — ad hoc post"]);
+    expect(node.stats).toEqual([]);
+  });
+});

--- a/apps/web/__tests__/arena-page.test.tsx
+++ b/apps/web/__tests__/arena-page.test.tsx
@@ -1,0 +1,178 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import ArenaPage from "@/app/arena/page";
+import { AuthProvider } from "@/lib/auth-context";
+import { BrandProvider } from "@/lib/brand-context";
+import type { ArenaRun } from "@/lib/api";
+
+const fetchBrandsMock = vi.fn();
+const fetchLatestArenaRunMock = vi.fn();
+const fetchArenaRunForEventMock = vi.fn();
+const fetchCalendarEventsMock = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+vi.mock("@/lib/api", () => ({
+  fetchBrands: (...args: unknown[]) => fetchBrandsMock(...args),
+  fetchLatestArenaRun: (...args: unknown[]) => fetchLatestArenaRunMock(...args),
+  fetchArenaRunForEvent: (...args: unknown[]) => fetchArenaRunForEventMock(...args),
+  fetchCalendarEvents: (...args: unknown[]) => fetchCalendarEventsMock(...args),
+}));
+
+const BRANDS = [
+  {
+    id: "brand-1",
+    organization_id: "org-1",
+    name: "Acme Co",
+    industry: "Legal tech",
+    logo_url: null,
+    target_audience: null,
+    colors: ["#000"],
+    tone_descriptors: ["direct"],
+    product_catalog: null,
+    brand_report: null,
+    created_at: "2026-01-01",
+    updated_at: "2026-01-01",
+  },
+];
+
+const CALENDAR_EVENTS = [
+  {
+    id: "event-1",
+    brand_id: "brand-1",
+    title: "DPDP launch carousel",
+    description: null,
+    target_platforms: ["linkedin", "x"],
+    desired_format: "carousel",
+    target_datetime: "2026-09-01T12:00:00Z",
+    status: "pipeline_running",
+    created_at: "2026-08-01T00:00:00Z",
+    updated_at: "2026-08-01T00:00:00Z",
+  },
+];
+
+function makeRun(overrides: Partial<ArenaRun> = {}): ArenaRun {
+  return {
+    calendar_event_id: "event-1",
+    post: {
+      id: "post-1",
+      calendar_event_id: "event-1",
+      current_pipeline_stage: "human_review",
+      body_text: { linkedin: "70% of contracts fail diligence." },
+      media: null,
+      created_at: "2026-08-20T10:00:00Z",
+      updated_at: "2026-08-20T10:04:00Z",
+    },
+    agent_runs: [
+      {
+        id: "run-research",
+        agent_type: "research",
+        output: { research_brief: { industry_trends: [{ title: "DPDP readiness", url: "https://meity.gov.in/x" }] } },
+        model: "sonnet",
+        tokens: 400,
+        cost: 0.08,
+        latency_ms: 1200,
+        created_at: "2026-08-20T10:00:30Z",
+      },
+    ],
+    review_feedback: [
+      {
+        id: "fb-ai-1",
+        source: "ai_reviewer",
+        score: 84,
+        verdict: "approve",
+        comments: { platforms: {}, model: "openrouter/free" },
+        created_at: "2026-08-20T10:03:00Z",
+      },
+    ],
+    ...overrides,
+  };
+}
+
+function renderPage() {
+  return render(
+    <AuthProvider>
+      <BrandProvider>
+        <ArenaPage />
+      </BrandProvider>
+    </AuthProvider>
+  );
+}
+
+describe("ArenaPage", () => {
+  beforeEach(() => {
+    fetchBrandsMock.mockReset();
+    fetchLatestArenaRunMock.mockReset();
+    fetchArenaRunForEventMock.mockReset();
+    fetchCalendarEventsMock.mockReset();
+
+    window.localStorage.clear();
+    window.localStorage.setItem("raindeer.auth.token", "test-token");
+
+    fetchBrandsMock.mockResolvedValue(BRANDS);
+    fetchCalendarEventsMock.mockResolvedValue(CALENDAR_EVENTS);
+    fetchLatestArenaRunMock.mockResolvedValue(makeRun());
+  });
+
+  it("fetches the latest run for the selected brand and renders the real event title", async () => {
+    renderPage();
+
+    await waitFor(() => expect(fetchLatestArenaRunMock).toHaveBeenCalledWith("test-token", "brand-1"));
+    expect(await screen.findByText("RUNNING")).toBeInTheDocument();
+    expect(screen.getAllByText("DPDP launch carousel").length).toBeGreaterThan(0);
+  });
+
+  it("renders real AgentRun data in the research node and trace tab", async () => {
+    renderPage();
+
+    await screen.findByText("RUNNING");
+
+    // Node card + inspector summary line, derived from the real
+    // research_brief output (appears in both places).
+    expect(screen.getAllByText("1 source found").length).toBeGreaterThan(0);
+    // Trace tab entry for the same AgentRun row.
+    expect(screen.getByText(/research complete/)).toBeInTheDocument();
+  });
+
+  it("selecting a different node updates the inspector panel", async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    await screen.findByText("RUNNING");
+
+    await user.click(screen.getByRole("button", { name: "Select Kavi · Generation" }));
+
+    // The inspector's header now shows the selected node's name.
+    const inspectorHeadings = screen.getAllByText("Kavi · Generation");
+    expect(inspectorHeadings.length).toBeGreaterThan(1);
+  });
+
+  it("the 'Skip to review' control really links to /review-queue", async () => {
+    renderPage();
+
+    await screen.findByText("RUNNING");
+
+    const link = screen.getByRole("link", { name: /Skip to review/ });
+    expect(link).toHaveAttribute("href", "/review-queue");
+  });
+
+  it("never fabricates a system prompt — shows a clear not-available state", async () => {
+    renderPage();
+
+    await screen.findByText("RUNNING");
+
+    expect(screen.getByText(/Not available yet/)).toBeInTheDocument();
+  });
+
+  it("shows an empty state instead of fetching when no brand is selected", async () => {
+    fetchBrandsMock.mockResolvedValue([]);
+
+    renderPage();
+
+    expect(await screen.findByText("Select a brand to see its Content Arena.")).toBeInTheDocument();
+    expect(fetchLatestArenaRunMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/__tests__/auth-gate.test.tsx
+++ b/apps/web/__tests__/auth-gate.test.tsx
@@ -75,4 +75,29 @@ describe("AuthGate", () => {
       expect(replace).toHaveBeenCalledWith("/login?from=%2Fanalytics");
     });
   });
+
+  it("renders full-bleed routes (e.g. Content Arena) without the Nav sidebar", async () => {
+    mockPathname = "/arena";
+    window.localStorage.setItem("raindeer.auth.token", "test-token");
+
+    renderGate();
+
+    await waitFor(() => {
+      expect(screen.getByText("protected content")).toBeInTheDocument();
+    });
+    expect(replace).not.toHaveBeenCalled();
+    // Nav renders a "Main navigation" landmark — absent on full-bleed routes.
+    expect(screen.queryByRole("navigation", { name: "Main navigation" })).not.toBeInTheDocument();
+  });
+
+  it("still redirects unauthenticated visitors away from full-bleed routes", async () => {
+    mockPathname = "/arena";
+
+    renderGate();
+
+    await waitFor(() => {
+      expect(replace).toHaveBeenCalledWith("/login?from=%2Farena");
+    });
+    expect(screen.queryByText("protected content")).not.toBeInTheDocument();
+  });
 });

--- a/apps/web/app/arena/block-library.ts
+++ b/apps/web/app/arena/block-library.ts
@@ -1,0 +1,61 @@
+// Static block-type palette for the left sidebar (Issue #124 scopes this
+// to "a static visual list of block types — no drag-drop needed"). This
+// is UI chrome describing what kinds of blocks the pipeline is built
+// from, not per-run telemetry, so it's fine for it to be a fixed list
+// rather than derived from a specific run.
+export interface LibraryItem {
+  icon: string;
+  label: string;
+  color: string;
+}
+
+export interface LibraryGroup {
+  group: string;
+  items: LibraryItem[];
+}
+
+export const BLOCK_LIBRARY: LibraryGroup[] = [
+  {
+    group: "AGENTS",
+    items: [
+      { icon: "V", label: "Research · Ved", color: "#1B4DFF" },
+      { icon: "K", label: "Creative · Keshav", color: "#6B32C9" },
+      { icon: "K", label: "Generation · Kavi", color: "#0E7A4E" },
+      { icon: "N", label: "Reviewer · Neer", color: "#B46A00" },
+      { icon: "A", label: "Onboarding · Aarav", color: "#2C5FD6" },
+    ],
+  },
+  {
+    group: "TOOLS",
+    items: [
+      { icon: "⌕", label: "Web search", color: "#2B3D6B" },
+      { icon: "↗", label: "Trend radar", color: "#2B3D6B" },
+      { icon: "▧", label: "Image gen", color: "#2B3D6B" },
+      { icon: "▶", label: "Video gen", color: "#2B3D6B" },
+    ],
+  },
+  {
+    group: "DATA",
+    items: [
+      { icon: "B", label: "Brand memory", color: "#0B2A6B" },
+      { icon: "◍", label: "Audience", color: "#0B2A6B" },
+      { icon: "▲", label: "Past performance", color: "#0B2A6B" },
+    ],
+  },
+  {
+    group: "FLOW",
+    items: [
+      { icon: "☺", label: "Human approval", color: "#1B4DFF" },
+      { icon: "◇", label: "Condition", color: "#8B5BD6" },
+      { icon: "◷", label: "Wait until", color: "#8B5BD6" },
+    ],
+  },
+  {
+    group: "OUTPUT",
+    items: [
+      { icon: "◷", label: "Scheduler", color: "#1E7FB8" },
+      { icon: "➤", label: "Publisher", color: "#1E7FB8" },
+      { icon: "▲", label: "Analytics loop", color: "#C2477F" },
+    ],
+  },
+];

--- a/apps/web/app/arena/build-dock.ts
+++ b/apps/web/app/arena/build-dock.ts
@@ -1,0 +1,161 @@
+// Builds the bottom dock's four tabs (Trace / Outputs / Cost / Sources)
+// straight from the real AgentRun/Post rows in an ArenaRun — no invented
+// telemetry. Kept separate from build-nodes.ts (which is about the
+// canvas) since the dock reads the same run but summarizes it
+// differently (a flat timeline instead of per-node cards).
+import type { AgentType, ArenaAgentRun, ArenaRun } from "@/lib/api";
+import { formatClock, formatCost, formatTokens, truncate } from "./format";
+
+export const AGENT_DISPLAY_NAME: Record<AgentType, string> = {
+  research: "Ved",
+  creative: "Keshav",
+  generation: "Kavi",
+  reviewer: "Neer",
+  human_review: "system",
+  scheduler: "Scheduler",
+  publisher: "Publisher",
+  analytics_collector: "Analytics",
+};
+
+export interface TraceEntry {
+  id: string;
+  time: string;
+  who: string;
+  text: string;
+}
+
+function summarize(agentRun: ArenaAgentRun): string {
+  const output = agentRun.output ?? {};
+  switch (agentRun.agent_type) {
+    case "research": {
+      const brief = output.research_brief as { industry_trends?: { title: string }[] } | undefined;
+      const count = brief?.industry_trends?.length ?? 0;
+      return `research complete · ${count} industry trend${count === 1 ? "" : "s"} found`;
+    }
+    case "creative": {
+      const brief = output.creative_brief as { platforms?: Record<string, unknown> } | undefined;
+      const count = Object.keys(brief?.platforms ?? {}).length;
+      return `creative brief ready · ${count} platform${count === 1 ? "" : "s"}`;
+    }
+    case "generation": {
+      const gen = output.generation_output as { platforms?: Record<string, unknown> } | undefined;
+      const count = Object.keys(gen?.platforms ?? {}).length;
+      return `generated ${count} draft${count === 1 ? "" : "s"}` + (agentRun.model ? ` with ${agentRun.model}` : "");
+    }
+    case "reviewer":
+      return "reviewer pass complete — see Governance for score/verdict";
+    case "human_review":
+      return "resumed from the human_review checkpoint";
+    case "scheduler":
+      return "scheduler stage recorded (not yet implemented)";
+    case "publisher":
+      return "handed off to the publish queue";
+    case "analytics_collector":
+      return "analytics collector stage recorded (not yet implemented)";
+    default:
+      return "stage complete";
+  }
+}
+
+export function buildTrace(run: ArenaRun): TraceEntry[] {
+  return run.agent_runs.map((agentRun) => ({
+    id: agentRun.id,
+    time: agentRun.created_at,
+    who: AGENT_DISPLAY_NAME[agentRun.agent_type],
+    text: summarize(agentRun),
+  }));
+}
+
+export interface SourceEntry {
+  title: string;
+  url: string;
+  domain: string;
+}
+
+function domainOf(url: string): string {
+  try {
+    return new URL(url).hostname.replace(/^www\./, "");
+  } catch {
+    return url;
+  }
+}
+
+/** Real search results the Research Engine actually retrieved
+ * (packages/agents/pipeline/nodes/research_engine.py's
+ * industry_trends/platform_trends), not invented sources. Empty when
+ * research hasn't run yet. */
+export function buildSources(run: ArenaRun): SourceEntry[] {
+  const researchRun = run.agent_runs.find((r) => r.agent_type === "research");
+  const brief = researchRun?.output?.research_brief as
+    | {
+        industry_trends?: { title: string; url: string }[];
+        platform_trends?: Record<string, { title: string; url: string }[]>;
+      }
+    | undefined;
+  if (!brief) return [];
+
+  const results: { title: string; url: string }[] = [...(brief.industry_trends ?? [])];
+  for (const list of Object.values(brief.platform_trends ?? {})) {
+    if (Array.isArray(list)) results.push(...list);
+  }
+
+  const seen = new Set<string>();
+  const sources: SourceEntry[] = [];
+  for (const result of results) {
+    if (!result?.url || seen.has(result.url)) continue;
+    seen.add(result.url);
+    sources.push({ title: result.title || result.url, url: result.url, domain: domainOf(result.url) });
+  }
+  return sources;
+}
+
+export interface CostRow {
+  agentType: AgentType;
+  who: string;
+  model: string;
+  tokens: string;
+  cost: string;
+}
+
+export function buildCostRows(run: ArenaRun): CostRow[] {
+  return run.agent_runs
+    .filter((r) => r.cost !== null || r.tokens !== null)
+    .map((r) => ({
+      agentType: r.agent_type,
+      who: AGENT_DISPLAY_NAME[r.agent_type],
+      model: r.model ?? "—",
+      tokens: formatTokens(r.tokens),
+      cost: formatCost(r.cost),
+    }));
+}
+
+export function totalCost(run: ArenaRun): number {
+  return run.agent_runs.reduce((sum, r) => sum + (r.cost ?? 0), 0);
+}
+
+export function totalTokens(run: ArenaRun): number {
+  return run.agent_runs.reduce((sum, r) => sum + (r.tokens ?? 0), 0);
+}
+
+export interface DraftThumb {
+  platform: string;
+  format: string;
+  url: string;
+  captionPreview: string;
+}
+
+/** Real generated Post media (apps/api/models/post.py::Post.media) — empty
+ * (not filled with placeholders) when generation hasn't produced any
+ * media yet, e.g. a text-only run or one that hasn't reached generation. */
+export function buildDraftThumbs(run: ArenaRun): DraftThumb[] {
+  const media = run.post?.media ?? [];
+  const bodyText = run.post?.body_text ?? {};
+  return media.map((item) => ({
+    platform: item.platform,
+    format: item.format,
+    url: item.url,
+    captionPreview: bodyText[item.platform] ? truncate(bodyText[item.platform], 60) : "",
+  }));
+}
+
+export { formatClock };

--- a/apps/web/app/arena/build-nodes.ts
+++ b/apps/web/app/arena/build-nodes.ts
@@ -1,0 +1,335 @@
+// Merges the real data an Arena run has (ArenaRun from the API, plus the
+// CalendarEvent/Brand it belongs to) onto the static graph topology
+// (topology.ts) to produce what the canvas actually renders. This is
+// deliberately the one place that decides "what does this node say" —
+// kept as pure functions, no React, so it's unit-testable without
+// mounting the page.
+import type { ArenaAgentRun, ArenaReviewFeedback, ArenaRun, Brand, CalendarEvent } from "@/lib/api";
+import { formatCost, formatLatency, formatTokens, truncate } from "./format";
+import { ArenaNodeId, NODE_LAYOUT, NodeLayout } from "./topology";
+
+export type NodeStatus = "DONE" | "WAITING" | "QUEUED" | "SKIPPED" | "READ";
+
+export interface ArenaNodeView extends NodeLayout {
+  status: NodeStatus;
+  /** 1-3 short summary lines shown on the node card's body. */
+  lines: string[];
+  /** Up to 3 label/value stat tiles — real numbers only, "—" when absent. */
+  stats: { label: string; value: string }[];
+  /** One-line footer, e.g. a timestamp or a static description of what a
+   * still-stub stage does. */
+  footer: string;
+  /** The backing AgentRun row, if this stage has run — null for context
+   * nodes and for stages that haven't executed yet. */
+  agentRun: ArenaAgentRun | null;
+  /** ReviewFeedback rows relevant to this node (reviewer: ai_reviewer
+   * rows; human_review: human rows) — empty for every other node. */
+  reviewFeedback: ArenaReviewFeedback[];
+}
+
+const PIPELINE_STAGE_ORDER: ArenaNodeId[] = [
+  "research",
+  "creative",
+  "generation",
+  "reviewer",
+  "human_review",
+  "scheduler",
+  "publisher",
+  "analytics_collector",
+];
+
+// What each stage's real code actually does — static, factual, and true
+// regardless of whether it has run yet. Several of these (scheduler,
+// analytics_collector) are still stub nodes in
+// packages/agents/pipeline/graph.py — said plainly here rather than
+// implying they do something they don't.
+const STAGE_DESCRIPTIONS: Record<ArenaNodeId, string> = {
+  brief: "The calendar event this run was triggered from.",
+  brand: "Brand voice, audience and compliance rules retrieved for this run.",
+  research: "Gathers platform + industry trend research and brand context.",
+  creative: "Turns the research brief into a per-platform angle/hook/CTA.",
+  generation: "Writes per-platform copy (and media, where the brief calls for it).",
+  reviewer: "Scores the draft against brand voice/compliance and platform fit.",
+  human_review: "Durable pause — waits for a human decision, resumable across restarts.",
+  scheduler: "Not yet implemented — still a stub node that only records that it ran.",
+  publisher: "Hands the post to the async publish queue for each target platform.",
+  analytics_collector: "Not yet implemented — still a stub node that only records that it ran.",
+};
+
+function isTerminalRejected(post: ArenaRun["post"]): boolean {
+  return post?.current_pipeline_stage === "rejected";
+}
+
+function findAgentRun(agentRuns: ArenaAgentRun[], id: ArenaNodeId): ArenaAgentRun | null {
+  return agentRuns.find((run) => run.agent_type === id) ?? null;
+}
+
+function statusFor(
+  id: ArenaNodeId,
+  run: ArenaRun,
+  agentRun: ArenaAgentRun | null
+): NodeStatus {
+  if (agentRun) return "DONE";
+  if (id === "human_review" && run.post?.current_pipeline_stage === "human_review") {
+    return "WAITING";
+  }
+  const stageIndex = PIPELINE_STAGE_ORDER.indexOf(id);
+  if (isTerminalRejected(run.post) && stageIndex > PIPELINE_STAGE_ORDER.indexOf("human_review")) {
+    return "SKIPPED";
+  }
+  return "QUEUED";
+}
+
+function contextBriefNode(base: NodeLayout, event: CalendarEvent | null): ArenaNodeView {
+  if (!event) {
+    return {
+      ...base,
+      status: "READ",
+      lines: ["No calendar event — ad hoc post"],
+      stats: [],
+      footer: STAGE_DESCRIPTIONS.brief,
+      agentRun: null,
+      reviewFeedback: [],
+    };
+  }
+  return {
+    ...base,
+    status: "READ",
+    lines: [
+      truncate(event.title, 42),
+      `platforms: ${event.target_platforms.join(", ") || "—"}`,
+      `format: ${event.desired_format}`,
+    ],
+    stats: [
+      { label: "PLATFORMS", value: String(event.target_platforms.length) },
+      { label: "STATUS", value: event.status },
+      { label: "FORMAT", value: event.desired_format },
+    ],
+    footer: `calendar event · ${new Date(event.target_datetime).toLocaleDateString()}`,
+    agentRun: null,
+    reviewFeedback: [],
+  };
+}
+
+function contextBrandNode(base: NodeLayout, brand: Brand | null): ArenaNodeView {
+  if (!brand) {
+    return {
+      ...base,
+      status: "READ",
+      lines: ["No brand selected"],
+      stats: [],
+      footer: STAGE_DESCRIPTIONS.brand,
+      agentRun: null,
+      reviewFeedback: [],
+    };
+  }
+  return {
+    ...base,
+    status: "READ",
+    lines: [
+      brand.industry ?? "industry not set",
+      `${brand.tone_descriptors?.length ?? 0} tone descriptors`,
+    ],
+    stats: [
+      { label: "INDUSTRY", value: brand.industry ?? "—" },
+      { label: "COLORS", value: String(brand.colors?.length ?? 0) },
+      { label: "REPORT", value: brand.brand_report ? "ready" : "none" },
+    ],
+    footer: brand.name,
+    agentRun: null,
+    reviewFeedback: [],
+  };
+}
+
+function researchLines(agentRun: ArenaAgentRun): { lines: string[]; stats: { label: string; value: string }[] } {
+  const brief = agentRun.output?.research_brief as
+    | { platform_trends?: Record<string, unknown[]>; industry_trends?: { title: string }[] }
+    | undefined;
+  const platformTrendCount = brief?.platform_trends
+    ? Object.values(brief.platform_trends).reduce((sum, arr) => sum + (Array.isArray(arr) ? arr.length : 0), 0)
+    : 0;
+  const industryTrends = brief?.industry_trends ?? [];
+  const sourceCount = platformTrendCount + industryTrends.length;
+  return {
+    lines: [
+      `${sourceCount} source${sourceCount === 1 ? "" : "s"} found`,
+      industryTrends[0]?.title ? truncate(industryTrends[0].title, 48) : "no industry trend surfaced",
+    ],
+    stats: [
+      { label: "SOURCES", value: String(sourceCount) },
+      { label: "COST", value: formatCost(agentRun.cost) },
+      { label: "LATENCY", value: formatLatency(agentRun.latency_ms) },
+    ],
+  };
+}
+
+function creativeLines(agentRun: ArenaAgentRun): { lines: string[]; stats: { label: string; value: string }[] } {
+  const brief = agentRun.output?.creative_brief as
+    | { platforms?: Record<string, { hook?: string; format?: string }> }
+    | undefined;
+  const platforms = brief?.platforms ?? {};
+  const platformIds = Object.keys(platforms);
+  const firstHook = platformIds[0] ? platforms[platformIds[0]]?.hook : undefined;
+  return {
+    lines: [
+      `${platformIds.length} platform brief${platformIds.length === 1 ? "" : "s"}`,
+      firstHook ? truncate(firstHook, 52) : "no hook generated",
+    ],
+    stats: [
+      { label: "PLATFORMS", value: String(platformIds.length) },
+      { label: "MODEL", value: agentRun.model ?? "—" },
+      { label: "COST", value: formatCost(agentRun.cost) },
+    ],
+  };
+}
+
+function generationLines(agentRun: ArenaAgentRun): { lines: string[]; stats: { label: string; value: string }[] } {
+  const output = agentRun.output?.generation_output as
+    | { platforms?: Record<string, unknown> }
+    | undefined;
+  const platformIds = Object.keys(output?.platforms ?? {});
+  return {
+    lines: [
+      `${platformIds.length} draft${platformIds.length === 1 ? "" : "s"} written`,
+      agentRun.model ? `model: ${agentRun.model}` : "model not recorded",
+    ],
+    stats: [
+      { label: "DRAFTS", value: String(platformIds.length) },
+      { label: "TOKENS", value: formatTokens(agentRun.tokens) },
+      { label: "COST", value: formatCost(agentRun.cost) },
+    ],
+  };
+}
+
+function reviewerLines(
+  agentRun: ArenaAgentRun,
+  reviewFeedback: ArenaReviewFeedback[]
+): { lines: string[]; stats: { label: string; value: string }[] } {
+  const latest = reviewFeedback[reviewFeedback.length - 1];
+  return {
+    lines: latest
+      ? [`score ${latest.score.toFixed(0)}/100 · ${latest.verdict}`]
+      : ["review pass complete"],
+    stats: [
+      { label: "SCORE", value: latest ? latest.score.toFixed(0) : "—" },
+      { label: "VERDICT", value: latest ? latest.verdict : "—" },
+      { label: "COST", value: formatCost(agentRun.cost) },
+    ],
+  };
+}
+
+function humanReviewLines(
+  run: ArenaRun,
+  agentRun: ArenaAgentRun | null,
+  humanFeedback: ArenaReviewFeedback[]
+): { lines: string[]; stats: { label: string; value: string }[] } {
+  if (!agentRun && run.post?.current_pipeline_stage === "human_review") {
+    return {
+      lines: ["Paused — waiting on a human decision", "durable interrupt · resumes exactly here"],
+      stats: [{ label: "PENDING", value: "1" }, { label: "SINCE", value: formatClockShort(run.post.updated_at) }, { label: "SLA", value: "—" }],
+    };
+  }
+  const latest = humanFeedback[humanFeedback.length - 1];
+  if (latest) {
+    return {
+      lines: [`${latest.verdict} by a human reviewer`],
+      stats: [{ label: "VERDICT", value: latest.verdict }, { label: "SCORE", value: latest.score.toFixed(0) }, { label: "AT", value: formatClockShort(latest.created_at) }],
+    };
+  }
+  return { lines: ["not reached yet"], stats: [] };
+}
+
+function formatClockShort(iso: string): string {
+  const d = new Date(iso);
+  return Number.isNaN(d.getTime()) ? "—" : d.toLocaleTimeString(undefined, { hour: "2-digit", minute: "2-digit" });
+}
+
+function genericStageLines(agentRun: ArenaAgentRun): { lines: string[]; stats: { label: string; value: string }[] } {
+  return {
+    lines: [STAGE_DESCRIPTIONS[agentRun.agent_type], "ran successfully"],
+    stats: [
+      { label: "MODEL", value: agentRun.model ?? "—" },
+      { label: "COST", value: formatCost(agentRun.cost) },
+      { label: "LATENCY", value: formatLatency(agentRun.latency_ms) },
+    ],
+  };
+}
+
+function stageNode(
+  base: NodeLayout,
+  id: ArenaNodeId,
+  run: ArenaRun
+): ArenaNodeView {
+  const agentRun = findAgentRun(run.agent_runs, id);
+  const status = statusFor(id, run, agentRun);
+  const reviewFeedback =
+    id === "reviewer"
+      ? run.review_feedback.filter((f) => f.source === "ai_reviewer")
+      : id === "human_review"
+        ? run.review_feedback.filter((f) => f.source === "human")
+        : [];
+
+  if (!agentRun) {
+    const waiting = status === "WAITING";
+    const skipped = status === "SKIPPED";
+    let extra: { lines: string[]; stats: { label: string; value: string }[] } = {
+      lines: [skipped ? "skipped — run was rejected before reaching here" : "not run yet"],
+      stats: [],
+    };
+    if (id === "human_review" || waiting) {
+      extra = humanReviewLines(run, null, reviewFeedback);
+    }
+    return {
+      ...base,
+      status,
+      lines: extra.lines,
+      stats: extra.stats,
+      footer: STAGE_DESCRIPTIONS[id],
+      agentRun: null,
+      reviewFeedback,
+    };
+  }
+
+  let extra: { lines: string[]; stats: { label: string; value: string }[] };
+  switch (id) {
+    case "research":
+      extra = researchLines(agentRun);
+      break;
+    case "creative":
+      extra = creativeLines(agentRun);
+      break;
+    case "generation":
+      extra = generationLines(agentRun);
+      break;
+    case "reviewer":
+      extra = reviewerLines(agentRun, reviewFeedback);
+      break;
+    case "human_review":
+      extra = humanReviewLines(run, agentRun, reviewFeedback);
+      break;
+    default:
+      extra = genericStageLines(agentRun);
+  }
+
+  return {
+    ...base,
+    status,
+    lines: extra.lines,
+    stats: extra.stats,
+    footer: `${STAGE_DESCRIPTIONS[id]} · ${formatClockShort(agentRun.created_at)}`,
+    agentRun,
+    reviewFeedback,
+  };
+}
+
+export function buildArenaNodes(
+  run: ArenaRun,
+  event: CalendarEvent | null,
+  brand: Brand | null
+): ArenaNodeView[] {
+  return NODE_LAYOUT.map((base) => {
+    if (base.id === "brief") return contextBriefNode(base, event);
+    if (base.id === "brand") return contextBrandNode(base, brand);
+    return stageNode(base, base.id, run);
+  });
+}

--- a/apps/web/app/arena/dock.tsx
+++ b/apps/web/app/arena/dock.tsx
@@ -1,0 +1,175 @@
+"use client";
+
+import { useState } from "react";
+import type { ArenaRun } from "@/lib/api";
+import { buildCostRows, buildDraftThumbs, buildSources, buildTrace, totalCost, totalTokens } from "./build-dock";
+import { formatClock, formatCost, formatTokens } from "./format";
+
+type DockTab = "trace" | "outputs" | "cost" | "sources";
+
+const AGENT_COLOR: Record<string, string> = {
+  Ved: "#8FB4FF",
+  Keshav: "#C9A6FF",
+  Kavi: "#6BE3B0",
+  Neer: "#FFC46B",
+  system: "#7C8AB4",
+  Scheduler: "#7FD4FF",
+  Publisher: "#7FD4FF",
+  Analytics: "#FF9BC4",
+};
+
+export function Dock({ run }: { run: ArenaRun }) {
+  const [tab, setTab] = useState<DockTab>("trace");
+  const trace = buildTrace(run);
+  const costRows = buildCostRows(run);
+  const sources = buildSources(run);
+  const drafts = buildDraftThumbs(run);
+
+  const tabs: { id: DockTab; label: string; count: number | string }[] = [
+    { id: "trace", label: "Trace", count: trace.length },
+    { id: "outputs", label: "Outputs", count: Object.keys(run.post?.body_text ?? {}).length },
+    { id: "cost", label: "Cost", count: formatCost(totalCost(run)) },
+    { id: "sources", label: "Sources", count: sources.length },
+  ];
+
+  return (
+    <div className="grid h-[196px] min-h-0 grid-cols-[minmax(0,1fr)_320px] border-t border-arenadark-border bg-arenadark-panel">
+      <div className="flex min-h-0 flex-col border-r border-arenadark-border">
+        <div className="flex items-center gap-1 px-3.5 pt-2">
+          {tabs.map((t) => (
+            <button
+              key={t.id}
+              type="button"
+              onClick={() => setTab(t.id)}
+              aria-pressed={tab === t.id}
+              className="rounded-t-lg px-2.5 py-1.5 text-[11.5px] font-bold"
+              style={{ color: tab === t.id ? "#fff" : "#7C8AB4", background: tab === t.id ? "#131C3B" : "transparent" }}
+            >
+              {t.label} <span className="font-semibold text-arenadark-muted">{t.count}</span>
+            </button>
+          ))}
+        </div>
+
+        <div className="flex-1 overflow-auto px-3.5 py-2">
+          {tab === "trace" &&
+            (trace.length === 0 ? (
+              <EmptyDockState text="No agent runs logged yet for this run." />
+            ) : (
+              <ul className="flex flex-col gap-1.5" aria-label="Run trace">
+                {[...trace].reverse().map((entry) => (
+                  <li key={entry.id} className="flex items-start gap-2.5">
+                    <span className="flex-none pt-px font-mono text-[10px] text-arenadark-muted">
+                      {formatClock(entry.time)}
+                    </span>
+                    <span
+                      className="w-[70px] flex-none text-[10.5px] font-extrabold"
+                      style={{ color: AGENT_COLOR[entry.who] ?? "#93A2CC" }}
+                    >
+                      {entry.who}
+                    </span>
+                    <span className="min-w-0 text-[11.5px] leading-relaxed text-arenadark-text3">{entry.text}</span>
+                  </li>
+                ))}
+              </ul>
+            ))}
+
+          {tab === "outputs" &&
+            (!run.post?.body_text || Object.keys(run.post.body_text).length === 0 ? (
+              <EmptyDockState text="No generated copy yet — Generation hasn't run." />
+            ) : (
+              <ul className="flex flex-col gap-2">
+                {Object.entries(run.post.body_text).map(([platform, text]) => (
+                  <li key={platform} className="rounded-[9px] border border-arenadark-border3 bg-arenadark-panel3 px-2.5 py-2">
+                    <div className="mb-1 text-[9.5px] font-extrabold uppercase tracking-wide text-arenadark-muted">
+                      {platform}
+                    </div>
+                    <p className="text-[11.5px] leading-relaxed text-arenadark-text2">{text}</p>
+                  </li>
+                ))}
+              </ul>
+            ))}
+
+          {tab === "cost" &&
+            (costRows.length === 0 ? (
+              <EmptyDockState text="No cost/token data recorded yet." />
+            ) : (
+              <div>
+                <div className="mb-2 flex gap-4 text-[11.5px] text-arenadark-text2">
+                  <span>
+                    Total cost <b className="text-white">{formatCost(totalCost(run))}</b>
+                  </span>
+                  <span>
+                    Total tokens <b className="text-white">{formatTokens(totalTokens(run))}</b>
+                  </span>
+                </div>
+                <ul className="flex flex-col gap-1">
+                  {costRows.map((row) => (
+                    <li key={row.agentType} className="flex items-center gap-3 text-[11.5px] text-arenadark-text3">
+                      <span className="w-20 flex-none font-bold" style={{ color: AGENT_COLOR[row.who] ?? "#93A2CC" }}>
+                        {row.who}
+                      </span>
+                      <span className="w-28 flex-none font-mono text-[10.5px]">{row.model}</span>
+                      <span className="w-16 flex-none">{row.tokens} tok</span>
+                      <span>{row.cost}</span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            ))}
+
+          {tab === "sources" &&
+            (sources.length === 0 ? (
+              <EmptyDockState text="No sources yet — Research hasn't run." />
+            ) : (
+              <ul className="flex flex-col gap-1.5">
+                {sources.map((source) => (
+                  <li key={source.url} className="text-[11.5px]">
+                    <a
+                      href={source.url}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="font-semibold text-arenadark-text2 hover:underline"
+                    >
+                      {source.title}
+                    </a>
+                    <span className="ml-2 text-[11px] text-arenadark-muted">{source.domain}</span>
+                  </li>
+                ))}
+              </ul>
+            ))}
+        </div>
+      </div>
+
+      <div className="flex min-h-0 flex-col">
+        <div className="flex items-center gap-2 px-3.5 pb-1.5 pt-2.5">
+          <span className="text-[9.5px] font-extrabold tracking-[.13em] text-arenadark-muted">DRAFT MEDIA</span>
+          <span className="rounded-[5px] bg-[#152249] px-1.5 py-0.5 text-[10px] font-bold text-[#8FB4FF]">
+            {drafts.length}
+          </span>
+        </div>
+        <div className="flex flex-1 gap-2 overflow-auto px-3.5 pb-3">
+          {drafts.length === 0 ? (
+            <EmptyDockState text="No media generated for this run yet." />
+          ) : (
+            drafts.map((draft, i) => (
+              <div key={i} className="w-28 flex-none overflow-hidden rounded-[10px] border border-arenadark-border3 bg-arenadark-panel3">
+                {/* eslint-disable-next-line @next/next/no-img-element -- real Post.media URLs from arbitrary storage hosts, same as components/ui/Avatar.tsx */}
+                <img src={draft.url} alt={`${draft.platform} draft`} className="h-[78px] w-full object-cover" />
+                <div className="flex items-center gap-1 px-2 py-1.5">
+                  <span className="rounded-[4px] bg-arenadark-border3 px-1 text-[8.5px] font-extrabold text-white">
+                    {draft.platform}
+                  </span>
+                  <span className="truncate text-[9.5px] text-arenadark-muted2">{draft.format}</span>
+                </div>
+              </div>
+            ))
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function EmptyDockState({ text }: { text: string }) {
+  return <p className="text-[11.5px] italic text-arenadark-muted">{text}</p>;
+}

--- a/apps/web/app/arena/format.ts
+++ b/apps/web/app/arena/format.ts
@@ -1,0 +1,37 @@
+// Small formatting helpers shared across the Content Arena screen (Issue
+// #124). Kept pure/dependency-free so they're trivial to unit test.
+
+export function formatCost(cost: number | null | undefined): string {
+  if (cost === null || cost === undefined) return "—";
+  return `$${cost.toFixed(2)}`;
+}
+
+export function formatTokens(tokens: number | null | undefined): string {
+  if (tokens === null || tokens === undefined) return "—";
+  return tokens >= 1000 ? `${(tokens / 1000).toFixed(1)}k` : String(tokens);
+}
+
+export function formatLatency(latencyMs: number | null | undefined): string {
+  if (latencyMs === null || latencyMs === undefined) return "—";
+  return latencyMs >= 1000 ? `${(latencyMs / 1000).toFixed(1)}s` : `${Math.round(latencyMs)}ms`;
+}
+
+export function formatClock(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return "—";
+  return d.toLocaleTimeString(undefined, { hour: "2-digit", minute: "2-digit", second: "2-digit" });
+}
+
+export function formatElapsedSince(iso: string, now: Date = new Date()): string {
+  const start = new Date(iso).getTime();
+  if (Number.isNaN(start)) return "—";
+  const totalSeconds = Math.max(0, Math.floor((now.getTime() - start) / 1000));
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return `${String(minutes).padStart(2, "0")}:${String(seconds).padStart(2, "0")}`;
+}
+
+export function truncate(text: string, max: number): string {
+  if (text.length <= max) return text;
+  return `${text.slice(0, max - 1).trimEnd()}…`;
+}

--- a/apps/web/app/arena/inspector.tsx
+++ b/apps/web/app/arena/inspector.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import type { ArenaNodeView } from "./build-nodes";
+
+const isStageNode = (node: ArenaNodeView) => node.id !== "brief" && node.id !== "brand";
+
+export function Inspector({ node }: { node: ArenaNodeView }) {
+  return (
+    <aside className="flex min-h-0 flex-col border-l border-arenadark-border bg-arenadark-panel">
+      <div className="border-b border-arenadark-border px-4 py-3.5">
+        <div className="mb-2.5 flex items-center gap-2.5">
+          <div
+            className="flex h-[26px] w-[26px] flex-none items-center justify-center rounded-lg text-[11px] font-extrabold text-white"
+            style={{ background: node.color }}
+          >
+            {node.initial}
+          </div>
+          <div className="min-w-0 flex-1">
+            <div className="truncate text-sm font-bold text-white">{node.name}</div>
+            <div className="truncate text-[10.5px] text-arenadark-muted2">{node.sub}</div>
+          </div>
+        </div>
+        <div className="grid grid-cols-3 gap-1.5">
+          {node.stats.length > 0 ? (
+            node.stats.map((stat) => (
+              <div key={stat.label} className="rounded-[9px] border border-arenadark-border bg-arenadark-panel3 px-2 py-1.5">
+                <div className="text-[9px] font-bold tracking-wide text-arenadark-muted">{stat.label}</div>
+                <div className="mt-0.5 text-[12.5px] font-extrabold text-arenadark-text2">{stat.value}</div>
+              </div>
+            ))
+          ) : (
+            <div className="col-span-3 text-[11px] text-arenadark-muted">No stats yet</div>
+          )}
+        </div>
+      </div>
+
+      <div className="flex min-h-0 flex-1 flex-col gap-3 overflow-auto px-4 py-3.5">
+        <div>
+          <div className="mb-1.5 text-[10.5px] font-bold text-arenadark-muted2">Summary</div>
+          <div className="flex flex-col gap-1 rounded-[9px] border border-arenadark-border3 bg-arenadark-panel3 px-2.5 py-2">
+            {node.lines.map((line, i) => (
+              <div key={i} className="font-mono text-[11.5px] leading-relaxed text-arenadark-text2">
+                {line}
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {isStageNode(node) && (
+          <div>
+            <div className="mb-1.5 text-[10.5px] font-bold text-arenadark-muted2">System prompt · editable</div>
+            <div className="rounded-[9px] border border-dashed border-arenadark-border3 bg-arenadark-panel3 px-2.5 py-2.5 text-[11.5px] italic text-arenadark-muted">
+              Not available yet — this stage&apos;s AgentRun only records{" "}
+              <code className="not-italic">{"{post_id}"}</code> as input, not the prompt actually sent.
+            </div>
+          </div>
+        )}
+
+        {isStageNode(node) && (
+          <div className="min-h-0">
+            <div className="mb-1.5 text-[10.5px] font-bold text-arenadark-muted2">Raw output</div>
+            {node.agentRun?.output ? (
+              <pre className="max-h-40 overflow-auto whitespace-pre-wrap break-words rounded-[9px] border border-arenadark-border3 bg-arenadark-panel3 px-2.5 py-2 font-mono text-[10.5px] leading-relaxed text-arenadark-text3">
+                {JSON.stringify(node.agentRun.output, null, 2)}
+              </pre>
+            ) : (
+              <div className="rounded-[9px] border border-dashed border-arenadark-border3 bg-arenadark-panel3 px-2.5 py-2.5 text-[11.5px] italic text-arenadark-muted">
+                No output recorded yet — this stage hasn&apos;t run.
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+
+      <div className="flex flex-col gap-1.5 border-t border-arenadark-border px-4 py-3">
+        <button
+          type="button"
+          disabled
+          title="Coming soon"
+          className="h-9 cursor-not-allowed rounded-[10px] bg-brand-600/30 text-[12.5px] font-bold text-white/50"
+        >
+          Re-run from this block · Coming soon
+        </button>
+        <div className="flex gap-1.5">
+          {["Add branch", "Pin output", "Mute"].map((label) => (
+            <button
+              key={label}
+              type="button"
+              disabled
+              title="Coming soon"
+              className="h-8 flex-1 cursor-not-allowed rounded-[9px] border border-arenadark-border3 bg-arenadark-panel3 text-[11.5px] font-semibold text-arenadark-muted2"
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+      </div>
+    </aside>
+  );
+}

--- a/apps/web/app/arena/library-panel.tsx
+++ b/apps/web/app/arena/library-panel.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { BLOCK_LIBRARY } from "./block-library";
+
+/** Static visual list of block types (Issue #124 scopes this to
+ * read-only — no drag-drop). The search box filters the static list
+ * client-side, which is cheap and harmless to include even though
+ * dragging blocks onto the canvas is out of scope. */
+export function LibraryPanel() {
+  const [query, setQuery] = useState("");
+
+  const groups = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return BLOCK_LIBRARY;
+    return BLOCK_LIBRARY.map((group) => ({
+      ...group,
+      items: group.items.filter((item) => item.label.toLowerCase().includes(q)),
+    })).filter((group) => group.items.length > 0);
+  }, [query]);
+
+  return (
+    <aside className="flex min-h-0 flex-col border-r border-arenadark-border bg-arenadark-panel">
+      <div className="border-b border-arenadark-border px-3 pb-2.5 pt-3">
+        <input
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="Search blocks…"
+          aria-label="Search blocks"
+          className="h-8 w-full rounded-[9px] border border-arenadark-border3 bg-arenadark-panel3 px-2.5 text-xs text-arenadark-text2 outline-none placeholder:text-arenadark-muted"
+        />
+      </div>
+      <div className="flex-1 overflow-auto px-2.5 py-2.5">
+        {groups.length === 0 ? (
+          <p className="px-1 text-xs text-arenadark-muted">No blocks match &ldquo;{query}&rdquo;.</p>
+        ) : (
+          groups.map((group) => (
+            <div key={group.group} className="mb-3.5">
+              <div className="mb-1.5 px-0.5 text-[9.5px] font-extrabold tracking-[.13em] text-arenadark-muted">
+                {group.group}
+              </div>
+              <div className="flex flex-col gap-1">
+                {group.items.map((item) => (
+                  <div
+                    key={item.label}
+                    className="flex items-center gap-2 rounded-[9px] border border-arenadark-border bg-arenadark-panel3 px-2 py-1.5"
+                  >
+                    <span
+                      className="flex h-[18px] w-[18px] flex-none items-center justify-center rounded-[5px] text-[9.5px] font-extrabold text-white"
+                      style={{ background: item.color }}
+                    >
+                      {item.icon}
+                    </span>
+                    <span className="text-[11.5px] font-semibold text-arenadark-text2">{item.label}</span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          ))
+        )}
+      </div>
+    </aside>
+  );
+}

--- a/apps/web/app/arena/node-card.tsx
+++ b/apps/web/app/arena/node-card.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import type { ArenaNodeView } from "./build-nodes";
+import { STATUS_STYLES } from "./status-styles";
+
+export function NodeCard({
+  node,
+  isSelected,
+  onSelect,
+}: {
+  node: ArenaNodeView;
+  isSelected: boolean;
+  onSelect: (id: string) => void;
+}) {
+  const statusStyle = STATUS_STYLES[node.status];
+  const isLive = node.status === "WAITING";
+
+  return (
+    <button
+      type="button"
+      onClick={() => onSelect(node.id)}
+      aria-pressed={isSelected}
+      aria-label={`Select ${node.name}`}
+      style={{
+        left: node.x,
+        top: node.y,
+        width: node.w,
+        borderColor: isSelected ? "#3D6BFF" : node.status === "WAITING" ? "#7A5A1E" : "#1D2743",
+        boxShadow: isSelected
+          ? "0 0 0 3px rgba(61,107,255,.18)"
+          : isLive
+            ? "0 0 26px -8px rgba(43,109,255,.7)"
+            : "none",
+      }}
+      className="absolute flex cursor-pointer flex-col overflow-hidden rounded-[13px] border-[1.5px] bg-arenadark-panel2 text-left"
+    >
+      <div
+        className="flex items-center gap-1.5 border-b border-arenadark-border px-2.5 py-2"
+        style={{ background: isSelected ? "#17224A" : "#0F1731" }}
+      >
+        <div
+          className="flex h-[19px] w-[19px] flex-none items-center justify-center rounded-[6px] text-[9px] font-extrabold text-white"
+          style={{ background: node.color }}
+        >
+          {node.initial}
+        </div>
+        <span className="min-w-0 flex-1 truncate text-[11.5px] font-bold text-arenadark-text">{node.name}</span>
+        <span
+          className="flex-none rounded-[5px] px-[5px] py-[2px] text-[8.5px] font-extrabold tracking-wide"
+          style={{ color: statusStyle.fg, background: statusStyle.bg }}
+        >
+          {statusStyle.label}
+        </span>
+      </div>
+      <div className="flex flex-col gap-1 px-2.5 py-2">
+        {node.lines.map((line, i) => (
+          <div key={i} className="truncate font-mono text-[10.5px] leading-tight text-arenadark-text3">
+            {line}
+          </div>
+        ))}
+      </div>
+      <div className="mt-auto truncate border-t border-[#161F3C] bg-arenadark-panel px-2.5 py-1.5 font-mono text-[9.5px] text-arenadark-muted">
+        {node.footer}
+      </div>
+    </button>
+  );
+}

--- a/apps/web/app/arena/page.tsx
+++ b/apps/web/app/arena/page.tsx
@@ -1,0 +1,308 @@
+"use client";
+
+import Link from "next/link";
+import { Suspense, useCallback, useEffect, useMemo, useState } from "react";
+import { useSearchParams } from "next/navigation";
+import {
+  type ArenaRun,
+  type CalendarEvent,
+  fetchArenaRunForEvent,
+  fetchCalendarEvents,
+  fetchLatestArenaRun,
+} from "@/lib/api";
+import { useAuth } from "@/lib/auth-context";
+import { useBrand } from "@/lib/brand-context";
+import { buildArenaNodes } from "./build-nodes";
+import { totalCost } from "./build-dock";
+import { Dock } from "./dock";
+import { formatCost, formatElapsedSince } from "./format";
+import { Inspector } from "./inspector";
+import { LibraryPanel } from "./library-panel";
+import { NodeCard } from "./node-card";
+import { CANVAS_HEIGHT, CANVAS_WIDTH, EDGES, FEEDBACK_EDGE, LANES, edgePath, feedbackPath, type ArenaNodeId } from "./topology";
+
+// Same "keep it live without a manual refresh" convention as
+// apps/web/app/calendar/page.tsx and app/review-queue/page.tsx — a run's
+// AgentRun rows, review feedback, or pipeline stage can change from
+// outside this tab (e.g. the trigger poller advancing it, or a teammate
+// approving it from the Review Queue).
+const POLL_INTERVAL_MS = 15000;
+
+const TERMINAL_STAGES = new Set(["completed", "rejected", "failed"]);
+
+export default function ArenaPage() {
+  return (
+    <Suspense fallback={<div className="min-h-screen bg-arenadark-bg" />}>
+      <ArenaScreen />
+    </Suspense>
+  );
+}
+
+function ArenaScreen() {
+  const { token } = useAuth();
+  const { selectedBrand, selectedBrandId } = useBrand();
+  const searchParams = useSearchParams();
+  const eventIdParam = searchParams.get("event");
+
+  const [run, setRun] = useState<ArenaRun | null>(null);
+  const [events, setEvents] = useState<CalendarEvent[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [selectedNodeId, setSelectedNodeId] = useState<ArenaNodeId>("research");
+  // Purely client-side toggle — the transport controls next to it are
+  // render-only, per Issue #124's scope (no real playback/streaming).
+  const [isPlaying, setIsPlaying] = useState(true);
+  const [now, setNow] = useState(() => new Date());
+
+  const load = useCallback(
+    async (showSpinner: boolean) => {
+      if (!token || !selectedBrandId) {
+        setRun(null);
+        return;
+      }
+      if (showSpinner) setIsLoading(true);
+      setError(null);
+      try {
+        const [runResult, eventList] = await Promise.all([
+          eventIdParam
+            ? fetchArenaRunForEvent(token, selectedBrandId, eventIdParam)
+            : fetchLatestArenaRun(token, selectedBrandId),
+          fetchCalendarEvents(token, selectedBrandId),
+        ]);
+        setRun(runResult);
+        setEvents(eventList);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Failed to load the Content Arena run");
+      } finally {
+        if (showSpinner) setIsLoading(false);
+      }
+    },
+    [token, selectedBrandId, eventIdParam]
+  );
+
+  useEffect(() => {
+    setRun(null);
+    load(true);
+    const interval = setInterval(() => load(false), POLL_INTERVAL_MS);
+    const onFocus = () => load(false);
+    window.addEventListener("focus", onFocus);
+    return () => {
+      clearInterval(interval);
+      window.removeEventListener("focus", onFocus);
+    };
+  }, [load]);
+
+  // Live-ticking clock for the header's elapsed-time stat — the
+  // underlying timestamp (post.created_at) is real, this just keeps the
+  // displayed duration counting up between polls.
+  useEffect(() => {
+    const tick = setInterval(() => setNow(new Date()), 1000);
+    return () => clearInterval(tick);
+  }, []);
+
+  const event = useMemo(() => {
+    if (!run?.calendar_event_id) return null;
+    return events.find((e) => e.id === run.calendar_event_id) ?? null;
+  }, [run, events]);
+
+  const nodes = useMemo(() => {
+    if (!run) return [];
+    return buildArenaNodes(run, event, selectedBrand ?? null);
+  }, [run, event, selectedBrand]);
+
+  const nodesById = useMemo(() => new Map(nodes.map((n) => [n.id, n])), [nodes]);
+  const selectedNode = nodesById.get(selectedNodeId) ?? nodes[0] ?? null;
+
+  const edgeElements = useMemo(() => {
+    if (nodes.length === 0) return [];
+    const straight = EDGES.map(([a, b]) => {
+      const from = nodesById.get(a);
+      const to = nodesById.get(b);
+      if (!from || !to) return null;
+      const isActive = a === selectedNodeId || b === selectedNodeId;
+      return { key: `${a}-${b}`, d: edgePath(from, to), stroke: isActive ? "#3D6BFF" : "#22305C", dash: "6 6" };
+    }).filter((e): e is NonNullable<typeof e> => e !== null);
+
+    const [fa, fb] = FEEDBACK_EDGE;
+    const feedbackFrom = nodesById.get(fa);
+    const feedbackTo = nodesById.get(fb);
+    if (feedbackFrom && feedbackTo) {
+      straight.push({
+        key: `${fa}-${fb}-feedback`,
+        d: feedbackPath(feedbackFrom, feedbackTo),
+        stroke: "#C2477F",
+        dash: "2 7",
+      });
+    }
+    return straight;
+  }, [nodes, nodesById, selectedNodeId]);
+
+  const isRunning = !!run?.post && !TERMINAL_STAGES.has(run.post.current_pipeline_stage);
+  const waitingOnYou = nodes.some((n) => n.status === "WAITING");
+  const runCost = run ? totalCost(run) : 0;
+
+  const headerTitle = event ? event.title : run?.post ? "Ad hoc post run" : "Content Arena";
+
+  return (
+    <div className="flex h-screen flex-col bg-arenadark-bg text-arenadark-text">
+      <header className="flex flex-none items-center justify-between gap-4 border-b border-arenadark-border bg-arenadark-panel px-[18px] py-2.5">
+        <div className="flex min-w-0 items-center gap-3">
+          <Link
+            href="/calendar"
+            className="flex h-[31px] items-center rounded-[9px] border border-arenadark-border3 bg-arenadark-panel3 px-2.5 text-[12.5px] font-semibold text-arenadark-text2"
+          >
+            ←
+          </Link>
+          <div className="min-w-0">
+            <div className="flex items-center gap-2">
+              <span className="truncate text-[14.5px] font-bold text-white">{headerTitle}</span>
+              {run?.post ? (
+                <span
+                  className="flex items-center gap-1.5 rounded-[6px] px-[7px] py-[3px] text-[10px] font-extrabold tracking-wide"
+                  style={
+                    isRunning
+                      ? { color: "#6BE3B0", background: "rgba(107,227,176,.12)", border: "1px solid rgba(107,227,176,.3)" }
+                      : { color: "#7C8AB4", background: "rgba(124,138,180,.12)", border: "1px solid rgba(124,138,180,.3)" }
+                  }
+                >
+                  {isRunning && <i className="h-1.5 w-1.5 animate-rd-blink rounded-full bg-[#6BE3B0]" />}
+                  {isRunning ? "RUNNING" : run.post.current_pipeline_stage.toUpperCase()}
+                </span>
+              ) : null}
+            </div>
+            <div className="mt-0.5 flex items-center gap-3.5">
+              {run?.post ? (
+                <>
+                  <Stat label="elapsed" value={formatElapsedSince(run.post.created_at, now)} />
+                  <Stat label="agent runs" value={String(run.agent_runs.length)} />
+                  <Stat label="spent" value={formatCost(runCost)} />
+                  <Stat label="waiting on you" value={waitingOnYou ? "1" : "0"} />
+                </>
+              ) : (
+                <span className="text-[11px] text-arenadark-muted2">No pipeline run yet for this brand.</span>
+              )}
+            </div>
+          </div>
+        </div>
+        <div className="flex flex-none items-center gap-1.5">
+          <div className="flex items-center gap-0.5 rounded-[9px] border border-arenadark-border3 bg-arenadark-panel3 p-[3px]">
+            <button type="button" onClick={() => {}} aria-label="Skip to start" className="h-[26px] w-7 rounded-[7px] text-[11px] text-arenadark-text2">
+              ⏮
+            </button>
+            <button
+              type="button"
+              onClick={() => setIsPlaying((p) => !p)}
+              aria-label={isPlaying ? "Pause" : "Play"}
+              className="h-[26px] w-7 rounded-[7px] bg-brand-600 text-[11px] text-white"
+            >
+              {isPlaying ? "⏸" : "▶"}
+            </button>
+            <button type="button" onClick={() => {}} aria-label="Skip to end" className="h-[26px] w-7 rounded-[7px] text-[11px] text-arenadark-text2">
+              ⏭
+            </button>
+          </div>
+          <Link
+            href="/review-queue"
+            className="flex h-8 items-center rounded-[9px] bg-brand-600 px-3.5 text-xs font-bold text-white"
+          >
+            Skip to review →
+          </Link>
+        </div>
+      </header>
+
+      {error && (
+        <p role="alert" className="flex-none bg-danger-bg px-4 py-2 text-sm font-medium text-danger">
+          {error}
+        </p>
+      )}
+
+      {!selectedBrand ? (
+        <div className="flex flex-1 items-center justify-center text-sm text-arenadark-muted2">
+          Select a brand to see its Content Arena.
+        </div>
+      ) : isLoading && !run ? (
+        <div role="status" className="flex flex-1 items-center justify-center text-sm text-arenadark-muted2">
+          Loading run…
+        </div>
+      ) : (
+        <div className="grid min-h-0 flex-1 grid-cols-[206px_minmax(0,1fr)_336px]">
+          <LibraryPanel />
+
+          <div className="flex min-h-0 min-w-0 flex-col">
+            <div className="relative flex-1 overflow-auto bg-arenadark-bg">
+              {!run?.post ? (
+                <div className="flex h-full items-center justify-center px-6 text-center text-sm text-arenadark-muted2">
+                  No pipeline runs yet for this brand — trigger a calendar event to see it here.
+                </div>
+              ) : (
+                <div
+                  className="relative"
+                  style={{
+                    width: CANVAS_WIDTH,
+                    height: CANVAS_HEIGHT,
+                    backgroundImage: "radial-gradient(#18213F 1.1px, transparent 1.1px)",
+                    backgroundSize: "26px 26px",
+                  }}
+                >
+                  {LANES.map((lane) => (
+                    <div
+                      key={lane.id}
+                      className="absolute rounded-2xl border border-[#141C36]"
+                      style={{ top: 16, bottom: 16, left: lane.x, width: lane.w, background: "rgba(17,26,54,.35)" }}
+                    >
+                      <div
+                        className="absolute left-3.5 top-2.5 text-[9.5px] font-extrabold tracking-[.16em]"
+                        style={{ color: lane.fg }}
+                      >
+                        {lane.label}
+                      </div>
+                    </div>
+                  ))}
+
+                  <svg className="pointer-events-none absolute inset-0 h-full w-full">
+                    {edgeElements.map((edge) => (
+                      <path
+                        key={edge.key}
+                        d={edge.d}
+                        fill="none"
+                        stroke={edge.stroke}
+                        strokeWidth={1.6}
+                        strokeDasharray={edge.dash}
+                        className="animate-rd-dash"
+                      />
+                    ))}
+                  </svg>
+
+                  {nodes.map((node) => (
+                    <NodeCard
+                      key={node.id}
+                      node={node}
+                      isSelected={node.id === selectedNodeId}
+                      onSelect={(id) => setSelectedNodeId(id as ArenaNodeId)}
+                    />
+                  ))}
+                </div>
+              )}
+            </div>
+
+            {run && <Dock run={run} />}
+          </div>
+
+          {selectedNode ? (
+            <Inspector node={selectedNode} />
+          ) : (
+            <aside className="border-l border-arenadark-border bg-arenadark-panel" />
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function Stat({ label, value }: { label: string; value: string }) {
+  return (
+    <span className="text-[11px] text-arenadark-muted2">
+      <b className="font-bold text-arenadark-text2">{value}</b> {label}
+    </span>
+  );
+}

--- a/apps/web/app/arena/status-styles.ts
+++ b/apps/web/app/arena/status-styles.ts
@@ -1,0 +1,9 @@
+import type { NodeStatus } from "./build-nodes";
+
+export const STATUS_STYLES: Record<NodeStatus, { fg: string; bg: string; label: string }> = {
+  DONE: { fg: "#8FB4FF", bg: "rgba(143,180,255,.14)", label: "DONE" },
+  WAITING: { fg: "#FFC46B", bg: "rgba(255,196,107,.14)", label: "WAITING" },
+  QUEUED: { fg: "#7C8AB4", bg: "rgba(124,138,180,.14)", label: "QUEUED" },
+  SKIPPED: { fg: "#5B6A96", bg: "rgba(91,106,150,.14)", label: "SKIPPED" },
+  READ: { fg: "#8FB4FF", bg: "rgba(143,180,255,.14)", label: "READ" },
+};

--- a/apps/web/app/arena/topology.ts
+++ b/apps/web/app/arena/topology.ts
@@ -1,0 +1,117 @@
+// Static graph topology for the Content Arena canvas (Issue #124) —
+// lanes, node positions, and edges. This mirrors the layout of "Raindeer
+// Social Startup Onboarding/Raindeer Social.dc.html"'s CONTENT ARENA
+// block, trimmed to the nodes that map onto something real: the mockup
+// invents several flavor sub-steps per lane (trend radar, social
+// listening, A/B hook split, risk & compliance, alerts & handoff, ...)
+// that have no backend counterpart at all, and Issue #124 is explicit
+// that node data must come from real data wherever it exists rather than
+// inventing telemetry for things the pipeline doesn't track. So this
+// graph has exactly one node per real thing: the two pieces of context a
+// run reads (the calendar event's brief, the brand) plus the eight real
+// pipeline stages (apps/api/models/agent_run.py::AgentType /
+// packages/agents/pipeline/graph.py::PIPELINE_STAGES).
+import type { AgentType } from "@/lib/api";
+
+export type ArenaNodeId =
+  | "brief"
+  | "brand"
+  | AgentType; // research | creative | generation | reviewer | human_review | scheduler | publisher | analytics_collector
+
+export interface LaneDef {
+  id: string;
+  label: string;
+  x: number;
+  w: number;
+  fg: string;
+}
+
+// x/w chosen to comfortably fit each lane's node width(s) plus gutters,
+// same left-to-right pipeline reading order as the mockup's LANES array.
+export const LANES: LaneDef[] = [
+  { id: "context", label: "CONTEXT", x: 14, w: 210, fg: "#5B6A96" },
+  { id: "research", label: "RESEARCH · VED", x: 240, w: 230, fg: "#8FB4FF" },
+  { id: "strategy", label: "STRATEGY · KESHAV", x: 486, w: 230, fg: "#C9A6FF" },
+  { id: "production", label: "PRODUCTION · KAVI", x: 732, w: 230, fg: "#6BE3B0" },
+  { id: "governance", label: "GOVERNANCE · NEER", x: 978, w: 250, fg: "#FFC46B" },
+  { id: "distribution", label: "DISTRIBUTION", x: 1244, w: 230, fg: "#7FD4FF" },
+  { id: "learning", label: "LEARNING", x: 1490, w: 200, fg: "#FF9BC4" },
+];
+
+export interface NodeLayout {
+  id: ArenaNodeId;
+  lane: string;
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+  color: string;
+  initial: string;
+  name: string;
+  /** Shown in the inspector header under the node name. */
+  sub: string;
+}
+
+export const NODE_LAYOUT: NodeLayout[] = [
+  { id: "brief", lane: "context", x: 28, y: 70, w: 182, h: 108, color: "#5B6784", initial: "▤", name: "Campaign brief", sub: "Calendar event · input" },
+  { id: "brand", lane: "context", x: 28, y: 210, w: 182, h: 108, color: "#0B2A6B", initial: "B", name: "Brand memory", sub: "Brand · read-only" },
+  { id: "research", lane: "research", x: 254, y: 90, w: 202, h: 170, color: "#1B4DFF", initial: "V", name: "Ved · Research", sub: "Research engine" },
+  { id: "creative", lane: "strategy", x: 500, y: 90, w: 202, h: 160, color: "#6B32C9", initial: "K", name: "Keshav · Creative", sub: "Creative engine" },
+  { id: "generation", lane: "production", x: 746, y: 90, w: 202, h: 160, color: "#0E7A4E", initial: "K", name: "Kavi · Generation", sub: "Generation engine" },
+  { id: "reviewer", lane: "governance", x: 992, y: 70, w: 222, h: 150, color: "#B46A00", initial: "N", name: "Neer · Reviewer", sub: "Reviewer engine" },
+  { id: "human_review", lane: "governance", x: 992, y: 250, w: 222, h: 140, color: "#1B4DFF", initial: "☺", name: "Human approval", sub: "Flow · durable interrupt" },
+  { id: "scheduler", lane: "distribution", x: 1258, y: 90, w: 202, h: 110, color: "#1E7FB8", initial: "◷", name: "Scheduler", sub: "Distribution" },
+  { id: "publisher", lane: "distribution", x: 1258, y: 240, w: 202, h: 130, color: "#1E7FB8", initial: "➤", name: "Publisher", sub: "Distribution" },
+  { id: "analytics_collector", lane: "learning", x: 1504, y: 150, w: 172, h: 140, color: "#C2477F", initial: "▲", name: "Analytics collector", sub: "Learning loop · always on" },
+];
+
+export const NODE_LAYOUT_BY_ID: Record<string, NodeLayout> = Object.fromEntries(
+  NODE_LAYOUT.map((n) => [n.id, n])
+);
+
+// [from, to] pairs — same left-to-right pipeline order as
+// packages/agents/pipeline/graph.py::PIPELINE_STAGES, plus the two
+// context nodes feeding into research.
+export const EDGES: [ArenaNodeId, ArenaNodeId][] = [
+  ["brief", "research"],
+  ["brand", "research"],
+  ["research", "creative"],
+  ["creative", "generation"],
+  ["generation", "reviewer"],
+  ["reviewer", "human_review"],
+  ["human_review", "scheduler"],
+  ["scheduler", "publisher"],
+  ["publisher", "analytics_collector"],
+];
+
+// The one feedback edge the mockup calls out explicitly (dashed, its own
+// color) — analytics_collector really does feed the *next* run's research
+// stage (Post.brand_id's brand memory accumulates engagement_snapshots),
+// just not this run's own research node, hence drawn separately from the
+// straight-line EDGES above.
+export const FEEDBACK_EDGE: [ArenaNodeId, ArenaNodeId] = ["analytics_collector", "research"];
+
+export const CANVAS_WIDTH = 1820;
+export const CANVAS_HEIGHT = 460;
+
+/** A smooth left-to-right cubic bezier between two node edges, same shape
+ * as the mockup's own `path()` helper. */
+export function edgePath(a: NodeLayout, b: NodeLayout): string {
+  const x1 = a.x + a.w;
+  const y1 = a.y + a.h / 2;
+  const x2 = b.x;
+  const y2 = b.y + b.h / 2;
+  const dx = Math.max(36, (x2 - x1) / 2);
+  return `M${x1},${y1} C${x1 + dx},${y1} ${x2 - dx},${y2} ${x2},${y2}`;
+}
+
+/** The feedback edge loops under the canvas rather than straight across —
+ * same visual treatment as the mockup's FEEDBACK path. */
+export function feedbackPath(from: NodeLayout, to: NodeLayout): string {
+  const x1 = from.x + from.w / 2;
+  const y1 = from.y + from.h;
+  const x2 = to.x + to.w / 2;
+  const y2 = to.y + to.h;
+  const loopY = CANVAS_HEIGHT - 30;
+  return `M${x1},${y1} C${x1},${loopY} ${x2},${loopY} ${x2},${y2}`;
+}

--- a/apps/web/components/auth-gate.tsx
+++ b/apps/web/components/auth-gate.tsx
@@ -9,16 +9,26 @@ import { Nav } from "@/components/nav";
 // Routes reachable without a token. Everything else is gated.
 const PUBLIC_PATHS = ["/login"];
 
+// Routes that render their own full-height shell instead of the light
+// Nav sidebar + padded <main> every other authenticated route gets. The
+// Content Arena (Issue #124, apps/web/app/arena/page.tsx) is a
+// deliberately separate dark visual world from the rest of the app — see
+// tailwind.config.ts's `arenadark` tokens — so it needs the full viewport
+// to itself, not squeezed into the app shell's max-w-6xl column.
+const FULL_BLEED_PATHS = ["/arena"];
+
 /**
  * Wraps the whole app (mounted from app/layout.tsx). Redirects
  * unauthenticated visitors to /login on every protected route, and renders
- * the shell nav once a session is present.
+ * the shell nav once a session is present (except on FULL_BLEED_PATHS,
+ * which render directly — still gated by the same redirect logic below).
  */
 export function AuthGate({ children }: { children: ReactNode }) {
   const { token, isLoading } = useAuth();
   const pathname = usePathname();
   const router = useRouter();
   const isPublicPath = PUBLIC_PATHS.includes(pathname);
+  const isFullBleed = FULL_BLEED_PATHS.some((path) => pathname.startsWith(path));
 
   useEffect(() => {
     if (isLoading || isPublicPath) return;
@@ -43,6 +53,10 @@ export function AuthGate({ children }: { children: ReactNode }) {
   if (!token) {
     // Redirect kicked off above; render nothing while it lands.
     return null;
+  }
+
+  if (isFullBleed) {
+    return <>{children}</>;
   }
 
   return (

--- a/apps/web/components/nav.tsx
+++ b/apps/web/components/nav.tsx
@@ -66,6 +66,16 @@ function IconSocial() {
     </svg>
   );
 }
+function IconArena() {
+  return (
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+      <circle cx="6" cy="6" r="2.2" stroke="currentColor" strokeWidth="1.8" />
+      <circle cx="18" cy="6" r="2.2" stroke="currentColor" strokeWidth="1.8" />
+      <circle cx="12" cy="18" r="2.2" stroke="currentColor" strokeWidth="1.8" />
+      <path d="M7.7 7.4L11 16M16.3 7.4L13 16M8.2 6h7.6" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" />
+    </svg>
+  );
+}
 function IconAnalytics() {
   return (
     <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden="true">
@@ -101,13 +111,14 @@ function IconSettings() {
 }
 
 // Every route here already exists as a real page. Screens still landing
-// from the mockup migration (Arena, Research, Creative, Create Post,
-// Content AI, Settings) add their own nav entry in their own PR once the
-// page itself exists — keeps this list from linking to 404s in the
-// meantime.
+// from the mockup migration (Research, Creative, Create Post, Content AI,
+// Settings) add their own nav entry in their own PR once the page itself
+// exists — keeps this list from linking to 404s in the meantime. Arena
+// (Issue #124) is the first of those to land.
 const NAV_LINKS: { href: string; label: string; icon: () => ReactNode }[] = [
   { href: "/", label: "Dashboard", icon: IconDashboard },
   { href: "/calendar", label: "Calendar", icon: IconCalendar },
+  { href: "/arena", label: "Content Arena", icon: IconArena },
   { href: "/review-queue", label: "Review Queue", icon: IconReview },
   { href: "/brands", label: "Brands", icon: IconBrand },
   { href: "/onboarding", label: "Onboarding", icon: IconOnboarding },

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -356,6 +356,106 @@ export async function rescheduleReviewPost(
   return res.json();
 }
 
+// --- Content Arena (Issue #124) ---
+
+// Mirrors apps/api/models/agent_run.py::AgentType — only the eight
+// per-post pipeline stages can appear here (onboarding/weekly_report runs
+// never carry a post_id, so the arena endpoints below can never surface
+// them).
+export type AgentType =
+  | "research"
+  | "creative"
+  | "generation"
+  | "reviewer"
+  | "human_review"
+  | "scheduler"
+  | "publisher"
+  | "analytics_collector";
+
+// Mirrors apps/api/schemas/arena.py::ArenaAgentRunRead. `output` is
+// whatever structured dict that stage's node returned (e.g.
+// research_brief/creative_brief/generation_output/review_output) —
+// rendered defensively, never assumed to have every key. `input` is not
+// exposed: run_pipeline only ever writes {"post_id": ...} into it, never
+// a real prompt.
+export interface ArenaAgentRun {
+  id: string;
+  agent_type: AgentType;
+  output: Record<string, unknown> | null;
+  model: string | null;
+  tokens: number | null;
+  cost: number | null;
+  latency_ms: number | null;
+  created_at: string;
+}
+
+// Mirrors apps/api/schemas/arena.py::ArenaReviewFeedbackRead.
+export interface ArenaReviewFeedback {
+  id: string;
+  source: ReviewSource;
+  score: number;
+  verdict: ReviewVerdict;
+  comments: Record<string, unknown>;
+  created_at: string;
+}
+
+// Mirrors apps/api/schemas/arena.py::ArenaPostRead — a thin Post
+// projection, not the full row.
+export interface ArenaPost {
+  id: string;
+  calendar_event_id: string | null;
+  current_pipeline_stage: PipelineStage;
+  body_text: Record<string, string> | null;
+  media: { platform: string; format: string; url: string }[] | null;
+  created_at: string;
+  updated_at: string;
+}
+
+// Mirrors apps/api/schemas/arena.py::ArenaRunRead. `post` is null when the
+// calendar event hasn't been triggered into a Post yet (or the brand has
+// no posts at all, for fetchLatestArenaRun) — agent_runs/review_feedback
+// are always empty in that case too.
+export interface ArenaRun {
+  calendar_event_id: string | null;
+  post: ArenaPost | null;
+  agent_runs: ArenaAgentRun[];
+  review_feedback: ArenaReviewFeedback[];
+}
+
+// apps/api/routers/arena.py mounts these under /brands/{brand_id}/arena —
+// same brand-scoping convention as calendarEventsUrl/reviewQueueUrl above.
+function arenaUrl(brandId: string, suffix: string): string {
+  return `${API_URL}/brands/${brandId}/arena${suffix}`;
+}
+
+export async function fetchArenaRunForEvent(
+  token: string,
+  brandId: string,
+  eventId: string
+): Promise<ArenaRun> {
+  const res = await fetch(arenaUrl(brandId, `/by-event/${eventId}`), {
+    headers: authHeaders(token),
+  });
+
+  if (!res.ok) {
+    throw new ApiError(await parseErrorDetail(res), res.status);
+  }
+
+  return res.json();
+}
+
+export async function fetchLatestArenaRun(token: string, brandId: string): Promise<ArenaRun> {
+  const res = await fetch(arenaUrl(brandId, "/latest"), {
+    headers: authHeaders(token),
+  });
+
+  if (!res.ok) {
+    throw new ApiError(await parseErrorDetail(res), res.status);
+  }
+
+  return res.json();
+}
+
 // --- Social accounts (Issue #91) ---
 
 // Mirrors apps/api/models/social_account.py::SocialPlatform. "linkedin" is


### PR DESCRIPTION
## Linked issue
Closes #124

## Why
Issue #124 asks for a static/lightly-interactive first pass at a Content Arena screen: a dark node-canvas visualizing one pipeline run as a DAG, built on the design-system foundation branch (#122's `arenadark` tokens). Explicitly out of scope for this PR: real-time streaming, drag-drop block editing, working re-run/branch/mute actions.

## What changed

**Backend — one additive, read-only endpoint** (`apps/api/routers/arena.py`, `apps/api/schemas/arena.py`):
- `GET /brands/{brand_id}/arena/by-event/{event_id}` and `GET /brands/{brand_id}/arena/latest` — both return `{calendar_event_id, post, agent_runs, review_feedback}`, composing `AgentRun` + `Post` + `ReviewFeedback` for one pipeline run in real pipeline order, so the frontend doesn't stitch together several existing endpoints itself (nothing currently exposes `AgentRun` at all).
- `AgentRun.input` is deliberately never exposed — `run_pipeline` only ever writes `{"post_id": ...}` into it, never a real prompt.
- Ordering handles a subtlety: Postgres's `now()` is constant for a whole transaction, so AgentRun rows logged within one `run_pipeline()` call can share an identical `created_at` — ties are broken by each row's position in `PIPELINE_STAGES`, the pipeline's own execution order.
- No new tables/columns, no migration.

**Frontend — `apps/web/app/arena/page.tsx`**, plus supporting modules (`build-nodes.ts`, `build-dock.ts`, `topology.ts`, `format.ts`, `block-library.ts`, `status-styles.ts`, and `node-card.tsx`/`inspector.tsx`/`dock.tsx`/`library-panel.tsx`):
- Header: real run title (from the calendar event), a real RUNNING/terminal-stage badge derived from `Post.current_pipeline_stage`, real run stats (elapsed, agent-run count, total cost, waiting-on-you), playback transport buttons (play/pause is a client-only toggle, prev/next are no-ops), and a "Skip to review" link that really navigates to `/review-queue`.
- Left block library: static visual list of block types (no drag-drop, per scope).
- Center canvas: 7 swim-lanes (Context/Research·Ved/Strategy·Keshav/Production·Kavi/Governance·Neer/Distribution/Learning) with animated dashed SVG edges (reusing the foundation's `rd-dash` animation). 10 nodes total: 2 context nodes (calendar-event brief, brand memory) + the 8 real pipeline stages — deliberately dropping the mockup's extra flavor sub-steps (trend radar, A/B split, risk & compliance, etc.) since those have no backend counterpart and Issue #124 is explicit about not inventing telemetry.
- Node click selects it (client-side only) and highlights its edges.
- Bottom dock: Trace/Outputs/Cost/Sources tabs, all reading real `AgentRun`/`ReviewFeedback`/`Post` data, plus a draft-media filmstrip using real `Post.media` URLs (empty state when none exist yet).
- Right inspector: real stats (cost/tokens/latency) where an `AgentRun` exists; a "System prompt" section always shows a clear "Not available yet" state rather than fabricating one, since `AgentRun.input` never stores a real prompt; raw `AgentRun.output` is shown pretty-printed. Re-run/branch/mute buttons render disabled, labeled "Coming soon".
- `AuthGate` gets a `FULL_BLEED_PATHS` exception for `/arena` so this screen isn't squeezed into the light app shell's Nav sidebar + padded column — it's a deliberately separate dark visual world (per the foundation's `arenadark` tokens).
- Added an "Content Arena" Nav entry (the foundation branch's own comment anticipated this landing once the page existed).

## Real data vs. placeholders
- **Real**: node status (DONE/WAITING/QUEUED/SKIPPED) derived from actual `AgentRun` rows and `Post.current_pipeline_stage`; cost/tokens/latency/model on every node and in the Cost tab; the Trace tab's timestamped per-agent entries; Sources tab (real Tavily/Serper results from the Research Engine's stored output); draft filmstrip (real `Post.media` URLs); header run stats; calendar-event/brand context nodes.
- **Clearly-labeled placeholders**: the "System prompt" section always shows "Not available yet" (backend genuinely doesn't persist prompts); Re-run/branch/mute buttons are disabled and labeled "Coming soon"; playback transport is render-only/no-op (except a client-only play/pause toggle); the left block library is a static list, not derived from a specific run.
- **Nothing fabricated**: no invented per-node telemetry for pipeline sub-steps (trend radar, A/B testing, risk & compliance, etc.) that don't exist in the backend — those mockup flavor nodes were dropped rather than faked.

## How I tested this
- Backend: `pytest apps/api/tests packages/agents/tests` — 337 passed. `alembic heads` unchanged (`5b29b584c4fa`, no migration).
- Frontend (`fnm use 18`): `npx vitest run` — 75 passed across 13 files (new: `arena-build-nodes.test.ts`, `arena-page.test.tsx`, plus additions to `api.test.ts` and `auth-gate.test.tsx`). `npx tsc --noEmit` clean. `npm run lint` clean (pre-existing `<img>` warning only, same as `components/ui/Avatar.tsx`). `npm run build` succeeds, `/arena` prerenders as a static route.

## Screenshots / recording
Not included — this PR was produced by an automated agent without a browser session to capture one. Structure/behavior is covered by the test suite above.

## Checklist
- [x] Tests added/updated and passing locally
- [x] Migration included if the schema changed — n/a, no schema change
- [x] No secrets, API keys, or `.env` values committed
- [x] Docs/README updated if behavior or setup changed — n/a
- [x] Branched from `feature/issue-122-mockup-design-system` (this issue's foundation branch) and targeting the same, per Issue #124's instructions

🤖 Generated with [Claude Code](https://claude.com/claude-code)