### PR TITLE
fix(storage): add missing apikey header for Supabase's current API key format

### DIFF
--- a/apps/api/tests/test_storage.py
+++ b/apps/api/tests/test_storage.py
@@ -25,6 +25,9 @@ def test_upload_returns_public_url(db_session) -> None:
     assert url == "https://project.supabase.co/storage/v1/object/public/brand-assets/org1/brand1/logo"
     call_kwargs = mock_post.call_args.kwargs
     assert call_kwargs["headers"]["Authorization"] == "Bearer test-key"
+    # Required alongside Authorization — Supabase's gateway 403s current-
+    # format (sb_secret_.../sb_publishable_...) project keys without it.
+    assert call_kwargs["headers"]["apikey"] == "test-key"
     assert call_kwargs["headers"]["Content-Type"] == "image/png"
     assert call_kwargs["headers"]["x-upsert"] == "true"
     assert call_kwargs["content"] == b"fake-image-bytes"
@@ -45,6 +48,7 @@ def test_delete_calls_correct_endpoint(db_session) -> None:
     url_called = mock_delete.call_args.args[0]
     assert url_called == "https://project.supabase.co/storage/v1/object/brand-assets/org1/brand1/logo"
     assert mock_delete.call_args.kwargs["headers"]["Authorization"] == "Bearer test-key"
+    assert mock_delete.call_args.kwargs["headers"]["apikey"] == "test-key"
 
 
 def test_upload_logs_integration_call(db_session) -> None:

--- a/packages/integrations/storage/supabase_provider.py
+++ b/packages/integrations/storage/supabase_provider.py
@@ -21,6 +21,12 @@ class SupabaseStorageProvider(StorageProvider):
                 f"{self.base_url}/storage/v1/object/{self.bucket}/{path}",
                 headers={
                     "Authorization": f"Bearer {self.service_key}",
+                    # Supabase's gateway rejects requests missing this
+                    # header ("Invalid Compact JWS") for project API keys
+                    # issued in the current sb_secret_.../sb_publishable_...
+                    # format — Authorization alone (sufficient for the
+                    # legacy JWT-format service_role key) is not enough.
+                    "apikey": self.service_key,
                     "Content-Type": content_type,
                     "x-upsert": "true",
                 },
@@ -34,7 +40,7 @@ class SupabaseStorageProvider(StorageProvider):
         with track_integration_call("supabase", "storage"):
             response = httpx.delete(
                 f"{self.base_url}/storage/v1/object/{self.bucket}/{path}",
-                headers={"Authorization": f"Bearer {self.service_key}"},
+                headers={"Authorization": f"Bearer {self.service_key}", "apikey": self.service_key},
                 timeout=self.timeout,
             )
             response.raise_for_status()


### PR DESCRIPTION
Closes #136

Found and root-caused while wiring up real Supabase credentials to test image storage end-to-end locally.

## Bug
`SupabaseStorageProvider.upload()`/`delete()` only send `Authorization: Bearer <service_key>`. Supabase's Storage gateway rejects this for project API keys issued in the current `sb_secret_.../sb_publishable_...` format:
```
{"error":"Unauthorized","message":"Invalid Compact JWS"}
```
It also requires an `apikey` header carrying the same key — `Authorization` alone isn't enough for this key format (may explain why this went unnoticed: legacy JWT-format `service_role` keys reportedly still work with `Authorization` alone).

## Fix
Add `apikey: self.service_key` alongside `Authorization` on both `upload()` and `delete()`.

## Verification
Tested against a real Supabase project end-to-end outside the test suite:
1. Confirmed the bug reproduces with only `Authorization` (403, "Invalid Compact JWS")
2. Applied the fix, confirmed a real file upload succeeds and the returned public URL is actually fetchable (200, correct bytes)
3. Cleaned up the test object afterward

## Test plan
- [x] Updated `test_storage.py` to assert the `apikey` header is present on both upload and delete — 5/5 pass
- [x] `pytest apps/api/tests packages/agents/tests` — 399 passed, no regressions