### PR TITLE
feat(api,web): review queue classification + regenerate with Neer's feedback

### DIFF
--- a/apps/api/routers/review.py
+++ b/apps/api/routers/review.py
@@ -20,6 +20,10 @@ forward:
                  target_datetime (Issue #26/#27) — reused as-is rather
                  than adding a second scheduling field to Post — again
                  without touching the graph.
+  * regenerate — Issue #140: asks Generation Engine to revise the draft
+                 using the latest AI review's per-platform issues/
+                 suggested_edits, appending a PostVersion the same way
+                 edit does, again without touching the graph.
 
 Approve and reject both append a ReviewFeedback row (Issue #24's table)
 with source=human, sitting alongside the Reviewer Engine's own
@@ -58,6 +62,7 @@ from apps.api.schemas.review import (
 )
 from packages.agents.pipeline.checkpointer import get_postgres_checkpointer
 from packages.agents.pipeline.graph import run_pipeline
+from packages.agents.pipeline.nodes.generation_engine import regenerate_copy_with_feedback
 
 router = APIRouter(prefix="/brands/{brand_id}/review-queue", tags=["review"])
 
@@ -96,6 +101,21 @@ def _require_paused_at_human_review(post: Post) -> None:
                 f"(current stage: {post.current_pipeline_stage.value})"
             ),
         )
+
+
+def _latest_ai_review_or_409(db: Session, post: Post) -> ReviewFeedback:
+    feedback = (
+        db.query(ReviewFeedback)
+        .filter(ReviewFeedback.post_id == post.id, ReviewFeedback.source == ReviewSource.AI_REVIEWER)
+        .order_by(ReviewFeedback.created_at.desc())
+        .first()
+    )
+    if feedback is None:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Post has no AI review yet — nothing to regenerate from",
+        )
+    return feedback
 
 
 def _feedback_by_post(db: Session, post_ids: list[uuid.UUID]) -> dict[uuid.UUID, list[ReviewFeedback]]:
