### PR TITLE
feat(agents,web): sharpen pipeline prompts + polish Content Arena visuals

### DIFF
--- a/apps/web/app/arena/node-card.tsx
+++ b/apps/web/app/arena/node-card.tsx
@@ -7,10 +7,16 @@ export function NodeCard({
   node,
   isSelected,
   onSelect,
+  index = 0,
 }: {
   node: ArenaNodeView;
   isSelected: boolean;
   onSelect: (id: string) => void;
+  /** Render order among the currently-visible nodes — used only to stagger
+   * each card's entrance animation so the arena doesn't pop in all at
+   * once (Issue #139's "richer entrance animation" pass). Purely
+   * cosmetic, has no effect on layout/topology. */
+  index?: number;
 }) {
   const statusStyle = STATUS_STYLES[node.status];
   const isLive = node.status === "WAITING";
@@ -26,11 +32,21 @@ export function NodeCard({
         top: node.y,
         width: node.w,
         borderColor: isSelected ? "#3D6BFF" : node.status === "WAITING" ? "#7A5A1E" : "#1D2743",
-        boxShadow: isSelected
-          ? "0 0 0 3px rgba(61,107,255,.18)"
-          : isLive
-            ? "0 0 26px -8px rgba(43,109,255,.7)"
-            : "none",
+        boxShadow: isSelected ? "0 0 0 3px rgba(61,107,255,.18)" : undefined,
+        // Both animations are driven from one shorthand (rather than two
+        // Tailwind `animate-*` utility classes, which would silently
+        // override each other since each sets the whole `animation`
+        // property) so the entrance stagger and the live glow pulse run
+        // at once. The keyframes themselves still come from
+        // tailwind.config.ts's rd-node-in/rd-arena-glow definitions.
+        animation: isLive
+          ? `rd-node-in 0.42s cubic-bezier(.2,.8,.3,1) both, rd-arena-glow 2.2s ease-in-out infinite`
+          : `rd-node-in 0.42s cubic-bezier(.2,.8,.3,1) both`,
+        animationDelay: isLive ? `${index * 55}ms, ${index * 55}ms` : `${index * 55}ms`,
+        // Consumed by the rd-arena-glow keyframe so the pulsing glow
+        // color matches this node's own agent color instead of one
+        // hardcoded hue for every live node.
+        ["--arena-glow" as string]: isLive ? `${node.color}B3` : undefined,
       }}
       className="absolute flex cursor-pointer flex-col overflow-hidden rounded-[13px] border-[1.5px] bg-arenadark-panel2 text-left"
     >

--- a/apps/web/app/arena/page.tsx
+++ b/apps/web/app/arena/page.tsx
@@ -30,6 +30,23 @@ const POLL_INTERVAL_MS = 15000;
 
 const TERMINAL_STAGES = new Set(["completed", "rejected", "failed"]);
 
+/** Content Arena's edge-flow particles and background drift are cosmetic
+ * only (Issue #139) — this lets both bail out cleanly for anyone with
+ * `prefers-reduced-motion` set, same convention as the global CSS rule in
+ * app/globals.css that shortens every CSS animation/transition to
+ * effectively-instant for that preference. */
+function usePrefersReducedMotion(): boolean {
+  const [reduced, setReduced] = useState(false);
+  useEffect(() => {
+    const query = window.matchMedia("(prefers-reduced-motion: reduce)");
+    setReduced(query.matches);
+    const onChange = () => setReduced(query.matches);
+    query.addEventListener("change", onChange);
+    return () => query.removeEventListener("change", onChange);
+  }, []);
+  return reduced;
+}
+
 export default function ArenaPage() {
   return (
     <Suspense fallback={<div className="min-h-screen bg-arenadark-bg" />}>
@@ -53,6 +70,7 @@ function ArenaScreen() {
   // render-only, per Issue #124's scope (no real playback/streaming).
   const [isPlaying, setIsPlaying] = useState(true);
   const [now, setNow] = useState(() => new Date());
+  const reducedMotion = usePrefersReducedMotion();
 
   const load = useCallback(
     async (showSpinner: boolean) => {
@@ -236,12 +254,13 @@ function ArenaScreen() {
                 </div>
               ) : (
                 <div
-                  className="relative"
+                  className={reducedMotion ? "relative" : "relative animate-rd-bg-drift"}
                   style={{
                     width: CANVAS_WIDTH,
                     height: CANVAS_HEIGHT,
-                    backgroundImage: "radial-gradient(#18213F 1.1px, transparent 1.1px)",
-                    backgroundSize: "26px 26px",
+                    backgroundImage:
+                      "radial-gradient(circle at 30% 20%, rgba(61,107,255,.09), transparent 55%), radial-gradient(#18213F 1.1px, transparent 1.1px)",
+                    backgroundSize: "auto, 26px 26px",
                   }}
                 >
                   {LANES.map((lane) => (
@@ -263,6 +282,7 @@ function ArenaScreen() {
                     {edgeElements.map((edge) => (
                       <path
                         key={edge.key}
+                        id={`arena-edge-${edge.key}`}
                         d={edge.d}
                         fill="none"
                         stroke={edge.stroke}
@@ -271,12 +291,27 @@ function ArenaScreen() {
                         className="animate-rd-dash"
                       />
                     ))}
+                    {/* A small dot traveling each edge, suggesting live
+                        data flowing through the pipeline — purely
+                        decorative (Issue #124 stays static/lightly-
+                        interactive; nothing here reflects real progress),
+                        so it's skipped entirely under
+                        prefers-reduced-motion. */}
+                    {!reducedMotion &&
+                      edgeElements.map((edge) => (
+                        <circle key={`${edge.key}-particle`} r={2.5} fill={edge.stroke}>
+                          <animateMotion dur="1.8s" repeatCount="indefinite">
+                            <mpath href={`#arena-edge-${edge.key}`} />
+                          </animateMotion>
+                        </circle>
+                      ))}
                   </svg>
 
-                  {nodes.map((node) => (
+                  {nodes.map((node, index) => (
                     <NodeCard
                       key={node.id}
                       node={node}
+                      index={index}
                       isSelected={node.id === selectedNodeId}
                       onSelect={(id) => setSelectedNodeId(id as ArenaNodeId)}
                     />

--- a/apps/web/app/arena/page.tsx
+++ b/apps/web/app/arena/page.tsx
@@ -38,6 +38,11 @@ const TERMINAL_STAGES = new Set(["completed", "rejected", "failed"]);
 function usePrefersReducedMotion(): boolean {
   const [reduced, setReduced] = useState(false);
   useEffect(() => {
+    // jsdom (this repo's test environment) doesn't implement matchMedia —
+    // degrade to "motion allowed" rather than throwing, same
+    // fail-soft-on-an-unavailable-browser-API spirit as the rest of this
+    // codebase's provider/integration guards.
+    if (typeof window.matchMedia !== "function") return;
     const query = window.matchMedia("(prefers-reduced-motion: reduce)");
     setReduced(query.matches);
     const onChange = () => setReduced(query.matches);

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -39,3 +39,13 @@
     @apply bg-slate-300 rounded-full;
   }
 }
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.001ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.001ms !important;
+  }
+}

--- a/apps/web/tailwind.config.ts
+++ b/apps/web/tailwind.config.ts
@@ -116,6 +116,19 @@ const config: Config = {
         "rd-aurora": { "0%": { transform: "rotate(0deg) scale(1.4)" }, "100%": { transform: "rotate(360deg) scale(1.4)" } },
         "rd-wave": { "0%,100%": { transform: "scaleY(.35)" }, "50%": { transform: "scaleY(1)" } },
         "rd-rise": { from: { opacity: "0", transform: "translateY(6px)" }, to: { opacity: "1", transform: "none" } },
+        // --- Content Arena visual-polish additions (Issue #139) ---
+        "rd-node-in": {
+          from: { opacity: "0", transform: "translateY(8px) scale(.96)" },
+          to: { opacity: "1", transform: "none" },
+        },
+        "rd-arena-glow": {
+          "0%,100%": { boxShadow: "0 0 16px -6px var(--arena-glow, rgba(255,196,107,.75))" },
+          "50%": { boxShadow: "0 0 34px -2px var(--arena-glow, rgba(255,196,107,.95))" },
+        },
+        "rd-bg-drift": {
+          "0%,100%": { backgroundPosition: "0% 0%, 0px 0px" },
+          "50%": { backgroundPosition: "100% 100%, 26px 26px" },
+        },
       },
       animation: {
         "fade-in": "fade-in 0.15s ease-out",
@@ -127,6 +140,9 @@ const config: Config = {
         "rd-aurora": "rd-aurora 7s linear infinite",
         "rd-wave": "rd-wave 1.1s ease-in-out infinite",
         "rd-rise": "rd-rise 0.4s ease both",
+        "rd-node-in": "rd-node-in 0.42s cubic-bezier(.2,.8,.3,1) both",
+        "rd-arena-glow": "rd-arena-glow 2.2s ease-in-out infinite",
+        "rd-bg-drift": "rd-bg-drift 18s ease-in-out infinite alternate",
       },
     },
   },

--- a/packages/agents/pipeline/nodes/creative_engine.py
+++ b/packages/agents/pipeline/nodes/creative_engine.py
@@ -127,34 +127,81 @@ def _parse_platform_briefs(text: str, platforms: list[str]) -> dict[str, dict[st
     return result
 
 
+_BANNED_PHRASES = (
+    "in today's fast-paced world",
+    "in today's digital age",
+    "unlock the power of",
+    "look no further",
+    "game-changer",
+    "game changer",
+    "let's dive in",
+    "dive right in",
+    "unleash",
+    "elevate your",
+    "take it to the next level",
+    "in this day and age",
+    "revolutionize",
+    "the world of",
+    "whether you're a",
+)
+
+
 def _build_prompt(brand: Brand, research_brief: dict[str, Any], platforms: list[str]) -> str:
     industry = brand.industry or brand.name
-    return f"""You are a senior social media creative strategist deciding
-*how* to make a brand's next post land on each platform — not writing the
-copy itself, just the creative strategy behind it. Respond with strict
-JSON only — no markdown, no commentary, no code fences.
+    banned = ", ".join(f'"{phrase}"' for phrase in _BANNED_PHRASES)
+    return f"""You are Keshav, a senior social media creative strategist
+with a sharp eye for what actually stops a scroll versus what reads as
+generic AI-marketing filler. Your job is deciding *how* to make a brand's
+next post land on each platform — not writing the copy itself, just the
+creative strategy behind it. Respond with strict JSON only — no markdown,
+no commentary, no code fences.
 
 ## Brand
 {brand.name} ({industry})
 
-## Research brief
+## Research brief — use these SPECIFIC details, don't generalize past them
 Brand context: {json.dumps(research_brief.get("brand_context"))}
 Platform trends: {json.dumps(research_brief.get("platform_trends"))}
 Industry trends: {json.dumps(research_brief.get("industry_trends"))}
+Audience signals (real questions/complaints from this audience right now): {json.dumps(research_brief.get("audience_signals"))}
 Timing signal: {json.dumps(research_brief.get("timing_signal"))}
+
+## What makes a brief weak (avoid this)
+A brief is weak when its hook or angle could be copy-pasted onto any
+other brand in any other industry without anyone noticing. If the brand
+context or trends above contain a real name, number, product detail, or
+specific event, the hook or angle MUST reference it directly — that
+specificity is the whole point of doing research first. Never fall back
+to vague category-level marketing-speak ("quality you can trust",
+"customers love us") when a concrete detail from the brief is available.
+Never let a hook, angle, or CTA use or paraphrase any of these tired
+openers/phrases: {banned}.
 
 ## Task
 For EACH of these target platforms — {", ".join(platforms)} — produce a
-distinct creative brief, genuinely adapted to that platform's norms,
-audience expectations, and format conventions. Do not reuse the same
-angle, hook, CTA, or tone across platforms — each platform's brief must
-reflect how that platform is actually used.
+distinct creative brief, genuinely adapted to that platform's real norms:
+
+- linkedin: a professional but not corporate-stiff angle — thought
+  leadership, a specific lesson learned, or a data point worth debating.
+  Hooks should earn a read from a scrolling feed, not open with a title.
+- x: short, punchy, opinionated. The hook has to work as a standalone
+  one-liner — assume most readers never click through.
+- instagram: visual-first thinking — the angle should justify what's ON
+  SCREEN, not just what's said. Hook is the first line of caption before
+  "more" truncates it.
+- default/other platforms: infer sensible norms from how that platform is
+  actually used and stay consistent with them.
+
+Do not reuse the same angle, hook, CTA, or tone across platforms — each
+platform's brief must reflect how that platform is actually used, and
+each hook must be something a real person would stop scrolling for.
 
 Respond with a single JSON object whose keys are exactly the platform
 names listed above, and whose values are objects with these string keys:
 - "format": the post format (e.g. text_post, short_thread, image, carousel)
-- "angle": the creative angle/strategy for this post
-- "hook": the opening line/hook to grab attention
+- "angle": the creative angle/strategy for this post — specific, not generic
+- "hook": the exact opening line to grab attention — concrete, never a
+  category-level cliché
 - "cta": the call to action
 - "tone": the tone of voice for this platform
 

--- a/packages/agents/pipeline/nodes/generation_engine.py
+++ b/packages/agents/pipeline/nodes/generation_engine.py
@@ -302,23 +302,90 @@ def _fallback_copy_for(platform_brief: dict[str, Any], platform: str) -> str:
     return f"[Generation Engine fallback] Unable to generate copy for {platform}."
 
 
+# Copy that leans on these reads as AI-generated filler, not something a
+# person on the brand's social team actually wrote — banned outright.
+_BANNED_PHRASES = (
+    "in today's fast-paced world",
+    "in today's digital age",
+    "unlock the power of",
+    "look no further",
+    "game-changer",
+    "game changer",
+    "let's dive in",
+    "dive right in",
+    "unleash",
+    "elevate your",
+    "take it to the next level",
+    "revolutionize",
+    "buckle up",
+    "the world of",
+    "whether you're a",
+    "at the end of the day",
+)
+
+_PLATFORM_FORMAT_RULES = {
+    "linkedin": (
+        "LinkedIn: written like a real professional post, not a press "
+        "release. Short paragraphs (1-3 sentences), line breaks between "
+        "them for scannability. At most 0-3 hashtags at the very end, "
+        "never a wall of hashtags, never hashtags mid-sentence."
+    ),
+    "x": (
+        "X: tight and punchy, under ~280 characters unless the brief "
+        "explicitly calls for a thread. No hashtag walls — 0-1 hashtag "
+        "only if it's genuinely load-bearing. Every word has to earn its "
+        "place."
+    ),
+    "instagram": (
+        "Instagram: caption supports the visual, doesn't duplicate it. "
+        "Hook is the first line — it's the only part visible before "
+        "'more' truncates the rest. Hashtags are fine (5-15), grouped at "
+        "the end, relevant rather than generic (#love #instagood banned)."
+    ),
+}
+_DEFAULT_FORMAT_RULE = (
+    "Match this platform's real norms for length, formatting, and "
+    "hashtag/emoji use as implied by its brief."
+)
+
+
 def _build_prompt(platform_briefs: dict[str, dict[str, str]], platforms: list[str]) -> str:
     briefs_json = json.dumps({platform: platform_briefs.get(platform, {}) for platform in platforms})
-    return f"""You are a senior social media copywriter turning an
+    banned = ", ".join(f'"{phrase}"' for phrase in _BANNED_PHRASES)
+    format_rules = "\n".join(
+        f"- {platform}: {_PLATFORM_FORMAT_RULES.get(platform, _DEFAULT_FORMAT_RULE)}"
+        for platform in platforms
+    )
+    return f"""You are Kavi, a senior social media copywriter turning an
 already-approved creative brief into the final, publish-ready post copy —
-the actual words that will be posted, not more strategy. Respond with
-strict JSON only — no markdown, no commentary, no code fences.
+the actual words that will be posted, not more strategy. You write the
+way a genuinely good social media manager writes: specific, confident,
+a little opinionated, never generic. Respond with strict JSON only — no
+markdown, no commentary, no code fences.
 
 ## Creative briefs per platform
 {briefs_json}
+
+## Absolutely do not use these phrases or their close paraphrases
+{banned}. Also avoid: stacking 3+ emoji in a row, ending every sentence
+with an exclamation point, and asking a rhetorical question just to fill
+space ("Ever wonder why...?") unless the brief's hook actually calls for
+one.
+
+## Platform-native formatting — this is not optional
+{format_rules}
 
 ## Task
 For EACH of these target platforms — {", ".join(platforms)} — write the
 final post copy that follows that platform's brief (format, angle, hook,
 cta, tone) exactly: open with (or clearly incorporate) that platform's
-hook, end with (or clearly incorporate) its CTA, and match its tone. Each
-platform's copy must be genuinely distinct — reflecting that platform's
-own brief — not the same text reused across platforms.
+hook in the very first line — that's the only part of the post many
+readers will ever see — end with (or clearly incorporate) its CTA, and
+match its tone throughout, not just in the opening line. Write it like a
+specific, real post about this specific brand and angle, not a
+fill-in-the-blank template. Each platform's copy must be genuinely
+distinct in wording and structure — reflecting that platform's own brief
+— never the same text lightly reworded across platforms.
 
 Respond with a single JSON object whose keys are exactly the platform
 names listed above, and whose values are the final copy text (a plain

--- a/packages/agents/pipeline/nodes/research_engine.py
+++ b/packages/agents/pipeline/nodes/research_engine.py
@@ -143,6 +143,13 @@ def _research_brief(db: Session, post: Post) -> dict[str, Any]:
         for platform in platforms
     }
     industry_trend_results = _search_safely(f"{industry} industry trends")
+    # Pulls concrete, quotable audience pain points/questions rather than
+    # just category-level trend headlines — this is what lets downstream
+    # stages (creative/generation) write a hook that references something
+    # real instead of a generic category-level angle.
+    audience_signal_results = _search_safely(
+        f"what {industry} customers are asking about or complaining about right now"
+    )
 
     all_trend_results = [
         result for results in platform_trend_results.values() for result in results
@@ -160,6 +167,7 @@ def _research_brief(db: Session, post: Post) -> dict[str, Any]:
             platform: _serialize(results) for platform, results in platform_trend_results.items()
         },
         "industry_trends": _serialize(industry_trend_results),
+        "audience_signals": _serialize(audience_signal_results),
         "timing_signal": _build_timing_signal(
             platforms,
             all_trend_results,

--- a/packages/agents/pipeline/nodes/reviewer_engine.py
+++ b/packages/agents/pipeline/nodes/reviewer_engine.py
@@ -228,12 +228,14 @@ def _build_prompt(
     target_audience = brand.target_audience or "not specified"
     content_json = json.dumps({platform: body_text.get(platform, "") for platform in platforms})
 
-    return f"""You are a meticulous brand-voice, compliance, and
-platform-fit reviewer. You are given a finished draft post and must
-critically evaluate it BEFORE a human ever sees it — your job is to catch
-obvious misses so human review time goes toward judgment calls, not
-basic problems. Respond with strict JSON only — no markdown, no
-commentary, no code fences.
+    return f"""You are Neer, a meticulous brand-voice, compliance, and
+platform-fit reviewer — the last automated check before a human ever
+sees this draft. You are notoriously hard to impress: generic AI-sounding
+copy fails your review even if nothing is technically "wrong" with it,
+because bland, forgettable copy is itself a brand-fit failure. Your job
+is to catch obvious misses so human review time goes toward judgment
+calls, not basic problems. Respond with strict JSON only — no markdown,
+no commentary, no code fences.
 
 ## Brand
 {brand.name} ({industry})
@@ -252,20 +254,30 @@ evaluate that platform's draft copy against:
 1. Brand voice alignment — does it match the brand's tone descriptors and
    the reference material above, or does it read generic/off-brand/
    inconsistent with how this brand actually talks?
-2. Compliance and safety — unsubstantiated claims, prohibited or risky
+2. Genericness / "AI slop" check — could this exact copy be pasted onto a
+   different, unrelated brand's post with only the name swapped and no
+   one would notice? If yes, that alone justifies a "revise" or lower,
+   even with zero compliance issues — flag it as an issue by name (e.g.
+   "hook is a generic template, not specific to this brand/post") and
+   give a suggested edit that adds the missing specificity.
+3. Compliance and safety — unsubstantiated claims, prohibited or risky
    language, missing required disclosures, anything a legal/compliance
    reviewer would flag.
-3. Platform fit — does it respect that platform's norms (length,
-   formality, format conventions, audience expectations)?
+4. Platform fit — does it respect that platform's norms (length,
+   formality, hashtag/emoji conventions, whether the hook earns attention
+   in the first line, audience expectations)?
 
 Score each platform from 0 (severely off-brand, non-compliant, or wrong
-for the platform) to 100 (fully on-brand, compliant, and platform-
-appropriate). Assign a verdict: "approve" for a score of 80 or higher
-(ready as-is), "revise" for 50-79 (fixable issues), or "reject" below 50
-(fundamental problems). List the SPECIFIC issues you found — never a
-generic "needs improvement" — and give SPECIFIC, actionable suggested
+for the platform) to 100 (fully on-brand, compliant, specific, and
+platform-appropriate). Assign a verdict: "approve" for a score of 80 or
+higher (ready as-is), "revise" for 50-79 (fixable issues), or "reject"
+below 50 (fundamental problems, including copy so generic it doesn't
+represent this brand at all). List the SPECIFIC issues you found — never
+a generic "needs improvement" — and give SPECIFIC, actionable suggested
 edits: concrete rewording, a concrete fix, or a concrete rewritten
-passage, tied to what is actually wrong with THIS draft.
+passage, tied to what is actually wrong with THIS draft. A reviewer
+reading only your suggested_edits should be able to fix the draft without
+re-reading it.
 
 Respond with a single JSON object of exactly this shape:
 {{"platforms": {{"<platform>": {{"score": <number 0-100>, "verdict":


### PR DESCRIPTION
Closes #139

Stacked on #135 (Content Arena doesn't exist on `main` yet) — this PR's own diff is just the two changes below; the base-branch diff is #135's.

## Summary

**Prompt quality (packages/agents/pipeline/nodes/):**
- `creative_engine.py` (Keshav), `generation_engine.py` (Kavi), `reviewer_engine.py` (Neer): stronger persona framing, an explicit banned-phrase list (the usual AI-marketing tells — "unlock the power of", "game-changer", "in today's fast-paced world", etc.), platform-native formatting rules (LinkedIn hashtag limits, X length, Instagram hook-before-truncation), and an explicit demand to pull concrete specifics from the brief/research data rather than falling back to category-level marketing-speak.
- `research_engine.py` (Ved): one new search query for real audience questions/complaints (`audience_signals`), which `creative_engine.py`'s prompt now reads — gives Keshav's hooks something concrete to reference instead of generic trend headlines.
- `reviewer_engine.py` gets a sharper rubric: a "could this be pasted onto any other brand?" genericness check that alone justifies a revise/reject verdict.
- Same JSON I/O contract everywhere — only prompt wording changed, all 52 pipeline node tests pass unmodified.

**Content Arena visual polish (apps/web/app/arena/), scoped as pure visual polish per #124's documented static/lightly-interactive contract — no new functionality:**
- A small particle travels each DAG edge (SVG `animateMotion`/`mpath`).
- The currently-WAITING node gets a colored glow pulse (`rd-arena-glow`, keyed to that node's own agent color via a CSS var).
- Staggered per-node entrance animation (`rd-node-in`) instead of everything appearing at once.
- A slow-drifting background gradient (`rd-bg-drift`) behind the dotted grid.
- All of the above — plus every animation/transition app-wide — is disabled under `prefers-reduced-motion` via a new global rule in `globals.css`.

## Test plan
- [x] `packages/agents/tests/test_{creative,generation,research,reviewer}_engine.py` — 52 passed, unmodified
- [x] `npx tsc --noEmit` — clean
- [ ] `apps/web` vitest suite could not be run in this sandbox (Node 25's built-in `localStorage` breaks jsdom's `window.localStorage.clear()` in `vitest.setup.ts` — reproduced identically on the pre-change commit, so it's a local Node-version issue, not something this diff caused); CI runs on the pinned Node 18 from `frontend-ci.yml` and should be unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WP3zhi1Bqq2psuUPzbqk2n