@@ -243,6 +263,40 @@ def edit_post(
 
     post.body_text = payload.body_text
     db.add(PostVersion(post_id=post.id, body_text=payload.body_text))
+    db.flush()
+    db.refresh(post)
+
+    return _post_response(db, post)
+
+
+@router.post("/{post_id}/regenerate", response_model=ReviewQueuePostRead)
+def regenerate_post(
+    brand_id: uuid.UUID,
+    post_id: uuid.UUID,
+    db: Session = Depends(get_db),
+    current_user: CurrentUser = Depends(require_role(*WRITE_ROLES)),
+) -> ReviewQueuePostRead:
+    """Asks Kavi (generation_engine.py) to revise the draft using Neer's
+    (reviewer_engine.py) latest AI review — the per-platform `issues`/
+    `suggested_edits` already shown on the review-queue card — instead of
+    the human having to hand-edit the text themselves. Same "never touch
+    the checkpointed graph" contract as edit_post: the post stays paused
+    at human_review, ready for a follow-up edit/approve/reject call, and
+    a PostVersion is appended so the pre-regeneration draft is never
+    lost."""
+    brand = _get_org_brand(db, brand_id, current_user.org_id)
+    post = _get_post_or_404(db, brand.id, post_id)
+    _require_paused_at_human_review(post)
+
+    ai_review = _latest_ai_review_or_409(db, post)
+    feedback_by_platform = ai_review.comments.get("platforms", {}) if ai_review.comments else {}
+
+    revised_body_text, _model, _tokens = regenerate_copy_with_feedback(
+        post.body_text or {}, feedback_by_platform
+    )
+
+    post.body_text = revised_body_text
+    db.add(PostVersion(post_id=post.id, body_text=revised_body_text))
     db.flush()
     db.refresh(post)
 

--- a/apps/api/tests/test_review.py
+++ b/apps/api/tests/test_review.py
@@ -24,6 +24,7 @@ from apps.api.models import (
     Organization,
     PipelineStage,
     Post,
+    PostVersion,
     ReviewFeedback,
     ReviewSource,
     ReviewVerdict,
@@ -311,6 +312,94 @@ def test_reschedule_without_calendar_event_is_400(db_session, thread_cleanup) ->
     )
 
     assert response.status_code == 400
+
+
+# --- regenerate -------------------------------------------------------------
+
+
+@uses_test_session
+def test_regenerate_uses_ai_review_feedback(db_session, thread_cleanup) -> None:
+    brand, user = _setup_brand(db_session)
+    post = _post_at_human_review(db_session, brand, thread_cleanup)
+    original_body_text = dict(post.body_text or {})
+    assert original_body_text, "pipeline fixture should have produced generated copy"
+
+    ai_review = (
+        db_session.query(ReviewFeedback)
+        .filter(ReviewFeedback.post_id == post.id, ReviewFeedback.source == ReviewSource.AI_REVIEWER)
+        .one()
+    )
+    assert "platforms" in ai_review.comments
+
+    response = client.post(
+        f"/brands/{brand.id}/review-queue/{post.id}/regenerate",
+        headers=_auth_headers(user),
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert set(body["body_text"].keys()) == set(original_body_text.keys())
+    assert body["current_pipeline_stage"] == "human_review"
+
+    db_session.refresh(post)
+    # No LLM provider is configured in tests (see generation_engine.py's
+    # degrade-on-failure contract), so regenerate_copy_with_feedback falls
+    # back to returning the original draft unchanged — proves the
+    # fallback path works end-to-end rather than blanking the draft.
+    assert post.body_text == original_body_text
+    assert post.current_pipeline_stage == PipelineStage.HUMAN_REVIEW
+
+    versions = (
+        db_session.query(PostVersion)
+        .filter(PostVersion.post_id == post.id)
+        .order_by(PostVersion.created_at)
+        .all()
+    )
+    assert versions[-1].body_text == original_body_text
+
+
+@uses_test_session
+def test_regenerate_without_ai_review_is_409(db_session, thread_cleanup) -> None:
+    brand, user = _setup_brand(db_session)
+    post = Post(brand_id=brand.id, body_text={"linkedin": "Draft."})
+    post.current_pipeline_stage = PipelineStage.HUMAN_REVIEW
+    db_session.add(post)
+    db_session.flush()
+
+    response = client.post(
+        f"/brands/{brand.id}/review-queue/{post.id}/regenerate",
+        headers=_auth_headers(user),
+    )
+
+    assert response.status_code == 409
+
+
+@uses_test_session
+def test_regenerate_a_post_not_at_human_review_is_409(db_session, thread_cleanup) -> None:
+    brand, user = _setup_brand(db_session)
+    post = Post(brand_id=brand.id)
+    db_session.add(post)
+    db_session.flush()
+
+    response = client.post(
+        f"/brands/{brand.id}/review-queue/{post.id}/regenerate",
+        headers=_auth_headers(user),
+    )
+
+    assert response.status_code == 409
+
+
+@uses_test_session
+def test_viewer_cannot_regenerate(db_session, thread_cleanup) -> None:
+    brand, viewer = _setup_brand(db_session, UserRole.VIEWER)
+    post = _post_at_human_review(db_session, brand, thread_cleanup)
+
+    response = client.post(
+        f"/brands/{brand.id}/review-queue/{post.id}/regenerate",
+        headers=_auth_headers(viewer),
+    )
+
+    assert response.status_code == 403
 
 
 # --- scoping / isolation ----------------------------------------------------

--- a/apps/web/__tests__/review-queue-page.test.tsx
+++ b/apps/web/__tests__/review-queue-page.test.tsx
@@ -13,6 +13,7 @@ const approveReviewPostMock = vi.fn();
 const rejectReviewPostMock = vi.fn();
 const editReviewPostMock = vi.fn();
 const rescheduleReviewPostMock = vi.fn();
+const regenerateReviewPostMock = vi.fn();
 
 vi.mock("@/lib/api", () => ({
   fetchBrands: (...args: unknown[]) => fetchBrandsMock(...args),
@@ -21,6 +22,7 @@ vi.mock("@/lib/api", () => ({
   rejectReviewPost: (...args: unknown[]) => rejectReviewPostMock(...args),
   editReviewPost: (...args: unknown[]) => editReviewPostMock(...args),
   rescheduleReviewPost: (...args: unknown[]) => rescheduleReviewPostMock(...args),
+  regenerateReviewPost: (...args: unknown[]) => regenerateReviewPostMock(...args),
 }));
 
 const BRANDS = [
@@ -96,6 +98,7 @@ describe("ReviewQueuePage", () => {
     rejectReviewPostMock.mockReset();
     editReviewPostMock.mockReset();
     rescheduleReviewPostMock.mockReset();
+    regenerateReviewPostMock.mockReset();
 
     window.localStorage.clear();
     window.localStorage.setItem("raindeer.auth.token", "test-token");
@@ -232,5 +235,59 @@ describe("ReviewQueuePage", () => {
         expect.objectContaining({ target_datetime: expect.stringContaining("2026-09-05") })
       );
     });
+  });
+
+  it("regenerates a draft from Neer's feedback through the API", async () => {
+    fetchReviewQueueMock.mockResolvedValue([makePost()]);
+    regenerateReviewPostMock.mockResolvedValue(
+      makePost({ body_text: { linkedin: "A revised draft with a clear call to action." } })
+    );
+    const user = userEvent.setup();
+
+    renderPage();
+
+    await screen.findByText(/Check out our new widget line!/);
+    await act(async () => {
+      await user.click(screen.getByRole("button", { name: "Regenerate with Neer's feedback" }));
+    });
+
+    await waitFor(() => {
+      expect(regenerateReviewPostMock).toHaveBeenCalledWith("test-token", "brand-1", "post-1");
+    });
+    expect(await screen.findByText(/A revised draft with a clear call to action\./)).toBeInTheDocument();
+  });
+
+  it("hides posts with an approve verdict when filtering to Needs changes", async () => {
+    const needsChanges = makePost({ id: "post-1" });
+    const readyToApprove = makePost({
+      id: "post-2",
+      body_text: { linkedin: "A great, on-brand post." },
+      review_feedback: [
+        {
+          id: "feedback-ai-2",
+          post_id: "post-2",
+          source: "ai_reviewer",
+          score: 92,
+          verdict: "approve",
+          comments: {
+            platforms: { linkedin: { score: 92, verdict: "approve", issues: [], suggested_edits: "" } },
+            model: "openrouter/free",
+          },
+          created_at: "2026-08-20T10:05:00Z",
+        },
+      ],
+    });
+    fetchReviewQueueMock.mockResolvedValue([needsChanges, readyToApprove]);
+    const user = userEvent.setup();
+
+    renderPage();
+
+    expect(await screen.findByText(/Check out our new widget line!/)).toBeInTheDocument();
+    expect(screen.getByText(/A great, on-brand post\./)).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /^Needs changes/ }));
+
+    expect(screen.getByText(/Check out our new widget line!/)).toBeInTheDocument();
+    expect(screen.queryByText(/A great, on-brand post\./)).not.toBeInTheDocument();
   });
 });

--- a/apps/web/app/review-queue/page.tsx
+++ b/apps/web/app/review-queue/page.tsx
@@ -1,17 +1,20 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import {
   approveReviewPost,
   editReviewPost,
   fetchReviewQueue,
+  regenerateReviewPost,
   rejectReviewPost,
   rescheduleReviewPost,
+  type ReviewFeedback,
   type ReviewQueuePost,
 } from "@/lib/api";
 import { useAuth } from "@/lib/auth-context";
 import { useBrand } from "@/lib/brand-context";
 import { ReviewCard } from "./review-card";
+import { Button } from "@/components/ui/Button";
 import { Card } from "@/components/ui/Card";
 import { EmptyState } from "@/components/ui/EmptyState";
 import { PageHeader } from "@/components/ui/PageHeader";
@@ -23,6 +26,35 @@ import { useToast } from "@/components/ui/Toast";
 // by a teammate, or a new one can land at human_review, at any time.
 const POLL_INTERVAL_MS = 15000;
 
+// Triage bucket a post falls into, derived from its latest AI review
+// (mirrors review-card.tsx's own latestAiReview helper — kept local
+// rather than shared since each file needs a slightly different return
+// shape and this isn't worth a shared module yet).
+type TriageBucket = "needs_changes" | "ready" | "unreviewed";
+
+function latestAiReview(post: ReviewQueuePost): ReviewFeedback | null {
+  const aiReviews = post.review_feedback.filter((f) => f.source === "ai_reviewer");
+  return aiReviews.length > 0 ? aiReviews[aiReviews.length - 1] : null;
+}
+
+function triageBucket(post: ReviewQueuePost): TriageBucket {
+  const review = latestAiReview(post);
+  if (!review) return "unreviewed";
+  return review.verdict === "approve" ? "ready" : "needs_changes";
+}
+
+function triageScore(post: ReviewQueuePost): number {
+  // Used only to sort "worst first" — a post with no AI review yet sorts
+  // after everything that's been scored, since there's nothing urgent to
+  // triage about it yet.
+  const review = latestAiReview(post);
+  return review ? review.score : Infinity;
+}
+
+function platformsOf(post: ReviewQueuePost): string[] {
+  return Object.keys(post.body_text ?? {});
+}
+
 export default function ReviewQueuePage() {
   const { token } = useAuth();
   const { selectedBrand, selectedBrandId } = useBrand();
@@ -31,6 +63,8 @@ export default function ReviewQueuePage() {
   const [posts, setPosts] = useState<ReviewQueuePost[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [bucketFilter, setBucketFilter] = useState<TriageBucket | "all">("all");
+  const [platformFilter, setPlatformFilter] = useState<string | "all">("all");
 
   const loadQueue = useCallback(
     async (showSpinner: boolean) => {
@@ -123,6 +157,43 @@ export default function ReviewQueuePage() {
     }
   }
 
+  async function handleRegenerate(postId: string) {
+    if (!token || !selectedBrandId) return;
+    try {
+      const updated = await regenerateReviewPost(token, selectedBrandId, postId);
+      // Regenerating doesn't resume the graph either — the post stays in
+      // the queue with its revised draft.
+      replacePost(updated);
+      push("Draft regenerated from Neer's feedback", "success");
+    } catch (err) {
+      push(err instanceof Error ? err.message : "Failed to regenerate draft", "error");
+    }
+  }
+
+  const platformOptions = useMemo(() => {
+    const platforms = new Set<string>();
+    for (const post of posts) {
+      for (const platform of platformsOf(post)) platforms.add(platform);
+    }
+    return Array.from(platforms).sort();
+  }, [posts]);
+
+  const visiblePosts = useMemo(() => {
+    return posts
+      .filter((post) => bucketFilter === "all" || triageBucket(post) === bucketFilter)
+      .filter((post) => platformFilter === "all" || platformsOf(post).includes(platformFilter))
+      // Worst-first triage: lowest AI score (most urgent) surfaces first;
+      // posts with no AI review yet sort last (triageScore returns
+      // Infinity for those).
+      .sort((a, b) => triageScore(a) - triageScore(b));
+  }, [posts, bucketFilter, platformFilter]);
+
+  const bucketCounts = useMemo(() => {
+    const counts: Record<TriageBucket, number> = { needs_changes: 0, ready: 0, unreviewed: 0 };
+    for (const post of posts) counts[triageBucket(post)] += 1;
+    return counts;
+  }, [posts]);
+
   return (
     <div>
       <PageHeader
@@ -163,19 +234,92 @@ export default function ReviewQueuePage() {
           description="Nothing is waiting on human review right now."
         />
       ) : (
-        <ul className="space-y-4">
-          {posts.map((post) => (
-            <li key={post.id}>
-              <ReviewCard
-                post={post}
-                onApprove={handleApprove}
-                onReject={handleReject}
-                onEdit={handleEdit}
-                onReschedule={handleReschedule}
-              />
-            </li>
-          ))}
-        </ul>
+        <>
+          <div className="mb-4 flex flex-wrap items-center gap-x-6 gap-y-3">
+            <div className="flex flex-wrap items-center gap-1.5" role="group" aria-label="Filter by triage status">
+              <Button
+                type="button"
+                size="sm"
+                variant={bucketFilter === "all" ? "primary" : "outline"}
+                onClick={() => setBucketFilter("all")}
+              >
+                All ({posts.length})
+              </Button>
+              <Button
+                type="button"
+                size="sm"
+                variant={bucketFilter === "needs_changes" ? "primary" : "outline"}
+                onClick={() => setBucketFilter("needs_changes")}
+              >
+                Needs changes ({bucketCounts.needs_changes})
+              </Button>
+              <Button
+                type="button"
+                size="sm"
+                variant={bucketFilter === "ready" ? "primary" : "outline"}
+                onClick={() => setBucketFilter("ready")}
+              >
+                Ready to approve ({bucketCounts.ready})
+              </Button>
+              {bucketCounts.unreviewed > 0 && (
+                <Button
+                  type="button"
+                  size="sm"
+                  variant={bucketFilter === "unreviewed" ? "primary" : "outline"}
+                  onClick={() => setBucketFilter("unreviewed")}
+                >
+                  Unreviewed ({bucketCounts.unreviewed})
+                </Button>
+              )}
+            </div>
+
+            {platformOptions.length > 0 && (
+              <div className="flex flex-wrap items-center gap-1.5" role="group" aria-label="Filter by platform">
+                <Button
+                  type="button"
+                  size="sm"
+                  variant={platformFilter === "all" ? "secondary" : "ghost"}
+                  onClick={() => setPlatformFilter("all")}
+                >
+                  All platforms
+                </Button>
+                {platformOptions.map((platform) => (
+                  <Button
+                    key={platform}
+                    type="button"
+                    size="sm"
+                    variant={platformFilter === platform ? "secondary" : "ghost"}
+                    onClick={() => setPlatformFilter(platform)}
+                  >
+                    {platform}
+                  </Button>
+                ))}
+              </div>
+            )}
+          </div>
+
+          {visiblePosts.length === 0 ? (
+            <EmptyState
+              title="No posts match this filter"
+              description="Try a different triage or platform filter."
+            />
+          ) : (
+            <ul className="space-y-4">
+              {visiblePosts.map((post) => (
+                <li key={post.id}>
+                  <ReviewCard
+                    post={post}
+                    onApprove={handleApprove}
+                    onReject={handleReject}
+                    onEdit={handleEdit}
+                    onReschedule={handleReschedule}
+                    onRegenerate={handleRegenerate}
+                  />
+                </li>
+              ))}
+            </ul>
+          )}
+        </>
       )}
     </div>
   );

--- a/apps/web/app/review-queue/review-card.tsx
+++ b/apps/web/app/review-queue/review-card.tsx
@@ -74,15 +74,26 @@ function platformReviews(feedback: ReviewFeedback): Record<string, PlatformRevie
   return {};
 }
 
+// A review has something worth regenerating from only when at least one
+// platform actually flagged an issue or suggested a concrete edit — an
+// all-clear review has nothing for Kavi to act on.
+function hasActionableFeedback(feedback: ReviewFeedback | null): boolean {
+  if (!feedback) return false;
+  return Object.values(platformReviews(feedback)).some(
+    (review) => (review.issues && review.issues.length > 0) || Boolean(review.suggested_edits)
+  );
+}
+
 interface ReviewCardProps {
   post: ReviewQueuePost;
   onApprove: (postId: string, comments: string) => Promise<void>;
   onReject: (postId: string, comments: string) => Promise<void>;
   onEdit: (postId: string, bodyText: Record<string, string>) => Promise<void>;
   onReschedule: (postId: string, targetDatetimeIso: string) => Promise<void>;
+  onRegenerate: (postId: string) => Promise<void>;
 }
 
-export function ReviewCard({ post, onApprove, onReject, onEdit, onReschedule }: ReviewCardProps) {
+export function ReviewCard({ post, onApprove, onReject, onEdit, onReschedule, onRegenerate }: ReviewCardProps) {
   const [comments, setComments] = useState("");
   const [isEditing, setIsEditing] = useState(false);
   const [draftBody, setDraftBody] = useState<Record<string, string>>(post.body_text ?? {});
@@ -120,6 +131,10 @@ export function ReviewCard({ post, onApprove, onReject, onEdit, onReschedule }: 
       await onEdit(post.id, draftBody);
       setIsEditing(false);
     });
+  }
+
+  function handleRegenerate() {
+    run(() => onRegenerate(post.id));
   }
 
   function handleSaveReschedule() {
@@ -296,6 +311,17 @@ export function ReviewCard({ post, onApprove, onReject, onEdit, onReschedule }: 
       </div>
 
       <div className="flex flex-wrap items-center justify-end gap-2 border-t border-slate-100 bg-slate-50 px-5 py-4">
+        {hasActionableFeedback(aiReview) && (
+          <Button
+            type="button"
+            variant="outline"
+            onClick={handleRegenerate}
+            disabled={isSubmitting}
+            title="Ask Kavi to rewrite this draft using Neer's feedback above"
+          >
+            Regenerate with Neer&apos;s feedback
+          </Button>
+        )}
         {!isEditing && (
           <Button
             type="button"

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -337,6 +337,23 @@ export async function editReviewPost(
   return res.json();
 }
 
+export async function regenerateReviewPost(
+  token: string,
+  brandId: string,
+  postId: string
+): Promise<ReviewQueuePost> {
+  const res = await fetch(reviewQueueUrl(brandId, `/${postId}/regenerate`), {
+    method: "POST",
+    headers: { "Content-Type": "application/json", ...authHeaders(token) },
+  });
+
+  if (!res.ok) {
+    throw new ApiError(await parseErrorDetail(res), res.status);
+  }
+
+  return res.json();
+}
+
 export async function rescheduleReviewPost(
   token: string,
   brandId: string,

--- a/packages/agents/pipeline/nodes/generation_engine.py
+++ b/packages/agents/pipeline/nodes/generation_engine.py
@@ -328,6 +328,73 @@ Respond with ONLY the JSON object. No markdown code fences, no extra text.
 """
 
 
+def _build_regeneration_prompt(
+    body_text: dict[str, str], feedback_by_platform: dict[str, dict[str, Any]]
+) -> str:
+    platforms = list(body_text.keys())
+    drafts_json = json.dumps({platform: body_text.get(platform, "") for platform in platforms})
+    feedback_json = json.dumps(
+        {
+            platform: {
+                "issues": feedback_by_platform.get(platform, {}).get("issues", []),
+                "suggested_edits": feedback_by_platform.get(platform, {}).get("suggested_edits", ""),
+            }
+            for platform in platforms
+        }
+    )
+    return f"""You are a senior social media copywriter revising a draft
+post based on an editorial reviewer's feedback. Respond with strict JSON
+only — no markdown, no commentary, no code fences.
+
+## Current draft copy per platform
+{drafts_json}
+
+## Reviewer feedback per platform (issues to fix, and suggested edits)
+{feedback_json}
+
+## Task
+For EACH of these target platforms — {", ".join(platforms)} — rewrite that
+platform's draft to directly address every listed issue and incorporate
+the suggested edit, while preserving whatever already works about the
+current draft (its hook, structure, or tone where the feedback didn't
+flag a problem with it). A platform with no issues listed should come
+back materially unchanged. Each platform's revision must stay a genuinely
+distinct, platform-appropriate post — not the same text reused across
+platforms.
+
+Respond with a single JSON object whose keys are exactly the platform
+names listed above, and whose values are the revised copy text (a plain
+string) for that platform.
+
+Respond with ONLY the JSON object. No markdown code fences, no extra text.
+"""
+
+
+def regenerate_copy_with_feedback(
+    body_text: dict[str, str], feedback_by_platform: dict[str, dict[str, Any]]
+) -> tuple[dict[str, str], str, int]:
+    """Revises an already-generated draft using the Reviewer Engine's
+    (reviewer_engine.py) per-platform `issues`/`suggested_edits` — the
+    "Regenerate with Neer's feedback" action on the review queue (Issue
+    #140). Same interface-only, degrade-on-failure contract as
+    _generate_copy below: any LLM failure or unparseable response falls
+    back to the draft's ORIGINAL, unmodified text (never a blank/broken
+    draft) rather than raising."""
+    platforms = list(body_text.keys())
+    model = _default_model()
+    prompt = _build_regeneration_prompt(body_text, feedback_by_platform)
+    try:
+        response = get_llm_provider().complete(prompt=prompt, model=model, temperature=0.7)
+        revised = _parse_platform_copy(response.text, platforms)
+        return revised, response.model, response.input_tokens + response.output_tokens
+    except Exception:
+        logger.warning(
+            "Generation Engine regeneration LLM call/parse failed; keeping original draft",
+            exc_info=True,
+        )
+        return dict(body_text), model, 0
+
+
 def _generate_copy(
     platform_briefs: dict[str, dict[str, str]], platforms: list[str]
 ) -> tuple[dict[str, str], str, int]:

--- a/packages/agents/tests/test_generation_engine.py
+++ b/packages/agents/tests/test_generation_engine.py
@@ -41,6 +41,7 @@ from packages.agents.pipeline.graph import run_pipeline
 from packages.agents.pipeline.nodes.generation_engine import (
     GenerationEngineError,
     build_generation_node,
+    regenerate_copy_with_feedback,
 )
 from packages.integrations.llm.base import LLMResponse
 
@@ -312,6 +313,56 @@ def test_generation_degrades_gracefully_on_unparseable_llm_output(db_session) ->
 
     platforms = result["generation_output"]["platforms"]
     assert set(platforms.keys()) == {"linkedin", "x"}
+
+
+# --- regenerate_copy_with_feedback (Issue #140) --------------------------
+
+
+def test_regenerate_copy_with_feedback_calls_llm_provider_only_through_interface() -> None:
+    body_text = {"linkedin": "Original draft."}
+    feedback = {"linkedin": {"issues": ["Too vague"], "suggested_edits": "Add a concrete stat."}}
+
+    with patch(LLM_PATCH_TARGET) as mock_llm:
+        mock_llm.return_value.complete.return_value = LLMResponse(
+            text=json.dumps({"linkedin": "Revised draft with a concrete stat."}),
+            model="openrouter/free",
+            input_tokens=10,
+            output_tokens=5,
+        )
+        revised, model, tokens = regenerate_copy_with_feedback(body_text, feedback)
+
+    mock_llm.return_value.complete.assert_called_once()
+    assert revised == {"linkedin": "Revised draft with a concrete stat."}
+    assert model == "openrouter/free"
+    assert tokens == 15
+
+
+def test_regenerate_copy_with_feedback_falls_back_to_original_draft_on_llm_failure() -> None:
+    body_text = {"linkedin": "Original draft.", "x": "Original x draft."}
+    feedback = {"linkedin": {"issues": ["Too vague"], "suggested_edits": "Add a concrete stat."}}
+
+    with patch(LLM_PATCH_TARGET) as mock_llm:
+        mock_llm.return_value.complete.side_effect = Exception("LLM provider unreachable")
+        revised, _model, tokens = regenerate_copy_with_feedback(body_text, feedback)
+
+    assert revised == body_text
+    assert tokens == 0
+
+
+def test_regenerate_copy_with_feedback_falls_back_on_unparseable_output() -> None:
+    body_text = {"linkedin": "Original draft."}
+
+    with patch(LLM_PATCH_TARGET) as mock_llm:
+        mock_llm.return_value.complete.return_value = LLMResponse(
+            text="not valid json",
+            model="openrouter/free",
+            input_tokens=1,
+            output_tokens=1,
+        )
+        revised, _model, tokens = regenerate_copy_with_feedback(body_text, {})
+
+    assert revised == body_text
+    assert tokens == 0
 
 
 # --- error handling -----------------------------------------------------


### PR DESCRIPTION
Closes #140

## Summary
- New `POST /brands/{brand_id}/review-queue/{post_id}/regenerate` endpoint: asks Generation Engine to revise a paused post's draft using the latest AI review's per-platform `issues`/`suggested_edits`, appending a `PostVersion` (same convention `edit` already uses). Falls back to the original, unmodified draft on any LLM failure — never blanks it. Returns 409 if there's no AI review to regenerate from yet.
- `regenerate_copy_with_feedback()` added to `generation_engine.py`, reusing `_parse_platform_copy`/`_strip_code_fence`.
- Frontend: "Regenerate with Neer's feedback" button on each review card (enabled only when the AI review actually flagged something), wired through `regenerateReviewPost()` in `lib/api.ts`.
- Review queue page: triage filter chips (All / Needs changes / Ready to approve / Unreviewed) and per-platform filter chips, replacing the flat undifferentiated list. Default sort is worst-score-first so the posts needing the most attention surface first.

## Test plan
- [x] Backend: `pytest apps/api/tests packages/agents/tests` — 406 passed (includes new regenerate endpoint tests: happy path, 409 with no AI review, 409 not paused, viewer-forbidden; and generation_engine unit tests: LLM-interface-only, fallback-on-failure, fallback-on-unparseable-output)
- [x] Frontend: `vitest run` — 59 passed (includes new regenerate button test and triage-filter test)
- [x] `npx tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WP3zhi1Bqq2psuUPzbqk2n