### PR TITLE
feat(social): add YouTube, TikTok, Pinterest, Instagram, Threads, Facebook connections

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -78,6 +78,28 @@ X_REDIRECT_URI=http://localhost:8000/oauth/x/callback
 # App-level key, reserved for X's v1.1 media/upload endpoint (OAuth 1.0a,
 # not the OAuth2 flow used for publishing) — not required today.
 X_API_KEY=
+
+# One Meta Developer App (developers.facebook.com) covers all 3 of these.
+META_APP_ID=
+META_APP_SECRET=
+INSTAGRAM_REDIRECT_URI=http://localhost:8000/oauth/instagram/callback
+THREADS_REDIRECT_URI=http://localhost:8000/oauth/threads/callback
+FACEBOOK_REDIRECT_URI=http://localhost:8000/oauth/facebook/callback
+
+# Google Cloud Console OAuth client (YouTube Data API v3 enabled).
+YOUTUBE_CLIENT_ID=
+YOUTUBE_CLIENT_SECRET=
+YOUTUBE_REDIRECT_URI=http://localhost:8000/oauth/youtube/callback
+
+# TikTok for Developers app.
+TIKTOK_CLIENT_KEY=
+TIKTOK_CLIENT_SECRET=
+TIKTOK_REDIRECT_URI=http://localhost:8000/oauth/tiktok/callback
+
+# Pinterest Developers app.
+PINTEREST_APP_ID=
+PINTEREST_APP_SECRET=
+PINTEREST_REDIRECT_URI=http://localhost:8000/oauth/pinterest/callback
 # --- Pipeline trigger (Celery Beat, apps/api/worker.py) ---
 # Minutes ahead of a calendar event's target_datetime the pipeline trigger
 # job starts its pipeline run.

--- a/apps/api/config/__init__.py
+++ b/apps/api/config/__init__.py
@@ -36,6 +36,26 @@ class Settings(BaseSettings):
     # XProvider uses today.
     x_api_key: str | None = None
 
+    # Shared across Meta's 3 platforms (Instagram, Threads, Facebook) —
+    # one Meta Developer App covers all of them.
+    meta_app_id: str | None = None
+    meta_app_secret: str | None = None
+    instagram_redirect_uri: str | None = None
+    threads_redirect_uri: str | None = None
+    facebook_redirect_uri: str | None = None
+
+    youtube_client_id: str | None = None
+    youtube_client_secret: str | None = None
+    youtube_redirect_uri: str | None = None
+
+    tiktok_client_key: str | None = None
+    tiktok_client_secret: str | None = None
+    tiktok_redirect_uri: str | None = None
+
+    pinterest_app_id: str | None = None
+    pinterest_app_secret: str | None = None
+    pinterest_redirect_uri: str | None = None
+
     search_provider: str = "tavily"
     llm_provider: str = "openrouter"
     storage_provider: str = "supabase"

--- a/apps/api/models/social_account.py
+++ b/apps/api/models/social_account.py
@@ -11,6 +11,12 @@ from apps.api.config.database import Base
 
 class SocialPlatform(str, enum.Enum):
     LINKEDIN = "linkedin"
+    INSTAGRAM = "instagram"
+    THREADS = "threads"
+    FACEBOOK = "facebook"
+    YOUTUBE = "youtube"
+    TIKTOK = "tiktok"
+    PINTEREST = "pinterest"
 
 
 class SocialAccountStatus(str, enum.Enum):

--- a/apps/api/routers/social_accounts.py
+++ b/apps/api/routers/social_accounts.py
@@ -19,8 +19,26 @@ router = APIRouter(tags=["social-accounts"])
 
 WRITE_ROLES = (UserRole.OWNER, UserRole.ADMIN, UserRole.EDITOR)
 
-STATE_PURPOSE = "linkedin_oauth_connect"
 STATE_EXPIRES_MINUTES = 10
+
+# Every platform this connect/callback pair is wired for, keyed by the
+# `platform` path segment used in both the /connect and the vendor
+# redirect_uri, alongside the SocialAccount.platform enum member it maps
+# to, the Settings attribute holding its redirect_uri, and whether its
+# OAuth flow needs PKCE (only TikTok's does among the platforms below —
+# see TikTokProvider's docstring). Issue #138. Deliberately excludes
+# LinkedIn (kept as its own explicit endpoint pair below, unchanged, since
+# it predates this table) and X (issue #120/PR #121 owns that wiring
+# separately, to avoid two in-flight PRs racing to define the same
+# endpoint).
+_PLATFORM_CONFIG: dict[str, tuple[SocialPlatform, str, bool]] = {
+    "instagram": (SocialPlatform.INSTAGRAM, "instagram_redirect_uri", False),
+    "threads": (SocialPlatform.THREADS, "threads_redirect_uri", False),
+    "facebook": (SocialPlatform.FACEBOOK, "facebook_redirect_uri", False),
+    "youtube": (SocialPlatform.YOUTUBE, "youtube_redirect_uri", False),
+    "tiktok": (SocialPlatform.TIKTOK, "tiktok_redirect_uri", True),
+    "pinterest": (SocialPlatform.PINTEREST, "pinterest_redirect_uri", False),
+}
 
 
 def _get_org_brand(db: Session, brand_id: uuid.UUID, org_id: str) -> Brand:
@@ -49,24 +67,26 @@ def _get_account_or_404(
     return account
 
 
-def _create_state(brand_id: uuid.UUID) -> str:
+def _create_state(brand_id: uuid.UUID, platform: str) -> str:
     # The signed state token IS the authorization credential the callback
     # step relies on — WRITE_ROLES was already checked when /connect issued
-    # it, and LinkedIn's redirect back to /callback carries no Authorization
-    # header of its own, so this is what proves the callback is legitimate
-    # and which brand it's for.
+    # it, and the platform's redirect back to /callback carries no
+    # Authorization header of its own, so this is what proves the callback
+    # is legitimate, which brand it's for, and (via `purpose`) which
+    # platform it was issued for — a state minted for one platform's
+    # connect flow must not be replayable against another's callback.
     settings = get_settings()
     now = datetime.now(timezone.utc)
     payload = {
         "brand_id": str(brand_id),
-        "purpose": STATE_PURPOSE,
+        "purpose": f"{platform}_oauth_connect",
         "iat": now,
         "exp": now + timedelta(minutes=STATE_EXPIRES_MINUTES),
     }
     return jwt.encode(payload, settings.secret_key, algorithm=ALGORITHM)
 
 
-def _verify_state(state: str) -> uuid.UUID:
+def _verify_state(state: str, platform: str) -> uuid.UUID:
     settings = get_settings()
     try:
         payload = jwt.decode(state, settings.secret_key, algorithms=[ALGORITHM])
@@ -75,13 +95,39 @@ def _verify_state(state: str) -> uuid.UUID:
             status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid or expired OAuth state"
         ) from None
 
-    if payload.get("purpose") != STATE_PURPOSE:
+    if payload.get("purpose") != f"{platform}_oauth_connect":
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid OAuth state")
 
     try:
         return uuid.UUID(payload["brand_id"])
     except (KeyError, ValueError):
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid OAuth state") from None
+
+
+def _upsert_social_account(
+    db: Session, brand_id: uuid.UUID, platform: SocialPlatform, tokens
+) -> SocialAccount:
+    account = (
+        db.query(SocialAccount)
+        .filter(SocialAccount.brand_id == brand_id, SocialAccount.platform == platform)
+        .first()
+    )
+    if account is None:
+        account = SocialAccount(brand_id=brand_id, platform=platform)
+        db.add(account)
+
+    account.external_account_id = tokens.external_account_id
+    account.access_token_encrypted = encrypt_token(tokens.access_token)
+    account.refresh_token_encrypted = (
+        encrypt_token(tokens.refresh_token) if tokens.refresh_token else None
+    )
+    account.token_expires_at = tokens.expires_at
+    account.scopes = tokens.scopes
+    account.status = SocialAccountStatus.ACTIVE
+
+    db.flush()
+    db.refresh(account)
+    return account
 
 
 @router.get("/brands/{brand_id}/social-accounts", response_model=list[SocialAccountRead])
@@ -123,7 +169,7 @@ def connect_linkedin(
         )
 
     provider = get_social_oauth_provider("linkedin")
-    state = _create_state(brand_id)
+    state = _create_state(brand_id, "linkedin")
     url = provider.authorize_url(state=state, redirect_uri=settings.linkedin_redirect_uri)
     return AuthorizeUrlRead(authorize_url=url)
 
@@ -134,32 +180,73 @@ def linkedin_callback(
     state: str = Query(...),
     db: Session = Depends(get_db),
 ) -> SocialAccount:
-    brand_id = _verify_state(state)
+    brand_id = _verify_state(state, "linkedin")
     settings = get_settings()
     provider = get_social_oauth_provider("linkedin")
     tokens = provider.exchange_code(code=code, redirect_uri=settings.linkedin_redirect_uri or "")
+    return _upsert_social_account(db, brand_id, SocialPlatform.LINKEDIN, tokens)
 
-    account = (
-        db.query(SocialAccount)
-        .filter(SocialAccount.brand_id == brand_id, SocialAccount.platform == SocialPlatform.LINKEDIN)
-        .first()
+
+def _make_connect_endpoint(platform: str, social_platform: SocialPlatform, redirect_attr: str):
+    def _connect(
+        brand_id: uuid.UUID,
+        db: Session = Depends(get_db),
+        current_user: CurrentUser = Depends(require_role(*WRITE_ROLES)),
+    ) -> AuthorizeUrlRead:
+        _get_org_brand(db, brand_id, current_user.org_id)
+        settings = get_settings()
+        redirect_uri = getattr(settings, redirect_attr)
+        if not redirect_uri:
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail=f"{platform.capitalize()} OAuth is not configured",
+            )
+
+        provider = get_social_oauth_provider(platform)
+        state = _create_state(brand_id, platform)
+        url = provider.authorize_url(state=state, redirect_uri=redirect_uri)
+        return AuthorizeUrlRead(authorize_url=url)
+
+    _connect.__name__ = f"connect_{platform}"
+    return _connect
+
+
+def _make_callback_endpoint(
+    platform: str, social_platform: SocialPlatform, redirect_attr: str, requires_pkce: bool
+):
+    def _callback(
+        code: str = Query(...),
+        state: str = Query(...),
+        db: Session = Depends(get_db),
+    ) -> SocialAccount:
+        brand_id = _verify_state(state, platform)
+        settings = get_settings()
+        redirect_uri = getattr(settings, redirect_attr) or ""
+        provider = get_social_oauth_provider(platform)
+        # `state` doubles as the PKCE code_verifier for platforms that
+        # require it (currently only TikTok) — same "state is already
+        # unique per request, single-use, and round-trips unmodified
+        # through the redirect" reasoning XProvider's own PKCE handling
+        # uses. Every other provider's exchange_code ignores this kwarg.
+        tokens = provider.exchange_code(
+            code=code,
+            redirect_uri=redirect_uri,
+            code_verifier=state if requires_pkce else None,
+        )
+        return _upsert_social_account(db, brand_id, social_platform, tokens)
+
+    _callback.__name__ = f"{platform}_callback"
+    return _callback
+
+
+for _platform, (_social_platform, _redirect_attr, _requires_pkce) in _PLATFORM_CONFIG.items():
+    router.post(
+        f"/brands/{{brand_id}}/social-accounts/{_platform}/connect",
+        response_model=AuthorizeUrlRead,
+    )(_make_connect_endpoint(_platform, _social_platform, _redirect_attr))
+    router.get(f"/oauth/{_platform}/callback", response_model=SocialAccountRead)(
+        _make_callback_endpoint(_platform, _social_platform, _redirect_attr, _requires_pkce)
     )
-    if account is None:
-        account = SocialAccount(brand_id=brand_id, platform=SocialPlatform.LINKEDIN)
-        db.add(account)
-
-    account.external_account_id = tokens.external_account_id
-    account.access_token_encrypted = encrypt_token(tokens.access_token)
-    account.refresh_token_encrypted = (
-        encrypt_token(tokens.refresh_token) if tokens.refresh_token else None
-    )
-    account.token_expires_at = tokens.expires_at
-    account.scopes = tokens.scopes
-    account.status = SocialAccountStatus.ACTIVE
-
-    db.flush()
-    db.refresh(account)
-    return account
 
 
 @router.post(

--- a/apps/api/tests/test_integrations_registry.py
+++ b/apps/api/tests/test_integrations_registry.py
@@ -50,9 +50,25 @@ def test_get_social_oauth_provider_resolves_linkedin() -> None:
     assert isinstance(get_social_oauth_provider("linkedin"), LinkedInProvider)
 
 
+def test_get_social_oauth_provider_resolves_new_platforms() -> None:
+    from packages.integrations.social.facebook_provider import FacebookProvider
+    from packages.integrations.social.instagram_provider import InstagramProvider
+    from packages.integrations.social.pinterest_provider import PinterestProvider
+    from packages.integrations.social.threads_provider import ThreadsProvider
+    from packages.integrations.social.tiktok_provider import TikTokProvider
+    from packages.integrations.social.youtube_provider import YouTubeProvider
+
+    assert isinstance(get_social_oauth_provider("facebook"), FacebookProvider)
+    assert isinstance(get_social_oauth_provider("instagram"), InstagramProvider)
+    assert isinstance(get_social_oauth_provider("threads"), ThreadsProvider)
+    assert isinstance(get_social_oauth_provider("youtube"), YouTubeProvider)
+    assert isinstance(get_social_oauth_provider("tiktok"), TikTokProvider)
+    assert isinstance(get_social_oauth_provider("pinterest"), PinterestProvider)
+
+
 def test_unknown_social_platform_raises() -> None:
     with pytest.raises(ValueError, match="Unknown social platform"):
-        get_social_oauth_provider("tiktok")
+        get_social_oauth_provider("snapchat")
 
 
 def test_get_embedding_provider_defaults_to_openai() -> None:

--- a/apps/api/tests/test_publishing_adapters.py
+++ b/apps/api/tests/test_publishing_adapters.py
@@ -7,20 +7,43 @@ import pytest
 from apps.api.models import IntegrationCall
 from packages.integrations.registry import get_social_publisher
 from packages.integrations.social.base import PublishResult, SocialPublisher
+from packages.integrations.social.facebook_provider import FacebookProvider
+from packages.integrations.social.instagram_provider import InstagramProvider
 from packages.integrations.social.linkedin_provider import LinkedInProvider
+from packages.integrations.social.pinterest_provider import PinterestProvider
+from packages.integrations.social.threads_provider import ThreadsProvider
+from packages.integrations.social.tiktok_provider import TikTokProvider
 from packages.integrations.social.x_provider import XProvider
+from packages.integrations.social.youtube_provider import YouTubeProvider
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 
-# Domains only linkedin_provider.py / x_provider.py are allowed to
-# reference — everything else must go through SocialPublisher /
-# SocialOAuthProvider instead of talking to the vendor directly.
+# Domains only the matching provider file is allowed to reference —
+# everything else must go through SocialPublisher / SocialOAuthProvider
+# instead of talking to the vendor directly. Instagram/Facebook share
+# facebook.com/graph.facebook.com (same Meta Graph API host), so both
+# provider files are listed for that marker.
 VENDOR_MARKERS = {
-    "linkedin.com": "linkedin_provider.py",
-    "twitter.com": "x_provider.py",
+    "linkedin.com": ("linkedin_provider.py",),
+    "twitter.com": ("x_provider.py",),
+    "facebook.com": ("facebook_provider.py", "instagram_provider.py"),
+    "threads.net": ("threads_provider.py",),
+    "googleapis.com": ("youtube_provider.py",),
+    "tiktok.com": ("tiktok_provider.py",),
+    "tiktokapis.com": ("tiktok_provider.py",),
+    "pinterest.com": ("pinterest_provider.py",),
 }
 
-ALLOWED_FILES = {"linkedin_provider.py", "x_provider.py"}
+ALLOWED_FILES = {
+    "linkedin_provider.py",
+    "x_provider.py",
+    "facebook_provider.py",
+    "instagram_provider.py",
+    "threads_provider.py",
+    "youtube_provider.py",
+    "tiktok_provider.py",
+    "pinterest_provider.py",
+}
 
 
 def _mock_response(json_data: dict | None = None, status_code: int = 200, headers=None) -> MagicMock:
@@ -63,9 +86,63 @@ def test_registry_resolves_x_publisher() -> None:
     assert isinstance(get_social_publisher("x"), XProvider)
 
 
+def test_facebook_provider_implements_social_publisher() -> None:
+    provider = FacebookProvider(client_id="cid", client_secret="secret")
+    assert isinstance(provider, SocialPublisher)
+
+
+def test_instagram_provider_implements_social_publisher() -> None:
+    provider = InstagramProvider(client_id="cid", client_secret="secret")
+    assert isinstance(provider, SocialPublisher)
+
+
+def test_threads_provider_implements_social_publisher() -> None:
+    provider = ThreadsProvider(client_id="cid", client_secret="secret")
+    assert isinstance(provider, SocialPublisher)
+
+
+def test_registry_resolves_facebook_publisher() -> None:
+    assert isinstance(get_social_publisher("facebook"), FacebookProvider)
+
+
+def test_registry_resolves_instagram_publisher() -> None:
+    assert isinstance(get_social_publisher("instagram"), InstagramProvider)
+
+
+def test_registry_resolves_threads_publisher() -> None:
+    assert isinstance(get_social_publisher("threads"), ThreadsProvider)
+
+
+def test_youtube_provider_implements_social_publisher() -> None:
+    provider = YouTubeProvider(client_id="cid", client_secret="secret")
+    assert isinstance(provider, SocialPublisher)
+
+
+def test_tiktok_provider_implements_social_publisher() -> None:
+    provider = TikTokProvider(client_key="key", client_secret="secret")
+    assert isinstance(provider, SocialPublisher)
+
+
+def test_pinterest_provider_implements_social_publisher() -> None:
+    provider = PinterestProvider(client_id="cid", client_secret="secret")
+    assert isinstance(provider, SocialPublisher)
+
+
+def test_registry_resolves_youtube_publisher() -> None:
+    assert isinstance(get_social_publisher("youtube"), YouTubeProvider)
+
+
+def test_registry_resolves_tiktok_publisher() -> None:
+    assert isinstance(get_social_publisher("tiktok"), TikTokProvider)
+
+
+def test_registry_resolves_pinterest_publisher() -> None:
+    assert isinstance(get_social_publisher("pinterest"), PinterestProvider)
+
+
 def test_registry_unknown_platform_raises() -> None:
     with pytest.raises(ValueError, match="Unknown social platform"):
-        get_social_publisher("tiktok")
+        get_social_publisher("snapchat")
 
 
 def test_no_other_file_references_linkedin_or_x_vendor_urls() -> None:
@@ -84,7 +161,7 @@ def test_no_other_file_references_linkedin_or_x_vendor_urls() -> None:
             text = py_file.read_text()
         except (UnicodeDecodeError, OSError):
             continue
-        for marker in ("linkedin.com", "twitter.com", "api.x.com", "://x.com"):
+        for marker in (*VENDOR_MARKERS, "api.x.com", "://x.com"):
             if marker in text:
                 offenders.append(f"{py_file.relative_to(REPO_ROOT)} references {marker!r}")
     assert offenders == [], "\n".join(offenders)
@@ -700,3 +777,1231 @@ def test_x_get_engagement_logs_integration_call(db_session) -> None:
     )
     assert logged is not None
     assert logged.success is True
+
+
+# ---------------------------------------------------------------------
+# Facebook: OAuth-connection interface, same shape as LinkedIn/X's above —
+# exercised here for coverage since #110 is what introduces FacebookProvider.
+# ---------------------------------------------------------------------
+
+
+def test_facebook_authorize_url_includes_state_and_scopes() -> None:
+    provider = FacebookProvider(client_id="cid", client_secret="secret")
+    url = provider.authorize_url(state="signed-state", redirect_uri="https://app.test/callback")
+
+    assert url.startswith(FacebookProvider.AUTHORIZE_URL)
+    assert "client_id=cid" in url
+    assert "state=signed-state" in url
+    assert "pages_manage_posts" in url
+
+
+def test_facebook_exchange_code_returns_tokens_and_fetches_page_id() -> None:
+    provider = FacebookProvider(client_id="cid", client_secret="secret")
+    token_response = _mock_response({"access_token": "at-123", "expires_in": 5184000})
+    page_response = _mock_response({"id": "page-42", "name": "Acme Page"})
+
+    with patch("httpx.post", return_value=token_response), patch(
+        "httpx.get", return_value=page_response
+    ):
+        tokens = provider.exchange_code(code="auth-code", redirect_uri="https://app.test/callback")
+
+    assert tokens.access_token == "at-123"
+    assert tokens.refresh_token is None
+    assert tokens.external_account_id == "page-42"
+    assert tokens.expires_at is not None
+
+
+def test_facebook_is_token_valid_true_on_200() -> None:
+    provider = FacebookProvider(client_id="cid", client_secret="secret")
+    with patch("httpx.get", return_value=_mock_response({"id": "page-42"}, status_code=200)):
+        assert provider.is_token_valid("some-token") is True
+
+
+def test_facebook_is_token_valid_false_when_platform_rejects_it() -> None:
+    provider = FacebookProvider(client_id="cid", client_secret="secret")
+    with patch("httpx.get", return_value=_mock_response(status_code=401)):
+        assert provider.is_token_valid("revoked-token") is False
+
+
+# ---------------------------------------------------------------------
+# Facebook: successful publish
+# ---------------------------------------------------------------------
+
+
+def test_facebook_publish_success_returns_populated_result(db_session) -> None:
+    provider = FacebookProvider(client_id="cid", client_secret="secret")
+    page_response = _mock_response({"id": "page-42"})
+    post_response = _mock_response({"id": "page-42_999"})
+
+    with patch("httpx.get", return_value=page_response), patch(
+        "httpx.post", return_value=post_response
+    ):
+        result = provider.publish(access_token="good-token", content="hello world")
+
+    assert isinstance(result, PublishResult)
+    assert result.success is True
+    assert result.platform_post_id == "page-42_999"
+    assert result.platform_post_url is not None
+    assert result.error is None
+    assert result.refreshed_tokens is None
+
+
+def test_facebook_publish_success_logs_integration_call(db_session) -> None:
+    provider = FacebookProvider(client_id="cid", client_secret="secret")
+    page_response = _mock_response({"id": "page-42"})
+    post_response = _mock_response({"id": "page-42_999"})
+
+    with patch("httpx.get", return_value=page_response), patch(
+        "httpx.post", return_value=post_response
+    ):
+        provider.publish(access_token="good-token", content="hello world")
+
+    logged = (
+        db_session.query(IntegrationCall)
+        .filter_by(provider="facebook", capability="publish")
+        .order_by(IntegrationCall.created_at.desc())
+        .first()
+    )
+    assert logged is not None
+    assert logged.success is True
+
+
+def test_facebook_publish_includes_link_when_media_urls_given(db_session) -> None:
+    provider = FacebookProvider(client_id="cid", client_secret="secret")
+    page_response = _mock_response({"id": "page-42"})
+    post_response = _mock_response({"id": "page-42_999"})
+
+    with patch("httpx.get", return_value=page_response), patch(
+        "httpx.post", return_value=post_response
+    ) as mock_post:
+        result = provider.publish(
+            access_token="good-token",
+            content="hello world",
+            media_urls=["https://cdn.test/image.png"],
+        )
+
+    assert result.success is True
+    assert mock_post.call_args.kwargs["json"]["link"] == "https://cdn.test/image.png"
+
+
+# ---------------------------------------------------------------------
+# Facebook: expired token -> transparent refresh + retry
+# ---------------------------------------------------------------------
+
+
+def test_facebook_publish_refreshes_and_retries_once_on_expired_token(db_session) -> None:
+    provider = FacebookProvider(client_id="cid", client_secret="secret")
+
+    expired_page_response = _mock_response(status_code=401)
+    refresh_response = _mock_response({"access_token": "new-token", "expires_in": 5184000})
+    retry_page_response = _mock_response({"id": "page-42"})
+    retry_post_response = _mock_response({"id": "page-42_777"})
+
+    get_calls = [expired_page_response, retry_page_response]
+    post_calls = [refresh_response, retry_post_response]
+
+    with patch("httpx.get", side_effect=get_calls) as mock_get, patch(
+        "httpx.post", side_effect=post_calls
+    ) as mock_post:
+        result = provider.publish(
+            access_token="stale-token", content="hello world", refresh_token="prior-long-lived-token"
+        )
+
+    assert result.success is True
+    assert result.platform_post_id == "page-42_777"
+    assert result.refreshed_tokens is not None
+    assert result.refreshed_tokens.access_token == "new-token"
+    assert mock_get.call_count == 2
+    assert mock_post.call_count == 2
+
+
+def test_facebook_publish_expired_token_not_surfaced_as_failure(db_session) -> None:
+    provider = FacebookProvider(client_id="cid", client_secret="secret")
+
+    get_calls = [_mock_response(status_code=401), _mock_response({"id": "page-42"})]
+    post_calls = [
+        _mock_response({"access_token": "new-token"}),
+        _mock_response({"id": "id-1"}),
+    ]
+
+    with patch("httpx.get", side_effect=get_calls), patch("httpx.post", side_effect=post_calls):
+        result = provider.publish(
+            access_token="stale-token", content="hello world", refresh_token="prior-token"
+        )
+
+    assert result.success is True
+    assert result.error is None
+
+
+def test_facebook_publish_expired_token_without_refresh_token_fails(db_session) -> None:
+    provider = FacebookProvider(client_id="cid", client_secret="secret")
+
+    with patch("httpx.get", return_value=_mock_response(status_code=401)):
+        result = provider.publish(access_token="stale-token", content="hello world")
+
+    assert result.success is False
+    assert result.error is not None
+    assert "refresh" in result.error.lower()
+
+
+def test_facebook_publish_refresh_failure_surfaces_as_real_failure(db_session) -> None:
+    provider = FacebookProvider(client_id="cid", client_secret="secret")
+
+    with patch("httpx.get", return_value=_mock_response(status_code=401)), patch(
+        "httpx.post", return_value=_mock_response(status_code=400)
+    ):
+        result = provider.publish(
+            access_token="stale-token", content="hello world", refresh_token="bad-token"
+        )
+
+    assert result.success is False
+    assert result.error is not None
+
+
+# ---------------------------------------------------------------------
+# Facebook: hard (non-token) failures
+# ---------------------------------------------------------------------
+
+
+def test_facebook_publish_hard_http_failure_returns_failed_result(db_session) -> None:
+    provider = FacebookProvider(client_id="cid", client_secret="secret")
+
+    with patch("httpx.get", return_value=_mock_response({"id": "page-42"})), patch(
+        "httpx.post", return_value=_mock_response(status_code=500)
+    ):
+        result = provider.publish(access_token="good-token", content="hello world")
+
+    assert result.success is False
+    assert result.error is not None
+
+
+def test_facebook_publish_hard_failure_logged(db_session) -> None:
+    provider = FacebookProvider(client_id="cid", client_secret="secret")
+
+    with patch("httpx.get", return_value=_mock_response({"id": "page-42"})), patch(
+        "httpx.post", return_value=_mock_response(status_code=500)
+    ):
+        provider.publish(access_token="good-token", content="hello world")
+
+    logged = (
+        db_session.query(IntegrationCall)
+        .filter_by(provider="facebook", capability="publish")
+        .order_by(IntegrationCall.created_at.desc())
+        .first()
+    )
+    assert logged is not None
+    assert logged.success is False
+    assert logged.error_message is not None
+
+
+# ---------------------------------------------------------------------
+# Facebook: get_engagement()
+# ---------------------------------------------------------------------
+
+
+def test_facebook_get_engagement_success_returns_metrics(db_session) -> None:
+    provider = FacebookProvider(client_id="cid", client_secret="secret")
+
+    with patch(
+        "httpx.get",
+        return_value=_mock_response(
+            {
+                "likes": {"summary": {"total_count": 10}},
+                "comments": {"summary": {"total_count": 4}},
+                "shares": {"count": 2},
+            }
+        ),
+    ):
+        result = provider.get_engagement(access_token="good-token", platform_post_id="page-42_999")
+
+    assert result.success is True
+    assert result.rate_limited is False
+    assert result.metrics.likes == 10
+    assert result.metrics.comments == 4
+    assert result.metrics.shares == 2
+    assert result.metrics.impressions == 0
+
+
+def test_facebook_get_engagement_rate_limited_returns_flag_not_raise(db_session) -> None:
+    provider = FacebookProvider(client_id="cid", client_secret="secret")
+
+    with patch("httpx.get", return_value=_mock_response(status_code=429)):
+        result = provider.get_engagement(access_token="good-token", platform_post_id="page-42_999")
+
+    assert result.success is False
+    assert result.rate_limited is True
+    assert result.metrics is None
+
+
+def test_facebook_get_engagement_hard_http_failure_returns_failed_result(db_session) -> None:
+    provider = FacebookProvider(client_id="cid", client_secret="secret")
+
+    with patch("httpx.get", return_value=_mock_response(status_code=500)):
+        result = provider.get_engagement(access_token="good-token", platform_post_id="page-42_999")
+
+    assert result.success is False
+    assert result.rate_limited is False
+    assert result.error is not None
+
+
+def test_facebook_get_engagement_logs_integration_call(db_session) -> None:
+    provider = FacebookProvider(client_id="cid", client_secret="secret")
+
+    with patch(
+        "httpx.get",
+        return_value=_mock_response(
+            {"likes": {"summary": {"total_count": 1}}, "comments": {"summary": {"total_count": 0}}, "shares": {"count": 0}}
+        ),
+    ):
+        provider.get_engagement(access_token="good-token", platform_post_id="page-42_999")
+
+    logged = (
+        db_session.query(IntegrationCall)
+        .filter_by(provider="facebook", capability="get_engagement")
+        .order_by(IntegrationCall.created_at.desc())
+        .first()
+    )
+    assert logged is not None
+    assert logged.success is True
+
+
+# ---------------------------------------------------------------------
+# Instagram: OAuth-connection interface
+# ---------------------------------------------------------------------
+
+
+def test_instagram_authorize_url_includes_state_and_scopes() -> None:
+    provider = InstagramProvider(client_id="cid", client_secret="secret")
+    url = provider.authorize_url(state="signed-state", redirect_uri="https://app.test/callback")
+
+    assert url.startswith(InstagramProvider.AUTHORIZE_URL)
+    assert "client_id=cid" in url
+    assert "state=signed-state" in url
+    assert "instagram_content_publish" in url
+
+
+def test_instagram_exchange_code_returns_tokens_and_fetches_ig_user_id() -> None:
+    provider = InstagramProvider(client_id="cid", client_secret="secret")
+    token_response = _mock_response({"access_token": "at-123", "expires_in": 5184000})
+    accounts_response = _mock_response(
+        {"data": [{"id": "page-1", "instagram_business_account": {"id": "17841400000000000"}}]}
+    )
+
+    with patch("httpx.post", return_value=token_response), patch(
+        "httpx.get", return_value=accounts_response
+    ):
+        tokens = provider.exchange_code(code="auth-code", redirect_uri="https://app.test/callback")
+
+    assert tokens.access_token == "at-123"
+    assert tokens.external_account_id == "17841400000000000"
+
+
+def test_instagram_exchange_code_handles_no_linked_ig_account() -> None:
+    provider = InstagramProvider(client_id="cid", client_secret="secret")
+    token_response = _mock_response({"access_token": "at-123"})
+    accounts_response = _mock_response({"data": [{"id": "page-1"}]})
+
+    with patch("httpx.post", return_value=token_response), patch(
+        "httpx.get", return_value=accounts_response
+    ):
+        tokens = provider.exchange_code(code="auth-code", redirect_uri="https://app.test/callback")
+
+    assert tokens.external_account_id is None
+
+
+def test_instagram_is_token_valid_true_on_200() -> None:
+    provider = InstagramProvider(client_id="cid", client_secret="secret")
+    with patch("httpx.get", return_value=_mock_response({"data": []}, status_code=200)):
+        assert provider.is_token_valid("some-token") is True
+
+
+def test_instagram_is_token_valid_false_when_platform_rejects_it() -> None:
+    provider = InstagramProvider(client_id="cid", client_secret="secret")
+    with patch("httpx.get", return_value=_mock_response(status_code=401)):
+        assert provider.is_token_valid("revoked-token") is False
+
+
+# ---------------------------------------------------------------------
+# Instagram: publish requires media
+# ---------------------------------------------------------------------
+
+
+def test_instagram_publish_without_media_fails_without_any_http_call() -> None:
+    provider = InstagramProvider(client_id="cid", client_secret="secret")
+
+    with patch("httpx.get") as mock_get, patch("httpx.post") as mock_post:
+        result = provider.publish(access_token="good-token", content="hello world")
+
+    assert result.success is False
+    assert "media" in result.error.lower()
+    mock_get.assert_not_called()
+    mock_post.assert_not_called()
+
+
+# ---------------------------------------------------------------------
+# Instagram: successful publish (two-step container -> publish)
+# ---------------------------------------------------------------------
+
+
+def test_instagram_publish_success_returns_populated_result(db_session) -> None:
+    provider = InstagramProvider(client_id="cid", client_secret="secret")
+    accounts_response = _mock_response(
+        {"data": [{"id": "page-1", "instagram_business_account": {"id": "ig-user-1"}}]}
+    )
+    container_response = _mock_response({"id": "container-1"})
+    publish_response = _mock_response({"id": "ig-post-1"})
+
+    with patch("httpx.get", return_value=accounts_response), patch(
+        "httpx.post", side_effect=[container_response, publish_response]
+    ):
+        result = provider.publish(
+            access_token="good-token",
+            content="hello world",
+            media_urls=["https://cdn.test/photo.png"],
+        )
+
+    assert isinstance(result, PublishResult)
+    assert result.success is True
+    assert result.platform_post_id == "ig-post-1"
+    assert result.platform_post_url is not None
+    assert result.error is None
+
+
+def test_instagram_publish_success_logs_integration_call(db_session) -> None:
+    provider = InstagramProvider(client_id="cid", client_secret="secret")
+    accounts_response = _mock_response(
+        {"data": [{"id": "page-1", "instagram_business_account": {"id": "ig-user-1"}}]}
+    )
+    container_response = _mock_response({"id": "container-1"})
+    publish_response = _mock_response({"id": "ig-post-1"})
+
+    with patch("httpx.get", return_value=accounts_response), patch(
+        "httpx.post", side_effect=[container_response, publish_response]
+    ):
+        provider.publish(
+            access_token="good-token",
+            content="hello world",
+            media_urls=["https://cdn.test/photo.png"],
+        )
+
+    logged = (
+        db_session.query(IntegrationCall)
+        .filter_by(provider="instagram", capability="publish")
+        .order_by(IntegrationCall.created_at.desc())
+        .first()
+    )
+    assert logged is not None
+    assert logged.success is True
+
+
+def test_instagram_publish_fails_when_no_ig_account_linked(db_session) -> None:
+    provider = InstagramProvider(client_id="cid", client_secret="secret")
+    accounts_response = _mock_response({"data": [{"id": "page-1"}]})
+
+    with patch("httpx.get", return_value=accounts_response), patch("httpx.post") as mock_post:
+        result = provider.publish(
+            access_token="good-token",
+            content="hello world",
+            media_urls=["https://cdn.test/photo.png"],
+        )
+
+    assert result.success is False
+    assert "instagram" in result.error.lower()
+    mock_post.assert_not_called()
+
+
+# ---------------------------------------------------------------------
+# Instagram: expired token -> transparent refresh + retry
+# ---------------------------------------------------------------------
+
+
+def test_instagram_publish_refreshes_and_retries_once_on_expired_token(db_session) -> None:
+    provider = InstagramProvider(client_id="cid", client_secret="secret")
+
+    expired_accounts_response = _mock_response(status_code=401)
+    retry_accounts_response = _mock_response(
+        {"data": [{"id": "page-1", "instagram_business_account": {"id": "ig-user-1"}}]}
+    )
+    refresh_response = _mock_response({"access_token": "new-token", "expires_in": 5184000})
+    container_response = _mock_response({"id": "container-1"})
+    publish_response = _mock_response({"id": "ig-post-9"})
+
+    get_calls = [expired_accounts_response, retry_accounts_response]
+    post_calls = [refresh_response, container_response, publish_response]
+
+    with patch("httpx.get", side_effect=get_calls) as mock_get, patch(
+        "httpx.post", side_effect=post_calls
+    ) as mock_post:
+        result = provider.publish(
+            access_token="stale-token",
+            content="hello world",
+            media_urls=["https://cdn.test/photo.png"],
+            refresh_token="prior-long-lived-token",
+        )
+
+    assert result.success is True
+    assert result.platform_post_id == "ig-post-9"
+    assert result.refreshed_tokens is not None
+    assert result.refreshed_tokens.access_token == "new-token"
+    assert mock_get.call_count == 2
+    assert mock_post.call_count == 3
+
+
+def test_instagram_publish_expired_token_without_refresh_token_fails(db_session) -> None:
+    provider = InstagramProvider(client_id="cid", client_secret="secret")
+
+    with patch("httpx.get", return_value=_mock_response(status_code=401)):
+        result = provider.publish(
+            access_token="stale-token",
+            content="hello world",
+            media_urls=["https://cdn.test/photo.png"],
+        )
+
+    assert result.success is False
+    assert "refresh" in result.error.lower()
+
+
+def test_instagram_publish_refresh_failure_surfaces_as_real_failure(db_session) -> None:
+    provider = InstagramProvider(client_id="cid", client_secret="secret")
+
+    with patch("httpx.get", return_value=_mock_response(status_code=401)), patch(
+        "httpx.post", return_value=_mock_response(status_code=400)
+    ):
+        result = provider.publish(
+            access_token="stale-token",
+            content="hello world",
+            media_urls=["https://cdn.test/photo.png"],
+            refresh_token="bad-token",
+        )
+
+    assert result.success is False
+    assert result.error is not None
+
+
+# ---------------------------------------------------------------------
+# Instagram: hard (non-token) failures
+# ---------------------------------------------------------------------
+
+
+def test_instagram_publish_hard_http_failure_returns_failed_result(db_session) -> None:
+    provider = InstagramProvider(client_id="cid", client_secret="secret")
+    accounts_response = _mock_response(
+        {"data": [{"id": "page-1", "instagram_business_account": {"id": "ig-user-1"}}]}
+    )
+
+    with patch("httpx.get", return_value=accounts_response), patch(
+        "httpx.post", return_value=_mock_response(status_code=500)
+    ):
+        result = provider.publish(
+            access_token="good-token",
+            content="hello world",
+            media_urls=["https://cdn.test/photo.png"],
+        )
+
+    assert result.success is False
+    assert result.error is not None
+
+
+# ---------------------------------------------------------------------
+# Instagram: get_engagement()
+# ---------------------------------------------------------------------
+
+
+def test_instagram_get_engagement_success_returns_metrics(db_session) -> None:
+    provider = InstagramProvider(client_id="cid", client_secret="secret")
+
+    with patch(
+        "httpx.get",
+        return_value=_mock_response(
+            {
+                "data": [
+                    {"name": "likes", "values": [{"value": 12}]},
+                    {"name": "comments", "values": [{"value": 3}]},
+                    {"name": "saved", "values": [{"value": 5}]},
+                    {"name": "impressions", "values": [{"value": 400}]},
+                ]
+            }
+        ),
+    ):
+        result = provider.get_engagement(access_token="good-token", platform_post_id="ig-post-1")
+
+    assert result.success is True
+    assert result.metrics.likes == 12
+    assert result.metrics.comments == 3
+    assert result.metrics.shares == 5
+    assert result.metrics.impressions == 400
+
+
+def test_instagram_get_engagement_rate_limited_returns_flag_not_raise(db_session) -> None:
+    provider = InstagramProvider(client_id="cid", client_secret="secret")
+
+    with patch("httpx.get", return_value=_mock_response(status_code=429)):
+        result = provider.get_engagement(access_token="good-token", platform_post_id="ig-post-1")
+
+    assert result.success is False
+    assert result.rate_limited is True
+    assert result.metrics is None
+
+
+def test_instagram_get_engagement_logs_integration_call(db_session) -> None:
+    provider = InstagramProvider(client_id="cid", client_secret="secret")
+
+    with patch(
+        "httpx.get",
+        return_value=_mock_response({"data": [{"name": "likes", "values": [{"value": 1}]}]}),
+    ):
+        provider.get_engagement(access_token="good-token", platform_post_id="ig-post-1")
+
+    logged = (
+        db_session.query(IntegrationCall)
+        .filter_by(provider="instagram", capability="get_engagement")
+        .order_by(IntegrationCall.created_at.desc())
+        .first()
+    )
+    assert logged is not None
+    assert logged.success is True
+
+
+# ---------------------------------------------------------------------
+# Threads: OAuth-connection interface
+# ---------------------------------------------------------------------
+
+
+def test_threads_authorize_url_includes_state_and_scopes() -> None:
+    provider = ThreadsProvider(client_id="cid", client_secret="secret")
+    url = provider.authorize_url(state="signed-state", redirect_uri="https://app.test/callback")
+
+    assert url.startswith(ThreadsProvider.AUTHORIZE_URL)
+    assert "client_id=cid" in url
+    assert "state=signed-state" in url
+    assert "threads_content_publish" in url
+
+
+def test_threads_exchange_code_returns_tokens_from_response_directly() -> None:
+    # Unlike LinkedIn/X/Facebook/Instagram, Threads' token-exchange response
+    # includes user_id directly — no separate userinfo call is needed.
+    provider = ThreadsProvider(client_id="cid", client_secret="secret")
+    token_response = _mock_response(
+        {"access_token": "at-123", "user_id": 999888777, "expires_in": 3600}
+    )
+
+    with patch("httpx.post", return_value=token_response) as mock_post, patch(
+        "httpx.get"
+    ) as mock_get:
+        tokens = provider.exchange_code(code="auth-code", redirect_uri="https://app.test/callback")
+
+    assert tokens.access_token == "at-123"
+    assert tokens.external_account_id == "999888777"
+    assert tokens.expires_at is not None
+    mock_get.assert_not_called()
+    mock_post.assert_called_once()
+
+
+def test_threads_is_token_valid_true_on_200() -> None:
+    provider = ThreadsProvider(client_id="cid", client_secret="secret")
+    with patch("httpx.get", return_value=_mock_response({"id": "user-1"}, status_code=200)):
+        assert provider.is_token_valid("some-token") is True
+
+
+def test_threads_is_token_valid_false_when_platform_rejects_it() -> None:
+    provider = ThreadsProvider(client_id="cid", client_secret="secret")
+    with patch("httpx.get", return_value=_mock_response(status_code=401)):
+        assert provider.is_token_valid("revoked-token") is False
+
+
+# ---------------------------------------------------------------------
+# Threads: successful publish (two-step container -> publish, text-only ok)
+# ---------------------------------------------------------------------
+
+
+def test_threads_publish_success_returns_populated_result(db_session) -> None:
+    provider = ThreadsProvider(client_id="cid", client_secret="secret")
+    me_response = _mock_response({"id": "user-1"})
+    container_response = _mock_response({"id": "container-1"})
+    publish_response = _mock_response({"id": "thread-1"})
+
+    with patch("httpx.get", return_value=me_response), patch(
+        "httpx.post", side_effect=[container_response, publish_response]
+    ):
+        result = provider.publish(access_token="good-token", content="hello world")
+
+    assert isinstance(result, PublishResult)
+    assert result.success is True
+    assert result.platform_post_id == "thread-1"
+    assert result.platform_post_url is not None
+    assert result.error is None
+
+
+def test_threads_publish_success_logs_integration_call(db_session) -> None:
+    provider = ThreadsProvider(client_id="cid", client_secret="secret")
+    me_response = _mock_response({"id": "user-1"})
+    container_response = _mock_response({"id": "container-1"})
+    publish_response = _mock_response({"id": "thread-1"})
+
+    with patch("httpx.get", return_value=me_response), patch(
+        "httpx.post", side_effect=[container_response, publish_response]
+    ):
+        provider.publish(access_token="good-token", content="hello world")
+
+    logged = (
+        db_session.query(IntegrationCall)
+        .filter_by(provider="threads", capability="publish")
+        .order_by(IntegrationCall.created_at.desc())
+        .first()
+    )
+    assert logged is not None
+    assert logged.success is True
+
+
+def test_threads_publish_with_media_sets_image_body(db_session) -> None:
+    provider = ThreadsProvider(client_id="cid", client_secret="secret")
+    me_response = _mock_response({"id": "user-1"})
+    container_response = _mock_response({"id": "container-1"})
+    publish_response = _mock_response({"id": "thread-1"})
+
+    with patch("httpx.get", return_value=me_response), patch(
+        "httpx.post", side_effect=[container_response, publish_response]
+    ) as mock_post:
+        result = provider.publish(
+            access_token="good-token",
+            content="hello world",
+            media_urls=["https://cdn.test/image.png"],
+        )
+
+    assert result.success is True
+    first_call_body = mock_post.call_args_list[0].kwargs["json"]
+    assert first_call_body["media_type"] == "IMAGE"
+    assert first_call_body["image_url"] == "https://cdn.test/image.png"
+
+
+# ---------------------------------------------------------------------
+# Threads: expired token -> transparent refresh + retry
+# ---------------------------------------------------------------------
+
+
+def test_threads_publish_refreshes_and_retries_once_on_expired_token(db_session) -> None:
+    provider = ThreadsProvider(client_id="cid", client_secret="secret")
+
+    expired_me_response = _mock_response(status_code=401)
+    refresh_response = _mock_response({"access_token": "new-token", "expires_in": 5184000})
+    retry_me_response = _mock_response({"id": "user-1"})
+    container_response = _mock_response({"id": "container-1"})
+    publish_response = _mock_response({"id": "thread-9"})
+
+    get_calls = [expired_me_response, refresh_response, retry_me_response]
+    post_calls = [container_response, publish_response]
+
+    with patch("httpx.get", side_effect=get_calls) as mock_get, patch(
+        "httpx.post", side_effect=post_calls
+    ) as mock_post:
+        result = provider.publish(
+            access_token="stale-token", content="hello world", refresh_token="prior-token"
+        )
+
+    assert result.success is True
+    assert result.platform_post_id == "thread-9"
+    assert result.refreshed_tokens is not None
+    assert result.refreshed_tokens.access_token == "new-token"
+    assert mock_get.call_count == 3
+    assert mock_post.call_count == 2
+
+
+def test_threads_publish_expired_token_without_refresh_token_fails(db_session) -> None:
+    provider = ThreadsProvider(client_id="cid", client_secret="secret")
+
+    with patch("httpx.get", return_value=_mock_response(status_code=401)):
+        result = provider.publish(access_token="stale-token", content="hello world")
+
+    assert result.success is False
+    assert "refresh" in result.error.lower()
+
+
+def test_threads_publish_refresh_failure_surfaces_as_real_failure(db_session) -> None:
+    provider = ThreadsProvider(client_id="cid", client_secret="secret")
+
+    get_calls = [_mock_response(status_code=401), _mock_response(status_code=400)]
+
+    with patch("httpx.get", side_effect=get_calls):
+        result = provider.publish(
+            access_token="stale-token", content="hello world", refresh_token="bad-token"
+        )
+
+    assert result.success is False
+    assert result.error is not None
+
+
+# ---------------------------------------------------------------------
+# Threads: hard (non-token) failures
+# ---------------------------------------------------------------------
+
+
+def test_threads_publish_hard_http_failure_returns_failed_result(db_session) -> None:
+    provider = ThreadsProvider(client_id="cid", client_secret="secret")
+    me_response = _mock_response({"id": "user-1"})
+
+    with patch("httpx.get", return_value=me_response), patch(
+        "httpx.post", return_value=_mock_response(status_code=500)
+    ):
+        result = provider.publish(access_token="good-token", content="hello world")
+
+    assert result.success is False
+    assert result.error is not None
+
+
+# ---------------------------------------------------------------------
+# Threads: get_engagement()
+# ---------------------------------------------------------------------
+
+
+def test_threads_get_engagement_success_returns_metrics(db_session) -> None:
+    provider = ThreadsProvider(client_id="cid", client_secret="secret")
+
+    with patch(
+        "httpx.get",
+        return_value=_mock_response(
+            {
+                "data": [
+                    {"name": "likes", "values": [{"value": 7}]},
+                    {"name": "replies", "values": [{"value": 1}]},
+                    {"name": "reposts", "values": [{"value": 2}]},
+                    {"name": "views", "values": [{"value": 50}]},
+                ]
+            }
+        ),
+    ):
+        result = provider.get_engagement(access_token="good-token", platform_post_id="thread-1")
+
+    assert result.success is True
+    assert result.metrics.likes == 7
+    assert result.metrics.comments == 1
+    assert result.metrics.shares == 2
+    assert result.metrics.impressions == 50
+
+
+def test_threads_get_engagement_rate_limited_returns_flag_not_raise(db_session) -> None:
+    provider = ThreadsProvider(client_id="cid", client_secret="secret")
+
+    with patch("httpx.get", return_value=_mock_response(status_code=429)):
+        result = provider.get_engagement(access_token="good-token", platform_post_id="thread-1")
+
+    assert result.success is False
+    assert result.rate_limited is True
+    assert result.metrics is None
+
+
+def test_threads_get_engagement_logs_integration_call(db_session) -> None:
+    provider = ThreadsProvider(client_id="cid", client_secret="secret")
+
+    with patch(
+        "httpx.get",
+        return_value=_mock_response({"data": [{"name": "likes", "values": [{"value": 1}]}]}),
+    ):
+        provider.get_engagement(access_token="good-token", platform_post_id="thread-1")
+
+    logged = (
+        db_session.query(IntegrationCall)
+        .filter_by(provider="threads", capability="get_engagement")
+        .order_by(IntegrationCall.created_at.desc())
+        .first()
+    )
+    assert logged is not None
+    assert logged.success is True
+
+
+# ---------------------------------------------------------------------
+# YouTube: OAuth
+# ---------------------------------------------------------------------
+
+
+def test_youtube_authorize_url_includes_offline_access_and_scopes() -> None:
+    provider = YouTubeProvider(client_id="cid", client_secret="secret")
+
+    url = provider.authorize_url(state="state-123", redirect_uri="https://app.test/callback")
+
+    assert url.startswith("https://accounts.google.com/o/oauth2/v2/auth")
+    assert "access_type=offline" in url
+    assert "state=state-123" in url
+    assert "youtube.upload" in url
+
+
+def test_youtube_exchange_code_returns_tokens_and_fetches_channel_id() -> None:
+    provider = YouTubeProvider(client_id="cid", client_secret="secret")
+    token_response = _mock_response(
+        {
+            "access_token": "at-123",
+            "refresh_token": "rt-123",
+            "expires_in": 3600,
+            "scope": "https://www.googleapis.com/auth/youtube.upload",
+        }
+    )
+    channels_response = _mock_response({"items": [{"id": "channel-1"}]})
+
+    with patch("httpx.post", return_value=token_response), patch(
+        "httpx.get", return_value=channels_response
+    ):
+        tokens = provider.exchange_code(code="auth-code", redirect_uri="https://app.test/callback")
+
+    assert tokens.access_token == "at-123"
+    assert tokens.refresh_token == "rt-123"
+    assert tokens.external_account_id == "channel-1"
+    assert tokens.expires_at is not None
+
+
+def test_youtube_is_token_valid_true_on_200() -> None:
+    provider = YouTubeProvider(client_id="cid", client_secret="secret")
+
+    with patch("httpx.get", return_value=_mock_response({"expires_in": 100})):
+        assert provider.is_token_valid("good-token") is True
+
+
+def test_youtube_is_token_valid_false_when_platform_rejects_it() -> None:
+    provider = YouTubeProvider(client_id="cid", client_secret="secret")
+
+    with patch("httpx.get", return_value=_mock_response(status_code=400)):
+        assert provider.is_token_valid("bad-token") is False
+
+
+# ---------------------------------------------------------------------
+# YouTube: publish() / get_engagement()
+# ---------------------------------------------------------------------
+
+
+def test_youtube_publish_without_media_fails_without_any_http_call() -> None:
+    provider = YouTubeProvider(client_id="cid", client_secret="secret")
+
+    with patch("httpx.post") as mock_post, patch("httpx.get") as mock_get:
+        result = provider.publish(access_token="good-token", content="hello")
+
+    assert result.success is False
+    assert "media_urls" in (result.error or "").lower() or "video" in (result.error or "").lower()
+    mock_post.assert_not_called()
+    mock_get.assert_not_called()
+
+
+def test_youtube_publish_success_returns_populated_result(db_session) -> None:
+    provider = YouTubeProvider(client_id="cid", client_secret="secret")
+    session_response = _mock_response(headers={"Location": "https://upload.example/session-1"})
+    put_response = _mock_response({"id": "video-1"})
+
+    with patch("httpx.get", return_value=MagicMock(content=b"fake-video-bytes")), patch(
+        "httpx.post", return_value=session_response
+    ), patch("httpx.put", return_value=put_response):
+        result = provider.publish(
+            access_token="good-token", content="My video", media_urls=["https://cdn.test/video.mp4"]
+        )
+
+    assert result.success is True
+    assert result.platform_post_id == "video-1"
+    assert result.platform_post_url == "https://youtube.com/watch?v=video-1"
+
+
+def test_youtube_publish_success_logs_integration_call(db_session) -> None:
+    provider = YouTubeProvider(client_id="cid", client_secret="secret")
+    session_response = _mock_response(headers={"Location": "https://upload.example/session-1"})
+    put_response = _mock_response({"id": "video-1"})
+
+    with patch("httpx.get", return_value=MagicMock(content=b"fake-video-bytes")), patch(
+        "httpx.post", return_value=session_response
+    ), patch("httpx.put", return_value=put_response):
+        provider.publish(
+            access_token="good-token", content="My video", media_urls=["https://cdn.test/video.mp4"]
+        )
+
+    logged = (
+        db_session.query(IntegrationCall)
+        .filter_by(provider="youtube", capability="publish")
+        .order_by(IntegrationCall.created_at.desc())
+        .first()
+    )
+    assert logged is not None
+    assert logged.success is True
+
+
+def test_youtube_get_engagement_success_returns_metrics(db_session) -> None:
+    provider = YouTubeProvider(client_id="cid", client_secret="secret")
+
+    with patch(
+        "httpx.get",
+        return_value=_mock_response(
+            {"items": [{"statistics": {"likeCount": "5", "commentCount": "2", "viewCount": "100"}}]}
+        ),
+    ):
+        result = provider.get_engagement(access_token="good-token", platform_post_id="video-1")
+
+    assert result.success is True
+    assert result.metrics.likes == 5
+    assert result.metrics.comments == 2
+    assert result.metrics.impressions == 100
+    assert result.metrics.shares == 0
+
+
+def test_youtube_get_engagement_rate_limited_returns_flag_not_raise(db_session) -> None:
+    provider = YouTubeProvider(client_id="cid", client_secret="secret")
+
+    with patch("httpx.get", return_value=_mock_response(status_code=429)):
+        result = provider.get_engagement(access_token="good-token", platform_post_id="video-1")
+
+    assert result.success is False
+    assert result.rate_limited is True
+
+
+# ---------------------------------------------------------------------
+# TikTok: OAuth (PKCE)
+# ---------------------------------------------------------------------
+
+
+def test_tiktok_authorize_url_includes_s256_code_challenge() -> None:
+    provider = TikTokProvider(client_key="key", client_secret="secret")
+
+    url = provider.authorize_url(state="verifier-state", redirect_uri="https://app.test/callback")
+
+    assert url.startswith("https://www.tiktok.com/v2/auth/authorize/")
+    assert "code_challenge_method=S256" in url
+    assert "state=verifier-state" in url
+    # The challenge must be a deterministic function of the verifier, not
+    # the raw verifier itself (unlike XProvider's "plain" shortcut).
+    assert "verifier-state" not in url.split("code_challenge=")[1].split("&")[0]
+
+
+def test_tiktok_exchange_code_requires_code_verifier() -> None:
+    provider = TikTokProvider(client_key="key", client_secret="secret")
+
+    with pytest.raises(ValueError, match="code_verifier"):
+        provider.exchange_code(code="auth-code", redirect_uri="https://app.test/callback")
+
+
+def test_tiktok_exchange_code_returns_tokens() -> None:
+    provider = TikTokProvider(client_key="key", client_secret="secret")
+    token_response = _mock_response(
+        {
+            "access_token": "at-123",
+            "refresh_token": "rt-123",
+            "expires_in": 86400,
+            "open_id": "tiktok-user-1",
+            "scope": "user.info.basic,video.publish",
+        }
+    )
+
+    with patch("httpx.post", return_value=token_response) as mock_post:
+        tokens = provider.exchange_code(
+            code="auth-code", redirect_uri="https://app.test/callback", code_verifier="verifier-state"
+        )
+
+    assert tokens.access_token == "at-123"
+    assert tokens.external_account_id == "tiktok-user-1"
+    assert mock_post.call_args.kwargs["data"]["code_verifier"] == "verifier-state"
+
+
+def test_tiktok_is_token_valid_true_on_200() -> None:
+    provider = TikTokProvider(client_key="key", client_secret="secret")
+
+    with patch("httpx.get", return_value=_mock_response({"data": {}})):
+        assert provider.is_token_valid("good-token") is True
+
+
+def test_tiktok_is_token_valid_false_when_platform_rejects_it() -> None:
+    provider = TikTokProvider(client_key="key", client_secret="secret")
+
+    with patch("httpx.get", return_value=_mock_response(status_code=401)):
+        assert provider.is_token_valid("bad-token") is False
+
+
+# ---------------------------------------------------------------------
+# TikTok: publish() / get_engagement()
+# ---------------------------------------------------------------------
+
+
+def test_tiktok_publish_without_media_fails_without_any_http_call() -> None:
+    provider = TikTokProvider(client_key="key", client_secret="secret")
+
+    with patch("httpx.post") as mock_post:
+        result = provider.publish(access_token="good-token", content="hello")
+
+    assert result.success is False
+    mock_post.assert_not_called()
+
+
+def test_tiktok_publish_success_returns_populated_result(db_session) -> None:
+    provider = TikTokProvider(client_key="key", client_secret="secret")
+
+    with patch("httpx.post", return_value=_mock_response({"data": {"publish_id": "pub-1"}})):
+        result = provider.publish(
+            access_token="good-token", content="caption", media_urls=["https://cdn.test/video.mp4"]
+        )
+
+    assert result.success is True
+    assert result.platform_post_id == "pub-1"
+
+
+def test_tiktok_publish_success_logs_integration_call(db_session) -> None:
+    provider = TikTokProvider(client_key="key", client_secret="secret")
+
+    with patch("httpx.post", return_value=_mock_response({"data": {"publish_id": "pub-1"}})):
+        provider.publish(
+            access_token="good-token", content="caption", media_urls=["https://cdn.test/video.mp4"]
+        )
+
+    logged = (
+        db_session.query(IntegrationCall)
+        .filter_by(provider="tiktok", capability="publish")
+        .order_by(IntegrationCall.created_at.desc())
+        .first()
+    )
+    assert logged is not None
+    assert logged.success is True
+
+
+def test_tiktok_get_engagement_success_returns_metrics(db_session) -> None:
+    provider = TikTokProvider(client_key="key", client_secret="secret")
+
+    with patch(
+        "httpx.post",
+        return_value=_mock_response(
+            {
+                "data": {
+                    "videos": [
+                        {"like_count": 10, "comment_count": 3, "share_count": 4, "view_count": 200}
+                    ]
+                }
+            }
+        ),
+    ):
+        result = provider.get_engagement(access_token="good-token", platform_post_id="pub-1")
+
+    assert result.success is True
+    assert result.metrics.likes == 10
+    assert result.metrics.shares == 4
+    assert result.metrics.impressions == 200
+
+
+def test_tiktok_get_engagement_rate_limited_returns_flag_not_raise(db_session) -> None:
+    provider = TikTokProvider(client_key="key", client_secret="secret")
+
+    with patch("httpx.post", return_value=_mock_response(status_code=429)):
+        result = provider.get_engagement(access_token="good-token", platform_post_id="pub-1")
+
+    assert result.success is False
+    assert result.rate_limited is True
+
+
+# ---------------------------------------------------------------------
+# Pinterest: OAuth
+# ---------------------------------------------------------------------
+
+
+def test_pinterest_authorize_url_includes_state_and_scopes() -> None:
+    provider = PinterestProvider(client_id="cid", client_secret="secret")
+
+    url = provider.authorize_url(state="state-123", redirect_uri="https://app.test/callback")
+
+    assert url.startswith("https://www.pinterest.com/oauth/")
+    assert "state=state-123" in url
+    assert "pins%3Awrite" in url or "pins:write" in url
+
+
+def test_pinterest_exchange_code_returns_tokens_and_fetches_username() -> None:
+    provider = PinterestProvider(client_id="cid", client_secret="secret")
+    token_response = _mock_response(
+        {"access_token": "at-123", "refresh_token": "rt-123", "expires_in": 2592000, "scope": "pins:write"}
+    )
+    account_response = _mock_response({"username": "acme"})
+
+    with patch("httpx.post", return_value=token_response), patch(
+        "httpx.get", return_value=account_response
+    ):
+        tokens = provider.exchange_code(code="auth-code", redirect_uri="https://app.test/callback")
+
+    assert tokens.access_token == "at-123"
+    assert tokens.external_account_id == "acme"
+
+
+def test_pinterest_is_token_valid_true_on_200() -> None:
+    provider = PinterestProvider(client_id="cid", client_secret="secret")
+
+    with patch("httpx.get", return_value=_mock_response({"username": "acme"})):
+        assert provider.is_token_valid("good-token") is True
+
+
+def test_pinterest_is_token_valid_false_when_platform_rejects_it() -> None:
+    provider = PinterestProvider(client_id="cid", client_secret="secret")
+
+    with patch("httpx.get", return_value=_mock_response(status_code=401)):
+        assert provider.is_token_valid("bad-token") is False
+
+
+# ---------------------------------------------------------------------
+# Pinterest: publish() / get_engagement()
+# ---------------------------------------------------------------------
+
+
+def test_pinterest_publish_without_media_fails_without_any_http_call() -> None:
+    provider = PinterestProvider(client_id="cid", client_secret="secret")
+
+    with patch("httpx.post") as mock_post, patch("httpx.get") as mock_get:
+        result = provider.publish(access_token="good-token", content="hello")
+
+    assert result.success is False
+    mock_post.assert_not_called()
+    mock_get.assert_not_called()
+
+
+def test_pinterest_publish_success_returns_populated_result(db_session) -> None:
+    provider = PinterestProvider(client_id="cid", client_secret="secret")
+
+    with patch("httpx.get", return_value=_mock_response({"items": [{"id": "board-1"}]})), patch(
+        "httpx.post", return_value=_mock_response({"id": "pin-1"})
+    ):
+        result = provider.publish(
+            access_token="good-token", content="caption", media_urls=["https://cdn.test/image.png"]
+        )
+
+    assert result.success is True
+    assert result.platform_post_id == "pin-1"
+    assert result.platform_post_url == "https://pinterest.com/pin/pin-1"
+
+
+def test_pinterest_publish_success_logs_integration_call(db_session) -> None:
+    provider = PinterestProvider(client_id="cid", client_secret="secret")
+
+    with patch("httpx.get", return_value=_mock_response({"items": [{"id": "board-1"}]})), patch(
+        "httpx.post", return_value=_mock_response({"id": "pin-1"})
+    ):
+        provider.publish(
+            access_token="good-token", content="caption", media_urls=["https://cdn.test/image.png"]
+        )
+
+    logged = (
+        db_session.query(IntegrationCall)
+        .filter_by(provider="pinterest", capability="publish")
+        .order_by(IntegrationCall.created_at.desc())
+        .first()
+    )
+    assert logged is not None
+    assert logged.success is True
+
+
+def test_pinterest_get_engagement_success_returns_metrics(db_session) -> None:
+    provider = PinterestProvider(client_id="cid", client_secret="secret")
+
+    with patch(
+        "httpx.get",
+        return_value=_mock_response(
+            {"all": {"summary_metrics": {"IMPRESSION": 100, "SAVE": 8, "OUTBOUND_CLICK": 3}}}
+        ),
+    ):
+        result = provider.get_engagement(access_token="good-token", platform_post_id="pin-1")
+
+    assert result.success is True
+    assert result.metrics.likes == 8
+    assert result.metrics.shares == 3
+    assert result.metrics.impressions == 100
+
+
+def test_pinterest_get_engagement_rate_limited_returns_flag_not_raise(db_session) -> None:
+    provider = PinterestProvider(client_id="cid", client_secret="secret")
+
+    with patch("httpx.get", return_value=_mock_response(status_code=429)):
+        result = provider.get_engagement(access_token="good-token", platform_post_id="pin-1")
+
+    assert result.success is False
+    assert result.rate_limited is True

--- a/apps/api/tests/test_social_accounts.py
+++ b/apps/api/tests/test_social_accounts.py
@@ -98,7 +98,7 @@ def test_callback_stores_tokens_encrypted_not_plaintext(db_session) -> None:
     from apps.api.routers.social_accounts import _create_state
 
     brand, _user = _setup_brand(db_session)
-    state = _create_state(brand.id)
+    state = _create_state(brand.id, "linkedin")
 
     fake_tokens = SocialTokens(
         access_token="super-secret-access-token",
@@ -149,9 +149,9 @@ def test_callback_reconnect_upserts_same_row(db_session) -> None:
 
     with patch("apps.api.routers.social_accounts.get_social_oauth_provider") as mock_provider:
         mock_provider.return_value.exchange_code.return_value = tokens_v1
-        client.get("/oauth/linkedin/callback", params={"code": "c1", "state": _create_state(brand.id)})
+        client.get("/oauth/linkedin/callback", params={"code": "c1", "state": _create_state(brand.id, "linkedin")})
         mock_provider.return_value.exchange_code.return_value = tokens_v2
-        client.get("/oauth/linkedin/callback", params={"code": "c2", "state": _create_state(brand.id)})
+        client.get("/oauth/linkedin/callback", params={"code": "c2", "state": _create_state(brand.id, "linkedin")})
 
     accounts = db_session.query(SocialAccount).filter(SocialAccount.brand_id == brand.id).all()
     assert len(accounts) == 1
@@ -241,3 +241,152 @@ def test_cross_org_social_account_access_returns_404(db_session) -> None:
     )
 
     assert response.status_code == 404
+
+
+@uses_test_session
+def test_connect_instagram_returns_authorize_url_with_signed_state(db_session, monkeypatch) -> None:
+    from apps.api.config import get_settings
+
+    monkeypatch.setenv("INSTAGRAM_REDIRECT_URI", "http://localhost:8000/oauth/instagram/callback")
+    get_settings.cache_clear()
+    brand, user = _setup_brand(db_session)
+
+    response = client.post(
+        f"/brands/{brand.id}/social-accounts/instagram/connect", headers=_auth_headers(user)
+    )
+    get_settings.cache_clear()
+
+    assert response.status_code == 200
+    assert "state=" in response.json()["authorize_url"]
+
+
+@uses_test_session
+def test_connect_503_when_youtube_not_configured(db_session, monkeypatch) -> None:
+    from apps.api.config import get_settings
+
+    monkeypatch.setenv("YOUTUBE_REDIRECT_URI", "")
+    get_settings.cache_clear()
+    brand, user = _setup_brand(db_session)
+
+    response = client.post(
+        f"/brands/{brand.id}/social-accounts/youtube/connect", headers=_auth_headers(user)
+    )
+    get_settings.cache_clear()
+
+    assert response.status_code == 503
+
+
+@uses_test_session
+def test_tiktok_callback_passes_state_as_pkce_code_verifier(db_session, monkeypatch) -> None:
+    from apps.api.config import get_settings
+    from apps.api.routers.social_accounts import _create_state
+
+    monkeypatch.setenv("TIKTOK_REDIRECT_URI", "http://localhost:8000/oauth/tiktok/callback")
+    get_settings.cache_clear()
+
+    brand, _user = _setup_brand(db_session)
+    state = _create_state(brand.id, "tiktok")
+    fake_tokens = SocialTokens(
+        access_token="token", refresh_token=None, expires_at=None,
+        scopes=["video.publish"], external_account_id="tiktok-user-1",
+    )
+
+    with patch("apps.api.routers.social_accounts.get_social_oauth_provider") as mock_provider:
+        mock_provider.return_value.exchange_code.return_value = fake_tokens
+        response = client.get("/oauth/tiktok/callback", params={"code": "auth-code", "state": state})
+        get_settings.cache_clear()
+
+        mock_provider.return_value.exchange_code.assert_called_once_with(
+            code="auth-code",
+            redirect_uri="http://localhost:8000/oauth/tiktok/callback",
+            code_verifier=state,
+        )
+
+    assert response.status_code == 200
+    account = (
+        db_session.query(SocialAccount)
+        .filter(SocialAccount.brand_id == brand.id, SocialAccount.platform == SocialPlatform.TIKTOK)
+        .one()
+    )
+    assert account.external_account_id == "tiktok-user-1"
+
+
+@uses_test_session
+def test_non_pkce_callback_does_not_pass_code_verifier(db_session, monkeypatch) -> None:
+    from apps.api.config import get_settings
+    from apps.api.routers.social_accounts import _create_state
+
+    monkeypatch.setenv("FACEBOOK_REDIRECT_URI", "http://localhost:8000/oauth/facebook/callback")
+    get_settings.cache_clear()
+
+    brand, _user = _setup_brand(db_session)
+    state = _create_state(brand.id, "facebook")
+    fake_tokens = SocialTokens(
+        access_token="token", refresh_token=None, expires_at=None,
+        scopes=["pages_manage_posts"], external_account_id="page-1",
+    )
+
+    with patch("apps.api.routers.social_accounts.get_social_oauth_provider") as mock_provider:
+        mock_provider.return_value.exchange_code.return_value = fake_tokens
+        client.get("/oauth/facebook/callback", params={"code": "auth-code", "state": state})
+        get_settings.cache_clear()
+
+        mock_provider.return_value.exchange_code.assert_called_once_with(
+            code="auth-code",
+            redirect_uri="http://localhost:8000/oauth/facebook/callback",
+            code_verifier=None,
+        )
+
+
+@uses_test_session
+def test_state_from_one_platform_rejected_by_another_platforms_callback(db_session, monkeypatch) -> None:
+    from apps.api.config import get_settings
+    from apps.api.routers.social_accounts import _create_state
+
+    monkeypatch.setenv("INSTAGRAM_REDIRECT_URI", "http://localhost:8000/oauth/instagram/callback")
+    get_settings.cache_clear()
+
+    brand, _user = _setup_brand(db_session)
+    linkedin_state = _create_state(brand.id, "linkedin")
+
+    response = client.get(
+        "/oauth/instagram/callback", params={"code": "auth-code", "state": linkedin_state}
+    )
+    get_settings.cache_clear()
+
+    assert response.status_code == 400
+
+
+@uses_test_session
+def test_reconnecting_different_platforms_creates_separate_rows(db_session, monkeypatch) -> None:
+    from apps.api.config import get_settings
+    from apps.api.routers.social_accounts import _create_state
+
+    monkeypatch.setenv("PINTEREST_REDIRECT_URI", "http://localhost:8000/oauth/pinterest/callback")
+    get_settings.cache_clear()
+
+    brand, _user = _setup_brand(db_session)
+    linkedin_tokens = SocialTokens(
+        access_token="li-token", refresh_token=None, expires_at=None,
+        scopes=["openid"], external_account_id="member-1",
+    )
+    pinterest_tokens = SocialTokens(
+        access_token="pin-token", refresh_token=None, expires_at=None,
+        scopes=["pins:write"], external_account_id="acme",
+    )
+
+    with patch("apps.api.routers.social_accounts.get_social_oauth_provider") as mock_provider:
+        mock_provider.return_value.exchange_code.return_value = linkedin_tokens
+        client.get(
+            "/oauth/linkedin/callback",
+            params={"code": "c1", "state": _create_state(brand.id, "linkedin")},
+        )
+        mock_provider.return_value.exchange_code.return_value = pinterest_tokens
+        client.get(
+            "/oauth/pinterest/callback",
+            params={"code": "c2", "state": _create_state(brand.id, "pinterest")},
+        )
+        get_settings.cache_clear()
+
+    accounts = db_session.query(SocialAccount).filter(SocialAccount.brand_id == brand.id).all()
+    assert {account.platform for account in accounts} == {SocialPlatform.LINKEDIN, SocialPlatform.PINTEREST}

--- a/apps/web/__tests__/social-accounts-page.test.tsx
+++ b/apps/web/__tests__/social-accounts-page.test.tsx
@@ -11,6 +11,12 @@ import type { SocialAccount } from "@/lib/api";
 const fetchBrandsMock = vi.fn();
 const fetchSocialAccountsMock = vi.fn();
 const connectLinkedInMock = vi.fn();
+const connectInstagramMock = vi.fn();
+const connectThreadsMock = vi.fn();
+const connectFacebookMock = vi.fn();
+const connectYouTubeMock = vi.fn();
+const connectTikTokMock = vi.fn();
+const connectPinterestMock = vi.fn();
 const disconnectSocialAccountMock = vi.fn();
 
 vi.mock("@/lib/api", async () => {
@@ -20,6 +26,12 @@ vi.mock("@/lib/api", async () => {
     fetchBrands: (...args: unknown[]) => fetchBrandsMock(...args),
     fetchSocialAccounts: (...args: unknown[]) => fetchSocialAccountsMock(...args),
     connectLinkedIn: (...args: unknown[]) => connectLinkedInMock(...args),
+    connectInstagram: (...args: unknown[]) => connectInstagramMock(...args),
+    connectThreads: (...args: unknown[]) => connectThreadsMock(...args),
+    connectFacebook: (...args: unknown[]) => connectFacebookMock(...args),
+    connectYouTube: (...args: unknown[]) => connectYouTubeMock(...args),
+    connectTikTok: (...args: unknown[]) => connectTikTokMock(...args),
+    connectPinterest: (...args: unknown[]) => connectPinterestMock(...args),
     disconnectSocialAccount: (...args: unknown[]) => disconnectSocialAccountMock(...args),
   };
 });
@@ -78,6 +90,12 @@ describe("SocialAccountsPage", () => {
     fetchBrandsMock.mockReset();
     fetchSocialAccountsMock.mockReset();
     connectLinkedInMock.mockReset();
+    connectInstagramMock.mockReset();
+    connectThreadsMock.mockReset();
+    connectFacebookMock.mockReset();
+    connectYouTubeMock.mockReset();
+    connectTikTokMock.mockReset();
+    connectPinterestMock.mockReset();
     disconnectSocialAccountMock.mockReset();
     redirectToAuthorizeUrlMock.mockReset();
 
@@ -109,7 +127,44 @@ describe("SocialAccountsPage", () => {
   it("shows an empty state when nothing is connected for the brand", async () => {
     renderPage();
 
+    // Wait for the actual fetch chain (AuthProvider -> BrandProvider ->
+    // this page's own fetchSocialAccounts) to settle before asserting —
+    // see the identical fix in onboarding-page.test.tsx for why a bare
+    // findByText can occasionally race a still-loading intermediate render.
+    await waitFor(() => expect(fetchSocialAccountsMock).toHaveBeenCalled());
     expect(await screen.findByText("No accounts connected")).toBeInTheDocument();
+  });
+
+  it("starts the YouTube OAuth flow and redirects to the authorize URL on success", async () => {
+    connectYouTubeMock.mockResolvedValue({
+      authorize_url: "https://accounts.google.com/o/oauth2/v2/auth?foo=bar",
+    });
+    const user = userEvent.setup();
+
+    renderPage();
+    await waitFor(() => expect(fetchSocialAccountsMock).toHaveBeenCalled());
+
+    await user.click(screen.getByRole("button", { name: "Connect YouTube" }));
+
+    await waitFor(() => {
+      expect(connectYouTubeMock).toHaveBeenCalledWith("test-token", "brand-1");
+      expect(redirectToAuthorizeUrlMock).toHaveBeenCalledWith(
+        "https://accounts.google.com/o/oauth2/v2/auth?foo=bar"
+      );
+    });
+  });
+
+  it("shows a friendly message instead of a generic error when TikTok isn't configured", async () => {
+    connectTikTokMock.mockRejectedValue(new ApiError("Tiktok OAuth is not configured", 503));
+    const user = userEvent.setup();
+
+    renderPage();
+    await waitFor(() => expect(fetchSocialAccountsMock).toHaveBeenCalled());
+
+    await user.click(screen.getByRole("button", { name: "Connect TikTok" }));
+
+    expect(await screen.findByText("TikTok isn't configured on this server yet.")).toBeInTheDocument();
+    expect(redirectToAuthorizeUrlMock).not.toHaveBeenCalled();
   });
 
   it("starts the LinkedIn OAuth flow and redirects to the authorize URL on success", async () => {

--- a/apps/web/app/social-accounts/page.tsx
+++ b/apps/web/app/social-accounts/page.tsx
@@ -3,7 +3,13 @@
 import { useCallback, useEffect, useState } from "react";
 import {
   ApiError,
+  connectFacebook,
+  connectInstagram,
   connectLinkedIn,
+  connectPinterest,
+  connectThreads,
+  connectTikTok,
+  connectYouTube,
   disconnectSocialAccount,
   fetchSocialAccounts,
   type AuthorizeUrlResponse,
@@ -28,22 +34,44 @@ import { redirectToAuthorizeUrl } from "./redirect";
 // platform still renders instead of breaking.
 const PLATFORM_LABELS: Partial<Record<SocialPlatform, string>> = {
   linkedin: "LinkedIn",
+  instagram: "Instagram",
+  threads: "Threads",
+  facebook: "Facebook",
+  youtube: "YouTube",
+  tiktok: "TikTok",
+  pinterest: "Pinterest",
 };
 
 function platformLabel(platform: SocialPlatform): string {
   return PLATFORM_LABELS[platform] ?? platform;
 }
 
-// Platforms the UI can start a connect flow for. LinkedIn is genuinely the
-// only connectable platform today, but this is a list plus a lookup table
-// (not a single hardcoded button/handler) so a second provider is a data
-// change here rather than a rewrite of this page.
-const CONNECTABLE_PLATFORMS: SocialPlatform[] = ["linkedin"];
+// Platforms the UI can start a connect flow for — a list plus a lookup
+// table (not a hardcoded button/handler per platform) so adding another
+// provider is a data change here rather than a rewrite of this page.
+// Every platform below (Issue #138) is independently connectable; whether
+// it actually works depends on the corresponding *_REDIRECT_URI env var
+// being configured server-side (unconfigured ones 503, handled below).
+const CONNECTABLE_PLATFORMS: SocialPlatform[] = [
+  "linkedin",
+  "instagram",
+  "threads",
+  "facebook",
+  "youtube",
+  "tiktok",
+  "pinterest",
+];
 
 const CONNECT_HANDLERS: Partial<
   Record<SocialPlatform, (token: string, brandId: string) => Promise<AuthorizeUrlResponse>>
 > = {
   linkedin: connectLinkedIn,
+  instagram: connectInstagram,
+  threads: connectThreads,
+  facebook: connectFacebook,
+  youtube: connectYouTube,
+  tiktok: connectTikTok,
+  pinterest: connectPinterest,
 };
 
 const STATUS_TONE: Record<SocialAccountStatus, BadgeTone> = {

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -358,10 +358,15 @@ export async function rescheduleReviewPost(
 
 // --- Social accounts (Issue #91) ---
 
-// Mirrors apps/api/models/social_account.py::SocialPlatform. "linkedin" is
-// the only value today, but this is kept as a string union (not a literal)
-// so the UI layer can stay written generically as more providers land.
-export type SocialPlatform = "linkedin";
+// Mirrors apps/api/models/social_account.py::SocialPlatform.
+export type SocialPlatform =
+  | "linkedin"
+  | "instagram"
+  | "threads"
+  | "facebook"
+  | "youtube"
+  | "tiktok"
+  | "pinterest";
 
 // Mirrors apps/api/models/social_account.py::SocialAccountStatus.
 export type SocialAccountStatus = "active" | "expired" | "revoked";
@@ -410,7 +415,19 @@ export async function fetchSocialAccounts(token: string, brandId: string): Promi
 // separates "give me a URL" (POST .../linkedin/connect) from the redirect
 // the browser does with it.
 export async function connectLinkedIn(token: string, brandId: string): Promise<AuthorizeUrlResponse> {
-  const res = await fetch(socialAccountsUrl(brandId, "/linkedin/connect"), {
+  return connectPlatform(token, brandId, "linkedin");
+}
+
+// Same "give me a URL, don't navigate yourself" shape as connectLinkedIn
+// above, generalized by platform (Issue #138) since every platform's
+// /connect endpoint (apps/api/routers/social_accounts.py) is wired
+// identically — one function instead of one per platform.
+export async function connectPlatform(
+  token: string,
+  brandId: string,
+  platform: SocialPlatform
+): Promise<AuthorizeUrlResponse> {
+  const res = await fetch(socialAccountsUrl(brandId, `/${platform}/connect`), {
     method: "POST",
     headers: authHeaders(token),
   });
@@ -420,6 +437,30 @@ export async function connectLinkedIn(token: string, brandId: string): Promise<A
   }
 
   return res.json();
+}
+
+export async function connectInstagram(token: string, brandId: string): Promise<AuthorizeUrlResponse> {
+  return connectPlatform(token, brandId, "instagram");
+}
+
+export async function connectThreads(token: string, brandId: string): Promise<AuthorizeUrlResponse> {
+  return connectPlatform(token, brandId, "threads");
+}
+
+export async function connectFacebook(token: string, brandId: string): Promise<AuthorizeUrlResponse> {
+  return connectPlatform(token, brandId, "facebook");
+}
+
+export async function connectYouTube(token: string, brandId: string): Promise<AuthorizeUrlResponse> {
+  return connectPlatform(token, brandId, "youtube");
+}
+
+export async function connectTikTok(token: string, brandId: string): Promise<AuthorizeUrlResponse> {
+  return connectPlatform(token, brandId, "tiktok");
+}
+
+export async function connectPinterest(token: string, brandId: string): Promise<AuthorizeUrlResponse> {
+  return connectPlatform(token, brandId, "pinterest");
 }
 
 export async function disconnectSocialAccount(

--- a/migrations/versions/b7c9e2a4f1d3_social_platform_new_values.py
+++ b/migrations/versions/b7c9e2a4f1d3_social_platform_new_values.py
@@ -1,0 +1,47 @@
+"""social_platform new values (instagram, threads, facebook, youtube, tiktok, pinterest)
+
+Revision ID: b7c9e2a4f1d3
+Revises: 5b29b584c4fa
+Create Date: 2026-09-06 00:00:00.000000
+
+Issue #138 adds Instagram, Threads, Facebook, YouTube, TikTok, and
+Pinterest connections alongside LinkedIn — apps/api/models/
+social_account.py::SocialPlatform needs a matching row for each so a
+SocialAccount can actually be stored for the new platforms (same reason
+ad4c424c0dc8's social_accounts migration only defined 'LINKEDIN' for the
+one platform that existed at the time). Deliberately does not add 'X' —
+that's issue #120/PR #121's own migration, kept separate to avoid two
+open PRs racing to define the same enum value.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = 'b7c9e2a4f1d3'
+down_revision: Union[str, None] = '5b29b584c4fa'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+_NEW_VALUES = ('INSTAGRAM', 'THREADS', 'FACEBOOK', 'YOUTUBE', 'TIKTOK', 'PINTEREST')
+
+
+def upgrade() -> None:
+    for value in _NEW_VALUES:
+        op.execute(f"ALTER TYPE social_platform ADD VALUE IF NOT EXISTS '{value}'")
+
+
+def downgrade() -> None:
+    # Postgres has no ALTER TYPE ... DROP VALUE, so removing these means
+    # rebuilding the enum from scratch — same lossy-on-downgrade tradeoff
+    # 75d69ba778a0's agent_type downgrade and c41e72b7ec17's pipeline_stage
+    # downgrade already accept, and fails as expected if any social_accounts
+    # row already uses one of these values.
+    op.execute("ALTER TYPE social_platform RENAME TO social_platform_old")
+    op.execute("CREATE TYPE social_platform AS ENUM ('LINKEDIN')")
+    op.execute(
+        "ALTER TABLE social_accounts "
+        "ALTER COLUMN platform TYPE social_platform "
+        "USING platform::text::social_platform"
+    )
+    op.execute("DROP TYPE social_platform_old")

--- a/packages/integrations/registry.py
+++ b/packages/integrations/registry.py
@@ -9,8 +9,14 @@ from packages.integrations.llm.openrouter_provider import OpenRouterProvider
 from packages.integrations.search.base import SearchProvider
 from packages.integrations.search.tavily import TavilyProvider
 from packages.integrations.social.base import SocialOAuthProvider, SocialPublisher
+from packages.integrations.social.facebook_provider import FacebookProvider
+from packages.integrations.social.instagram_provider import InstagramProvider
 from packages.integrations.social.linkedin_provider import LinkedInProvider
+from packages.integrations.social.pinterest_provider import PinterestProvider
+from packages.integrations.social.threads_provider import ThreadsProvider
+from packages.integrations.social.tiktok_provider import TikTokProvider
 from packages.integrations.social.x_provider import XProvider
+from packages.integrations.social.youtube_provider import YouTubeProvider
 from packages.integrations.storage.base import StorageProvider
 from packages.integrations.storage.supabase_provider import SupabaseStorageProvider
 from packages.integrations.video_gen.base import VideoProvider
@@ -31,6 +37,45 @@ _EMBEDDING_PROVIDERS = {
     "openai": lambda settings: OpenAIEmbeddingProvider(api_key=settings.openai_api_key or ""),
 }
 
+def _facebook(settings):
+    return FacebookProvider(
+        client_id=settings.meta_app_id or "", client_secret=settings.meta_app_secret or ""
+    )
+
+
+def _instagram(settings):
+    return InstagramProvider(
+        client_id=settings.meta_app_id or "", client_secret=settings.meta_app_secret or ""
+    )
+
+
+def _threads(settings):
+    return ThreadsProvider(
+        client_id=settings.meta_app_id or "", client_secret=settings.meta_app_secret or ""
+    )
+
+
+def _youtube(settings):
+    return YouTubeProvider(
+        client_id=settings.youtube_client_id or "",
+        client_secret=settings.youtube_client_secret or "",
+    )
+
+
+def _tiktok(settings):
+    return TikTokProvider(
+        client_key=settings.tiktok_client_key or "",
+        client_secret=settings.tiktok_client_secret or "",
+    )
+
+
+def _pinterest(settings):
+    return PinterestProvider(
+        client_id=settings.pinterest_app_id or "",
+        client_secret=settings.pinterest_app_secret or "",
+    )
+
+
 _SOCIAL_OAUTH_PROVIDERS = {
     "linkedin": lambda settings: LinkedInProvider(
         client_id=settings.linkedin_client_id or "",
@@ -40,6 +85,12 @@ _SOCIAL_OAUTH_PROVIDERS = {
         client_id=settings.x_client_id or "",
         client_secret=settings.x_client_secret or "",
     ),
+    "facebook": _facebook,
+    "instagram": _instagram,
+    "threads": _threads,
+    "youtube": _youtube,
+    "tiktok": _tiktok,
+    "pinterest": _pinterest,
 }
 
 # Every publisher is currently the same adapter instance that also
@@ -56,6 +107,12 @@ _SOCIAL_PUBLISHERS = {
         client_id=settings.x_client_id or "",
         client_secret=settings.x_client_secret or "",
     ),
+    "facebook": _facebook,
+    "instagram": _instagram,
+    "threads": _threads,
+    "youtube": _youtube,
+    "tiktok": _tiktok,
+    "pinterest": _pinterest,
 }
 
 _STORAGE_PROVIDERS = {

--- a/packages/integrations/social/base.py
+++ b/packages/integrations/social/base.py
@@ -22,7 +22,14 @@ class SocialOAuthProvider(ABC):
         ...
 
     @abstractmethod
-    def exchange_code(self, code: str, redirect_uri: str) -> SocialTokens:
+    def exchange_code(
+        self, code: str, redirect_uri: str, code_verifier: str | None = None
+    ) -> SocialTokens:
+        """`code_verifier` only matters for a platform whose OAuth2 flow
+        requires PKCE (e.g. TikTokProvider) — every other adapter ignores
+        it. Optional with a None default so callers that don't need it
+        (LinkedIn, Instagram, Threads, Facebook, X) aren't forced to pass
+        anything."""
         ...
 
     @abstractmethod

--- a/packages/integrations/social/facebook_provider.py
+++ b/packages/integrations/social/facebook_provider.py
@@ -1,0 +1,263 @@
+from datetime import datetime, timedelta, timezone
+from urllib.parse import urlencode
+
+import httpx
+
+from packages.integrations.observability import track_integration_call
+from packages.integrations.social.base import (
+    EngagementMetrics,
+    EngagementResult,
+    PublishResult,
+    SocialOAuthProvider,
+    SocialPublisher,
+    SocialTokens,
+)
+
+
+class _TokenExpiredError(Exception):
+    """Internal signal that Facebook rejected access_token as
+    expired/invalid — distinct from other HTTP failures because it's the
+    one case publish() retries after a refresh, rather than surfacing
+    immediately."""
+
+
+class FacebookProvider(SocialOAuthProvider, SocialPublisher):
+    """The only file in this codebase allowed to call Facebook Graph API's
+    OAuth and Page-publishing endpoints directly.
+
+    Publishes to a Facebook Page, not a personal profile — the Graph API
+    has no endpoint for posting to a personal profile at all. `access_token`
+    throughout this adapter is therefore expected to be a Page access token
+    (not the user access token OAuth first hands back): `_fetch_page_id`
+    resolves which Page it belongs to by calling `/me` — called with a Page
+    token, `/me` identifies the Page itself, the same "ask the token who it
+    belongs to" trick LinkedInProvider._fetch_member_id uses.
+
+    Meta has no `refresh_token` concept like LinkedIn/X's OAuth2 refresh
+    grant — a long-lived token is "refreshed" by re-exchanging *itself*
+    (grant_type=fb_exchange_token) while still valid, not via a separate
+    refresh credential, and that re-exchange stops working the moment the
+    token is actually expired/revoked. `_refresh_access_token` models that:
+    it treats whatever is passed as `refresh_token` as the prior long-lived
+    access token to re-exchange, and the resulting SocialTokens.refresh_token
+    is the new access_token itself (so a caller can chain another refresh
+    later, same shape LinkedIn/X give their refresh_token).
+    """
+
+    GRAPH_VERSION = "v21.0"
+    AUTHORIZE_URL = f"https://www.facebook.com/{GRAPH_VERSION}/dialog/oauth"
+    TOKEN_URL = f"https://graph.facebook.com/{GRAPH_VERSION}/oauth/access_token"
+    ME_URL = f"https://graph.facebook.com/{GRAPH_VERSION}/me"
+
+    SCOPES = ("pages_show_list", "pages_read_engagement", "pages_manage_posts")
+
+    def __init__(self, client_id: str, client_secret: str, timeout: float = 15.0) -> None:
+        self.client_id = client_id
+        self.client_secret = client_secret
+        self.timeout = timeout
+
+    # -- SocialOAuthProvider -----------------------------------------------
+
+    def authorize_url(self, state: str, redirect_uri: str) -> str:
+        params = {
+            "response_type": "code",
+            "client_id": self.client_id,
+            "redirect_uri": redirect_uri,
+            "state": state,
+            "scope": ",".join(self.SCOPES),
+        }
+        return f"{self.AUTHORIZE_URL}?{urlencode(params)}"
+
+    def exchange_code(self, code: str, redirect_uri: str) -> SocialTokens:
+        with track_integration_call("facebook", "oauth_exchange"):
+            response = httpx.post(
+                self.TOKEN_URL,
+                data={
+                    "grant_type": "authorization_code",
+                    "code": code,
+                    "redirect_uri": redirect_uri,
+                    "client_id": self.client_id,
+                    "client_secret": self.client_secret,
+                },
+                timeout=self.timeout,
+            )
+            response.raise_for_status()
+            data = response.json()
+
+        expires_in = data.get("expires_in")
+        expires_at = (
+            datetime.now(timezone.utc) + timedelta(seconds=expires_in)
+            if expires_in is not None
+            else None
+        )
+        external_account_id = self._fetch_page_id(data["access_token"])
+
+        return SocialTokens(
+            access_token=data["access_token"],
+            # No standalone refresh_token — see class docstring.
+            refresh_token=None,
+            expires_at=expires_at,
+            scopes=list(self.SCOPES),
+            external_account_id=external_account_id,
+        )
+
+    def is_token_valid(self, access_token: str) -> bool:
+        with track_integration_call("facebook", "oauth_status_check"):
+            response = httpx.get(
+                self.ME_URL,
+                headers={"Authorization": f"Bearer {access_token}"},
+                timeout=self.timeout,
+            )
+        return response.status_code == 200
+
+    def _fetch_page_id(self, access_token: str) -> str | None:
+        with track_integration_call("facebook", "oauth_userinfo"):
+            response = httpx.get(
+                self.ME_URL,
+                headers={"Authorization": f"Bearer {access_token}"},
+                timeout=self.timeout,
+            )
+            response.raise_for_status()
+            return response.json().get("id")
+
+    # -- SocialPublisher -----------------------------------------------
+
+    def publish(
+        self,
+        access_token: str,
+        content: str,
+        media_urls: list[str] | None = None,
+        refresh_token: str | None = None,
+    ) -> PublishResult:
+        try:
+            return self._attempt_publish(access_token, content, media_urls)
+        except _TokenExpiredError:
+            if not refresh_token:
+                return PublishResult(
+                    success=False,
+                    error="Facebook access token expired/invalid and no refresh token is stored",
+                )
+            try:
+                new_tokens = self._refresh_access_token(refresh_token)
+            except Exception as exc:  # noqa: BLE001 - surfaced as PublishResult, not raised
+                return PublishResult(success=False, error=f"Facebook token refresh failed: {exc}")
+
+            try:
+                result = self._attempt_publish(new_tokens.access_token, content, media_urls)
+            except Exception as exc:  # noqa: BLE001
+                return PublishResult(
+                    success=False,
+                    error=f"Facebook publish failed after token refresh: {exc}",
+                )
+            result.refreshed_tokens = new_tokens
+            return result
+        except Exception as exc:  # noqa: BLE001 - vendor/network errors become failures, not raises
+            return PublishResult(success=False, error=str(exc))
+
+    def _attempt_publish(
+        self, access_token: str, content: str, media_urls: list[str] | None
+    ) -> PublishResult:
+        with track_integration_call("facebook", "publish"):
+            page_response = httpx.get(
+                self.ME_URL,
+                headers={"Authorization": f"Bearer {access_token}"},
+                timeout=self.timeout,
+            )
+            if page_response.status_code == 401:
+                raise _TokenExpiredError("Facebook rejected the access token")
+            page_response.raise_for_status()
+            page_id = page_response.json()["id"]
+
+            body: dict[str, object] = {"message": content}
+            if media_urls:
+                # A single link attachment — a multi-photo post needs the
+                # separate /{page-id}/photos endpoint (attach_to_object_id
+                # workflow), which no caller in this codebase produces yet.
+                body["link"] = media_urls[0]
+
+            response = httpx.post(
+                f"https://graph.facebook.com/{self.GRAPH_VERSION}/{page_id}/feed",
+                headers={"Authorization": f"Bearer {access_token}"},
+                json=body,
+                timeout=self.timeout,
+            )
+            if response.status_code == 401:
+                raise _TokenExpiredError("Facebook rejected the access token")
+            response.raise_for_status()
+            post_id = response.json().get("id")
+
+        return PublishResult(
+            success=True,
+            platform_post_id=post_id,
+            platform_post_url=f"https://www.facebook.com/{post_id}" if post_id else None,
+        )
+
+    # -- SocialPublisher: engagement -------------------------------------
+
+    def get_engagement(self, access_token: str, platform_post_id: str) -> EngagementResult:
+        try:
+            with track_integration_call("facebook", "get_engagement"):
+                response = httpx.get(
+                    f"https://graph.facebook.com/{self.GRAPH_VERSION}/{platform_post_id}",
+                    headers={"Authorization": f"Bearer {access_token}"},
+                    params={"fields": "likes.summary(true),comments.summary(true),shares"},
+                    timeout=self.timeout,
+                )
+                if response.status_code == 429:
+                    return EngagementResult(
+                        success=False,
+                        error="Facebook rate-limited this engagement request",
+                        rate_limited=True,
+                    )
+                response.raise_for_status()
+                data = response.json()
+        except Exception as exc:  # noqa: BLE001 - vendor/network errors become failures, not raises
+            return EngagementResult(success=False, error=str(exc))
+
+        # Post-level impressions require the separate Page Insights API
+        # (a different permission this adapter doesn't request today) —
+        # left at 0 rather than raised as a failure, same "unsupported
+        # metric reads 0, not unknown" convention EngagementSnapshot's
+        # model docstring establishes.
+        return EngagementResult(
+            success=True,
+            metrics=EngagementMetrics(
+                likes=data.get("likes", {}).get("summary", {}).get("total_count", 0),
+                comments=data.get("comments", {}).get("summary", {}).get("total_count", 0),
+                shares=data.get("shares", {}).get("count", 0),
+                impressions=0,
+            ),
+        )
+
+    def _refresh_access_token(self, refresh_token: str) -> SocialTokens:
+        with track_integration_call("facebook", "oauth_refresh"):
+            response = httpx.post(
+                self.TOKEN_URL,
+                data={
+                    "grant_type": "fb_exchange_token",
+                    "client_id": self.client_id,
+                    "client_secret": self.client_secret,
+                    "fb_exchange_token": refresh_token,
+                },
+                timeout=self.timeout,
+            )
+            response.raise_for_status()
+            data = response.json()
+
+        expires_in = data.get("expires_in")
+        expires_at = (
+            datetime.now(timezone.utc) + timedelta(seconds=expires_in)
+            if expires_in is not None
+            else None
+        )
+
+        return SocialTokens(
+            access_token=data["access_token"],
+            # See class docstring: Meta "refresh" re-exchanges the token
+            # itself, so the new access_token doubles as the next
+            # refresh_token a caller would pass in.
+            refresh_token=data.get("access_token"),
+            expires_at=expires_at,
+            scopes=list(self.SCOPES),
+            external_account_id=None,
+        )

--- a/packages/integrations/social/instagram_provider.py
+++ b/packages/integrations/social/instagram_provider.py
@@ -1,0 +1,292 @@
+from datetime import datetime, timedelta, timezone
+from urllib.parse import urlencode
+
+import httpx
+
+from packages.integrations.observability import track_integration_call
+from packages.integrations.social.base import (
+    EngagementMetrics,
+    EngagementResult,
+    PublishResult,
+    SocialOAuthProvider,
+    SocialPublisher,
+    SocialTokens,
+)
+
+
+class _TokenExpiredError(Exception):
+    """Internal signal that Instagram (Meta Graph API) rejected
+    access_token as expired/invalid — distinct from other HTTP failures
+    because it's the one case publish() retries after a refresh, rather
+    than surfacing immediately."""
+
+
+class _NoInstagramAccountError(Exception):
+    """Raised when the Facebook Page behind this token has no linked
+    Instagram professional account — a real, expected state (not every
+    Page has one converted), not a transport failure, so it's a distinct
+    class from _TokenExpiredError even though both fall back to the same
+    generic PublishResult(success=False, ...) in publish()."""
+
+
+class InstagramProvider(SocialOAuthProvider, SocialPublisher):
+    """The only file in this codebase allowed to call the Instagram Graph
+    API's OAuth and content-publishing endpoints directly.
+
+    Instagram's Content Publishing API rides on Facebook Login and the same
+    graph.facebook.com host FacebookProvider uses (same Meta developer app,
+    same reason META_APP_ID/META_APP_SECRET are shared config) — an IG
+    professional account is only reachable through the Facebook Page it's
+    linked to, never directly. `access_token` is a Page-scoped user access
+    token; `_fetch_ig_user_id` resolves the linked IG business account id
+    fresh on every call (via /me/accounts) rather than accepting it as a
+    parameter, the same "ask the token, don't thread an extra id through
+    the interface" choice LinkedInProvider/XProvider make for their own
+    account ids.
+
+    Instagram has no text-only post — every publish() call requires at
+    least one media URL; a caller that omits media_urls gets a normal
+    PublishResult(success=False, ...) rather than a raised error, same as
+    any other rejected-content failure.
+
+    Like FacebookProvider, Meta has no standalone refresh_token — see that
+    class's docstring for how _refresh_access_token models re-exchange
+    instead.
+    """
+
+    GRAPH_VERSION = "v21.0"
+    AUTHORIZE_URL = f"https://www.facebook.com/{GRAPH_VERSION}/dialog/oauth"
+    TOKEN_URL = f"https://graph.facebook.com/{GRAPH_VERSION}/oauth/access_token"
+    ACCOUNTS_URL = f"https://graph.facebook.com/{GRAPH_VERSION}/me/accounts"
+
+    SCOPES = (
+        "instagram_basic",
+        "instagram_content_publish",
+        "pages_show_list",
+        "pages_read_engagement",
+    )
+
+    def __init__(self, client_id: str, client_secret: str, timeout: float = 15.0) -> None:
+        self.client_id = client_id
+        self.client_secret = client_secret
+        self.timeout = timeout
+
+    # -- SocialOAuthProvider -----------------------------------------------
+
+    def authorize_url(self, state: str, redirect_uri: str) -> str:
+        params = {
+            "response_type": "code",
+            "client_id": self.client_id,
+            "redirect_uri": redirect_uri,
+            "state": state,
+            "scope": ",".join(self.SCOPES),
+        }
+        return f"{self.AUTHORIZE_URL}?{urlencode(params)}"
+
+    def exchange_code(self, code: str, redirect_uri: str) -> SocialTokens:
+        with track_integration_call("instagram", "oauth_exchange"):
+            response = httpx.post(
+                self.TOKEN_URL,
+                data={
+                    "grant_type": "authorization_code",
+                    "code": code,
+                    "redirect_uri": redirect_uri,
+                    "client_id": self.client_id,
+                    "client_secret": self.client_secret,
+                },
+                timeout=self.timeout,
+            )
+            response.raise_for_status()
+            data = response.json()
+
+        expires_in = data.get("expires_in")
+        expires_at = (
+            datetime.now(timezone.utc) + timedelta(seconds=expires_in)
+            if expires_in is not None
+            else None
+        )
+
+        try:
+            external_account_id = self._fetch_ig_user_id(data["access_token"])
+        except _NoInstagramAccountError:
+            external_account_id = None
+
+        return SocialTokens(
+            access_token=data["access_token"],
+            refresh_token=None,
+            expires_at=expires_at,
+            scopes=list(self.SCOPES),
+            external_account_id=external_account_id,
+        )
+
+    def is_token_valid(self, access_token: str) -> bool:
+        with track_integration_call("instagram", "oauth_status_check"):
+            response = httpx.get(
+                self.ACCOUNTS_URL,
+                headers={"Authorization": f"Bearer {access_token}"},
+                timeout=self.timeout,
+            )
+        return response.status_code == 200
+
+    def _fetch_ig_user_id(self, access_token: str) -> str:
+        with track_integration_call("instagram", "oauth_userinfo"):
+            response = httpx.get(
+                self.ACCOUNTS_URL,
+                headers={"Authorization": f"Bearer {access_token}"},
+                params={"fields": "instagram_business_account"},
+                timeout=self.timeout,
+            )
+            if response.status_code == 401:
+                raise _TokenExpiredError("Instagram rejected the access token")
+            response.raise_for_status()
+            pages = response.json().get("data", [])
+
+        for page in pages:
+            ig_account = page.get("instagram_business_account")
+            if ig_account and ig_account.get("id"):
+                return ig_account["id"]
+        raise _NoInstagramAccountError(
+            "No Instagram professional account is linked to this Facebook Page"
+        )
+
+    # -- SocialPublisher -----------------------------------------------
+
+    def publish(
+        self,
+        access_token: str,
+        content: str,
+        media_urls: list[str] | None = None,
+        refresh_token: str | None = None,
+    ) -> PublishResult:
+        if not media_urls:
+            return PublishResult(
+                success=False,
+                error="Instagram requires at least one media URL to publish a post",
+            )
+        try:
+            return self._attempt_publish(access_token, content, media_urls)
+        except _TokenExpiredError:
+            if not refresh_token:
+                return PublishResult(
+                    success=False,
+                    error="Instagram access token expired/invalid and no refresh token is stored",
+                )
+            try:
+                new_tokens = self._refresh_access_token(refresh_token)
+            except Exception as exc:  # noqa: BLE001 - surfaced as PublishResult, not raised
+                return PublishResult(success=False, error=f"Instagram token refresh failed: {exc}")
+
+            try:
+                result = self._attempt_publish(new_tokens.access_token, content, media_urls)
+            except Exception as exc:  # noqa: BLE001
+                return PublishResult(
+                    success=False,
+                    error=f"Instagram publish failed after token refresh: {exc}",
+                )
+            result.refreshed_tokens = new_tokens
+            return result
+        except Exception as exc:  # noqa: BLE001 - vendor/network errors become failures, not raises
+            return PublishResult(success=False, error=str(exc))
+
+    def _attempt_publish(
+        self, access_token: str, content: str, media_urls: list[str]
+    ) -> PublishResult:
+        with track_integration_call("instagram", "publish"):
+            ig_user_id = self._fetch_ig_user_id(access_token)
+
+            container_response = httpx.post(
+                f"https://graph.facebook.com/{self.GRAPH_VERSION}/{ig_user_id}/media",
+                headers={"Authorization": f"Bearer {access_token}"},
+                json={"image_url": media_urls[0], "caption": content},
+                timeout=self.timeout,
+            )
+            if container_response.status_code == 401:
+                raise _TokenExpiredError("Instagram rejected the access token")
+            container_response.raise_for_status()
+            creation_id = container_response.json()["id"]
+
+            publish_response = httpx.post(
+                f"https://graph.facebook.com/{self.GRAPH_VERSION}/{ig_user_id}/media_publish",
+                headers={"Authorization": f"Bearer {access_token}"},
+                json={"creation_id": creation_id},
+                timeout=self.timeout,
+            )
+            if publish_response.status_code == 401:
+                raise _TokenExpiredError("Instagram rejected the access token")
+            publish_response.raise_for_status()
+            post_id = publish_response.json().get("id")
+
+        return PublishResult(
+            success=True,
+            platform_post_id=post_id,
+            platform_post_url=f"https://www.instagram.com/p/{post_id}/" if post_id else None,
+        )
+
+    # -- SocialPublisher: engagement -------------------------------------
+
+    def get_engagement(self, access_token: str, platform_post_id: str) -> EngagementResult:
+        try:
+            with track_integration_call("instagram", "get_engagement"):
+                response = httpx.get(
+                    f"https://graph.facebook.com/{self.GRAPH_VERSION}/{platform_post_id}/insights",
+                    headers={"Authorization": f"Bearer {access_token}"},
+                    params={"metric": "impressions,reach,likes,comments,saved"},
+                    timeout=self.timeout,
+                )
+                if response.status_code == 429:
+                    return EngagementResult(
+                        success=False,
+                        error="Instagram rate-limited this engagement request",
+                        rate_limited=True,
+                    )
+                response.raise_for_status()
+                metric_rows = response.json().get("data", [])
+        except Exception as exc:  # noqa: BLE001 - vendor/network errors become failures, not raises
+            return EngagementResult(success=False, error=str(exc))
+
+        values = {
+            row["name"]: row.get("values", [{}])[0].get("value", 0)
+            for row in metric_rows
+            if row.get("name")
+        }
+        return EngagementResult(
+            success=True,
+            metrics=EngagementMetrics(
+                likes=values.get("likes", 0),
+                comments=values.get("comments", 0),
+                # Instagram has no public "share" count — "saved" is the
+                # closest amplification-style signal it exposes.
+                shares=values.get("saved", 0),
+                impressions=values.get("impressions", 0),
+            ),
+        )
+
+    def _refresh_access_token(self, refresh_token: str) -> SocialTokens:
+        with track_integration_call("instagram", "oauth_refresh"):
+            response = httpx.post(
+                self.TOKEN_URL,
+                data={
+                    "grant_type": "fb_exchange_token",
+                    "client_id": self.client_id,
+                    "client_secret": self.client_secret,
+                    "fb_exchange_token": refresh_token,
+                },
+                timeout=self.timeout,
+            )
+            response.raise_for_status()
+            data = response.json()
+
+        expires_in = data.get("expires_in")
+        expires_at = (
+            datetime.now(timezone.utc) + timedelta(seconds=expires_in)
+            if expires_in is not None
+            else None
+        )
+
+        return SocialTokens(
+            access_token=data["access_token"],
+            refresh_token=data.get("access_token"),
+            expires_at=expires_at,
+            scopes=list(self.SCOPES),
+            external_account_id=None,
+        )

--- a/packages/integrations/social/pinterest_provider.py
+++ b/packages/integrations/social/pinterest_provider.py
@@ -1,0 +1,267 @@
+import base64
+from datetime import datetime, timedelta, timezone
+from urllib.parse import urlencode
+
+import httpx
+
+from packages.integrations.observability import track_integration_call
+from packages.integrations.social.base import (
+    EngagementMetrics,
+    EngagementResult,
+    PublishResult,
+    SocialOAuthProvider,
+    SocialPublisher,
+    SocialTokens,
+)
+
+
+class _TokenExpiredError(Exception):
+    """Internal signal that Pinterest rejected access_token as expired/
+    invalid — distinct from other HTTP failures because it's the one case
+    publish() retries after a refresh, rather than surfacing immediately."""
+
+
+class PinterestProvider(SocialOAuthProvider, SocialPublisher):
+    """The only file in this codebase allowed to call the Pinterest API v5
+    directly. Standard OAuth2 authorization-code flow, HTTP Basic
+    client-credential auth on the token endpoint — same shape as
+    XProvider's _basic_auth_header, no PKCE required. Publishing creates a
+    Pin (Pinterest's only content unit) on the account's default board;
+    `content` is used as the Pin's description and `media_urls[0]` as its
+    image source.
+    """
+
+    AUTHORIZE_URL = "https://www.pinterest.com/oauth/"
+    TOKEN_URL = "https://api.pinterest.com/v5/oauth/token"
+    USER_ACCOUNT_URL = "https://api.pinterest.com/v5/user_account"
+    PINS_URL = "https://api.pinterest.com/v5/pins"
+    BOARDS_URL = "https://api.pinterest.com/v5/boards"
+
+    SCOPES = ("boards:read", "pins:read", "pins:write", "user_accounts:read")
+
+    def __init__(self, client_id: str, client_secret: str, timeout: float = 15.0) -> None:
+        self.client_id = client_id
+        self.client_secret = client_secret
+        self.timeout = timeout
+
+    def _basic_auth_header(self) -> str:
+        raw = f"{self.client_id}:{self.client_secret}".encode()
+        return f"Basic {base64.b64encode(raw).decode()}"
+
+    # -- SocialOAuthProvider ---------------------------------------------
+
+    def authorize_url(self, state: str, redirect_uri: str) -> str:
+        params = {
+            "response_type": "code",
+            "client_id": self.client_id,
+            "redirect_uri": redirect_uri,
+            "scope": ",".join(self.SCOPES),
+            "state": state,
+        }
+        return f"{self.AUTHORIZE_URL}?{urlencode(params)}"
+
+    def exchange_code(
+        self, code: str, redirect_uri: str, code_verifier: str | None = None
+    ) -> SocialTokens:
+        with track_integration_call("pinterest", "oauth_exchange"):
+            response = httpx.post(
+                self.TOKEN_URL,
+                data={
+                    "grant_type": "authorization_code",
+                    "code": code,
+                    "redirect_uri": redirect_uri,
+                },
+                headers={
+                    "Content-Type": "application/x-www-form-urlencoded",
+                    "Authorization": self._basic_auth_header(),
+                },
+                timeout=self.timeout,
+            )
+            response.raise_for_status()
+            data = response.json()
+
+        expires_in = data.get("expires_in")
+        expires_at = (
+            datetime.now(timezone.utc) + timedelta(seconds=expires_in)
+            if expires_in is not None
+            else None
+        )
+        raw_scope = data.get("scope")
+        scopes = raw_scope.split(",") if raw_scope else list(self.SCOPES)
+
+        external_account_id = self._fetch_username(data["access_token"])
+
+        return SocialTokens(
+            access_token=data["access_token"],
+            refresh_token=data.get("refresh_token"),
+            expires_at=expires_at,
+            scopes=scopes,
+            external_account_id=external_account_id,
+        )
+
+    def is_token_valid(self, access_token: str) -> bool:
+        with track_integration_call("pinterest", "oauth_status_check"):
+            response = httpx.get(
+                self.USER_ACCOUNT_URL,
+                headers={"Authorization": f"Bearer {access_token}"},
+                timeout=self.timeout,
+            )
+        return response.status_code == 200
+
+    def _fetch_username(self, access_token: str) -> str | None:
+        with track_integration_call("pinterest", "oauth_userinfo"):
+            response = httpx.get(
+                self.USER_ACCOUNT_URL,
+                headers={"Authorization": f"Bearer {access_token}"},
+                timeout=self.timeout,
+            )
+            response.raise_for_status()
+            return response.json().get("username")
+
+    def _fetch_default_board_id(self, access_token: str) -> str | None:
+        with track_integration_call("pinterest", "list_boards"):
+            response = httpx.get(
+                self.BOARDS_URL,
+                headers={"Authorization": f"Bearer {access_token}"},
+                params={"page_size": 1},
+                timeout=self.timeout,
+            )
+            response.raise_for_status()
+            items = response.json().get("items", [])
+            return items[0]["id"] if items else None
+
+    # -- SocialPublisher ---------------------------------------------------
+
+    def publish(
+        self,
+        access_token: str,
+        content: str,
+        media_urls: list[str] | None = None,
+        refresh_token: str | None = None,
+    ) -> PublishResult:
+        if not media_urls:
+            return PublishResult(
+                success=False,
+                error="Pinterest publish requires an image — no media_urls provided",
+            )
+        try:
+            return self._attempt_publish(access_token, content, media_urls[0])
+        except _TokenExpiredError:
+            if not refresh_token:
+                return PublishResult(
+                    success=False,
+                    error="Pinterest access token expired/invalid and no refresh token is stored",
+                )
+            try:
+                new_tokens = self._refresh_access_token(refresh_token)
+            except Exception as exc:  # noqa: BLE001 - surfaced as PublishResult, not raised
+                return PublishResult(success=False, error=f"Pinterest token refresh failed: {exc}")
+
+            try:
+                result = self._attempt_publish(new_tokens.access_token, content, media_urls[0])
+            except Exception as exc:  # noqa: BLE001
+                return PublishResult(
+                    success=False, error=f"Pinterest publish failed after token refresh: {exc}"
+                )
+            result.refreshed_tokens = new_tokens
+            return result
+        except Exception as exc:  # noqa: BLE001 - vendor/network errors become failures, not raises
+            return PublishResult(success=False, error=str(exc))
+
+    def _attempt_publish(
+        self, access_token: str, content: str, image_url: str
+    ) -> PublishResult:
+        with track_integration_call("pinterest", "publish"):
+            board_id = self._fetch_default_board_id(access_token)
+            if board_id is None:
+                return PublishResult(
+                    success=False, error="Pinterest account has no board to pin to"
+                )
+
+            response = httpx.post(
+                self.PINS_URL,
+                headers={
+                    "Authorization": f"Bearer {access_token}",
+                    "Content-Type": "application/json",
+                },
+                json={
+                    "board_id": board_id,
+                    "description": content,
+                    "media_source": {"source_type": "image_url", "url": image_url},
+                },
+                timeout=self.timeout,
+            )
+            if response.status_code == 401:
+                raise _TokenExpiredError("Pinterest rejected the access token")
+            response.raise_for_status()
+            data = response.json()
+
+        pin_id = data.get("id")
+        return PublishResult(
+            success=True,
+            platform_post_id=pin_id,
+            platform_post_url=f"https://pinterest.com/pin/{pin_id}" if pin_id else None,
+        )
+
+    # -- SocialPublisher: engagement ---------------------------------------
+
+    def get_engagement(self, access_token: str, platform_post_id: str) -> EngagementResult:
+        try:
+            with track_integration_call("pinterest", "get_engagement"):
+                response = httpx.get(
+                    f"{self.PINS_URL}/{platform_post_id}/analytics",
+                    headers={"Authorization": f"Bearer {access_token}"},
+                    params={"metric_types": "IMPRESSION,SAVE,PIN_CLICK,OUTBOUND_CLICK"},
+                    timeout=self.timeout,
+                )
+                if response.status_code == 429:
+                    return EngagementResult(
+                        success=False,
+                        error="Pinterest rate-limited this engagement request",
+                        rate_limited=True,
+                    )
+                response.raise_for_status()
+                totals = response.json().get("all", {}).get("summary_metrics", {})
+        except Exception as exc:  # noqa: BLE001 - vendor/network errors become failures, not raises
+            return EngagementResult(success=False, error=str(exc))
+
+        return EngagementResult(
+            success=True,
+            metrics=EngagementMetrics(
+                likes=int(totals.get("SAVE", 0)),
+                comments=0,  # Pinterest's Pin analytics expose no comment count.
+                shares=int(totals.get("OUTBOUND_CLICK", 0)),
+                impressions=int(totals.get("IMPRESSION", 0)),
+            ),
+        )
+
+    def _refresh_access_token(self, refresh_token: str) -> SocialTokens:
+        with track_integration_call("pinterest", "oauth_refresh"):
+            response = httpx.post(
+                self.TOKEN_URL,
+                data={"grant_type": "refresh_token", "refresh_token": refresh_token},
+                headers={
+                    "Content-Type": "application/x-www-form-urlencoded",
+                    "Authorization": self._basic_auth_header(),
+                },
+                timeout=self.timeout,
+            )
+            response.raise_for_status()
+            data = response.json()
+
+        expires_in = data.get("expires_in")
+        expires_at = (
+            datetime.now(timezone.utc) + timedelta(seconds=expires_in)
+            if expires_in is not None
+            else None
+        )
+        raw_scope = data.get("scope")
+        scopes = raw_scope.split(",") if raw_scope else list(self.SCOPES)
+
+        return SocialTokens(
+            access_token=data["access_token"],
+            refresh_token=data.get("refresh_token", refresh_token),
+            expires_at=expires_at,
+            scopes=scopes,
+            external_account_id=None,
+        )

--- a/packages/integrations/social/threads_provider.py
+++ b/packages/integrations/social/threads_provider.py
@@ -1,0 +1,264 @@
+from datetime import datetime, timedelta, timezone
+from urllib.parse import urlencode
+
+import httpx
+
+from packages.integrations.observability import track_integration_call
+from packages.integrations.social.base import (
+    EngagementMetrics,
+    EngagementResult,
+    PublishResult,
+    SocialOAuthProvider,
+    SocialPublisher,
+    SocialTokens,
+)
+
+
+class _TokenExpiredError(Exception):
+    """Internal signal that Threads rejected access_token as
+    expired/invalid — distinct from other HTTP failures because it's the
+    one case publish() retries after a refresh, rather than surfacing
+    immediately."""
+
+
+class ThreadsProvider(SocialOAuthProvider, SocialPublisher):
+    """The only file in this codebase allowed to call the Threads API's
+    OAuth and publishing endpoints directly.
+
+    Threads is a separate Meta product from the Facebook Graph API proper —
+    its own OAuth dialog (threads.net) and its own API host
+    (graph.threads.net) — but still registered under the same Meta
+    developer app as Facebook/Instagram, hence sharing META_APP_ID/
+    META_APP_SECRET with FacebookProvider/InstagramProvider even though the
+    endpoints themselves differ.
+
+    The authorization-code exchange response includes the Threads user id
+    directly (`user_id`), so unlike LinkedIn/X/Facebook/Instagram this
+    adapter doesn't need a separate userinfo call during exchange_code —
+    only publish()/is_token_valid(), which don't have that response handy,
+    re-fetch it from `/me`.
+
+    Threads publishing is two-step like Instagram's (create a media
+    container, then publish it) and supports text-only posts, unlike
+    Instagram.
+
+    Meta has no standalone refresh_token here either — see
+    FacebookProvider's docstring for the same "re-exchange the token
+    itself" shape, using Threads' own `th_refresh_token` grant.
+    """
+
+    AUTHORIZE_URL = "https://threads.net/oauth/authorize"
+    TOKEN_URL = "https://graph.threads.net/oauth/access_token"
+    REFRESH_URL = "https://graph.threads.net/refresh_access_token"
+    ME_URL = "https://graph.threads.net/v1.0/me"
+
+    SCOPES = ("threads_basic", "threads_content_publish")
+
+    def __init__(self, client_id: str, client_secret: str, timeout: float = 15.0) -> None:
+        self.client_id = client_id
+        self.client_secret = client_secret
+        self.timeout = timeout
+
+    # -- SocialOAuthProvider -----------------------------------------------
+
+    def authorize_url(self, state: str, redirect_uri: str) -> str:
+        params = {
+            "response_type": "code",
+            "client_id": self.client_id,
+            "redirect_uri": redirect_uri,
+            "state": state,
+            "scope": ",".join(self.SCOPES),
+        }
+        return f"{self.AUTHORIZE_URL}?{urlencode(params)}"
+
+    def exchange_code(self, code: str, redirect_uri: str) -> SocialTokens:
+        with track_integration_call("threads", "oauth_exchange"):
+            response = httpx.post(
+                self.TOKEN_URL,
+                data={
+                    "grant_type": "authorization_code",
+                    "code": code,
+                    "redirect_uri": redirect_uri,
+                    "client_id": self.client_id,
+                    "client_secret": self.client_secret,
+                },
+                timeout=self.timeout,
+            )
+            response.raise_for_status()
+            data = response.json()
+
+        expires_in = data.get("expires_in")
+        expires_at = (
+            datetime.now(timezone.utc) + timedelta(seconds=expires_in)
+            if expires_in is not None
+            else None
+        )
+
+        return SocialTokens(
+            access_token=data["access_token"],
+            refresh_token=None,
+            expires_at=expires_at,
+            scopes=list(self.SCOPES),
+            external_account_id=str(data["user_id"]) if data.get("user_id") is not None else None,
+        )
+
+    def is_token_valid(self, access_token: str) -> bool:
+        with track_integration_call("threads", "oauth_status_check"):
+            response = httpx.get(
+                self.ME_URL,
+                headers={"Authorization": f"Bearer {access_token}"},
+                timeout=self.timeout,
+            )
+        return response.status_code == 200
+
+    def _fetch_user_id(self, access_token: str) -> str:
+        with track_integration_call("threads", "oauth_userinfo"):
+            response = httpx.get(
+                self.ME_URL,
+                headers={"Authorization": f"Bearer {access_token}"},
+                timeout=self.timeout,
+            )
+            if response.status_code == 401:
+                raise _TokenExpiredError("Threads rejected the access token")
+            response.raise_for_status()
+            return response.json()["id"]
+
+    # -- SocialPublisher -----------------------------------------------
+
+    def publish(
+        self,
+        access_token: str,
+        content: str,
+        media_urls: list[str] | None = None,
+        refresh_token: str | None = None,
+    ) -> PublishResult:
+        try:
+            return self._attempt_publish(access_token, content, media_urls)
+        except _TokenExpiredError:
+            if not refresh_token:
+                return PublishResult(
+                    success=False,
+                    error="Threads access token expired/invalid and no refresh token is stored",
+                )
+            try:
+                new_tokens = self._refresh_access_token(refresh_token)
+            except Exception as exc:  # noqa: BLE001 - surfaced as PublishResult, not raised
+                return PublishResult(success=False, error=f"Threads token refresh failed: {exc}")
+
+            try:
+                result = self._attempt_publish(new_tokens.access_token, content, media_urls)
+            except Exception as exc:  # noqa: BLE001
+                return PublishResult(
+                    success=False,
+                    error=f"Threads publish failed after token refresh: {exc}",
+                )
+            result.refreshed_tokens = new_tokens
+            return result
+        except Exception as exc:  # noqa: BLE001 - vendor/network errors become failures, not raises
+            return PublishResult(success=False, error=str(exc))
+
+    def _attempt_publish(
+        self, access_token: str, content: str, media_urls: list[str] | None
+    ) -> PublishResult:
+        with track_integration_call("threads", "publish"):
+            threads_user_id = self._fetch_user_id(access_token)
+
+            body: dict[str, object] = {"text": content}
+            if media_urls:
+                body["media_type"] = "IMAGE"
+                body["image_url"] = media_urls[0]
+            else:
+                body["media_type"] = "TEXT"
+
+            container_response = httpx.post(
+                f"https://graph.threads.net/v1.0/{threads_user_id}/threads",
+                headers={"Authorization": f"Bearer {access_token}"},
+                json=body,
+                timeout=self.timeout,
+            )
+            if container_response.status_code == 401:
+                raise _TokenExpiredError("Threads rejected the access token")
+            container_response.raise_for_status()
+            creation_id = container_response.json()["id"]
+
+            publish_response = httpx.post(
+                f"https://graph.threads.net/v1.0/{threads_user_id}/threads_publish",
+                headers={"Authorization": f"Bearer {access_token}"},
+                json={"creation_id": creation_id},
+                timeout=self.timeout,
+            )
+            if publish_response.status_code == 401:
+                raise _TokenExpiredError("Threads rejected the access token")
+            publish_response.raise_for_status()
+            post_id = publish_response.json().get("id")
+
+        return PublishResult(
+            success=True,
+            platform_post_id=post_id,
+            platform_post_url=f"https://www.threads.net/t/{post_id}" if post_id else None,
+        )
+
+    # -- SocialPublisher: engagement -------------------------------------
+
+    def get_engagement(self, access_token: str, platform_post_id: str) -> EngagementResult:
+        try:
+            with track_integration_call("threads", "get_engagement"):
+                response = httpx.get(
+                    f"https://graph.threads.net/v1.0/{platform_post_id}/insights",
+                    headers={"Authorization": f"Bearer {access_token}"},
+                    params={"metric": "likes,replies,reposts,views"},
+                    timeout=self.timeout,
+                )
+                if response.status_code == 429:
+                    return EngagementResult(
+                        success=False,
+                        error="Threads rate-limited this engagement request",
+                        rate_limited=True,
+                    )
+                response.raise_for_status()
+                metric_rows = response.json().get("data", [])
+        except Exception as exc:  # noqa: BLE001 - vendor/network errors become failures, not raises
+            return EngagementResult(success=False, error=str(exc))
+
+        values = {
+            row["name"]: row.get("values", [{}])[0].get("value", 0)
+            for row in metric_rows
+            if row.get("name")
+        }
+        return EngagementResult(
+            success=True,
+            metrics=EngagementMetrics(
+                likes=values.get("likes", 0),
+                comments=values.get("replies", 0),
+                shares=values.get("reposts", 0),
+                impressions=values.get("views", 0),
+            ),
+        )
+
+    def _refresh_access_token(self, refresh_token: str) -> SocialTokens:
+        with track_integration_call("threads", "oauth_refresh"):
+            response = httpx.get(
+                self.REFRESH_URL,
+                params={
+                    "grant_type": "th_refresh_token",
+                    "access_token": refresh_token,
+                },
+                timeout=self.timeout,
+            )
+            response.raise_for_status()
+            data = response.json()
+
+        expires_in = data.get("expires_in")
+        expires_at = (
+            datetime.now(timezone.utc) + timedelta(seconds=expires_in)
+            if expires_in is not None
+            else None
+        )
+
+        return SocialTokens(
+            access_token=data["access_token"],
+            refresh_token=data.get("access_token"),
+            expires_at=expires_at,
+            scopes=list(self.SCOPES),
+            external_account_id=None,
+        )

--- a/packages/integrations/social/tiktok_provider.py
+++ b/packages/integrations/social/tiktok_provider.py
@@ -1,0 +1,259 @@
+import base64
+import hashlib
+from datetime import datetime, timedelta, timezone
+from urllib.parse import urlencode
+
+import httpx
+
+from packages.integrations.observability import track_integration_call
+from packages.integrations.social.base import (
+    EngagementMetrics,
+    EngagementResult,
+    PublishResult,
+    SocialOAuthProvider,
+    SocialPublisher,
+    SocialTokens,
+)
+
+
+class _TokenExpiredError(Exception):
+    """Internal signal that TikTok rejected access_token as expired/
+    invalid — distinct from other HTTP failures because it's the one case
+    publish() retries after a refresh, rather than surfacing immediately."""
+
+
+def _code_challenge_s256(verifier: str) -> str:
+    digest = hashlib.sha256(verifier.encode("ascii")).digest()
+    return base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
+
+
+class TikTokProvider(SocialOAuthProvider, SocialPublisher):
+    """The only file in this codebase allowed to call TikTok for
+    Developers' OAuth2 and Content Posting API directly.
+
+    Unlike XProvider's "plain" PKCE shortcut (code_challenge == the raw
+    verifier), TikTok's API requires the S256 method — this derives a real
+    code_challenge = base64url(sha256(code_verifier)) at authorize_url
+    time. Same "state doubles as the verifier" trick as XProvider (it's
+    already unique per request, single-use, and round-trips unmodified
+    through the redirect) — router code passes `state` back in as
+    `code_verifier` at exchange_code time, same as it does for X.
+    """
+
+    AUTHORIZE_URL = "https://www.tiktok.com/v2/auth/authorize/"
+    TOKEN_URL = "https://open.tiktokapis.com/v2/oauth/token/"
+    USERINFO_URL = "https://open.tiktokapis.com/v2/user/info/"
+    PUBLISH_INIT_URL = "https://open.tiktokapis.com/v2/post/publish/video/init/"
+    VIDEO_QUERY_URL = "https://open.tiktokapis.com/v2/video/query/"
+
+    SCOPES = ("user.info.basic", "video.publish", "video.list")
+
+    def __init__(self, client_key: str, client_secret: str, timeout: float = 30.0) -> None:
+        self.client_key = client_key
+        self.client_secret = client_secret
+        self.timeout = timeout
+
+    # -- SocialOAuthProvider ---------------------------------------------
+
+    def authorize_url(self, state: str, redirect_uri: str) -> str:
+        params = {
+            "client_key": self.client_key,
+            "response_type": "code",
+            "scope": ",".join(self.SCOPES),
+            "redirect_uri": redirect_uri,
+            "state": state,
+            "code_challenge": _code_challenge_s256(state),
+            "code_challenge_method": "S256",
+        }
+        return f"{self.AUTHORIZE_URL}?{urlencode(params)}"
+
+    def exchange_code(
+        self, code: str, redirect_uri: str, code_verifier: str | None = None
+    ) -> SocialTokens:
+        if not code_verifier:
+            raise ValueError("TikTokProvider.exchange_code requires code_verifier (PKCE)")
+
+        with track_integration_call("tiktok", "oauth_exchange"):
+            response = httpx.post(
+                self.TOKEN_URL,
+                data={
+                    "client_key": self.client_key,
+                    "client_secret": self.client_secret,
+                    "code": code,
+                    "grant_type": "authorization_code",
+                    "redirect_uri": redirect_uri,
+                    "code_verifier": code_verifier,
+                },
+                headers={"Content-Type": "application/x-www-form-urlencoded"},
+                timeout=self.timeout,
+            )
+            response.raise_for_status()
+            data = response.json()
+
+        expires_in = data.get("expires_in")
+        expires_at = (
+            datetime.now(timezone.utc) + timedelta(seconds=expires_in)
+            if expires_in is not None
+            else None
+        )
+        raw_scope = data.get("scope")
+        scopes = raw_scope.split(",") if raw_scope else list(self.SCOPES)
+
+        return SocialTokens(
+            access_token=data["access_token"],
+            refresh_token=data.get("refresh_token"),
+            expires_at=expires_at,
+            scopes=scopes,
+            external_account_id=data.get("open_id"),
+        )
+
+    def is_token_valid(self, access_token: str) -> bool:
+        with track_integration_call("tiktok", "oauth_status_check"):
+            response = httpx.get(
+                self.USERINFO_URL,
+                headers={"Authorization": f"Bearer {access_token}"},
+                params={"fields": "open_id"},
+                timeout=self.timeout,
+            )
+        return response.status_code == 200
+
+    # -- SocialPublisher ---------------------------------------------------
+
+    def publish(
+        self,
+        access_token: str,
+        content: str,
+        media_urls: list[str] | None = None,
+        refresh_token: str | None = None,
+    ) -> PublishResult:
+        if not media_urls:
+            return PublishResult(
+                success=False,
+                error="TikTok publish requires a video file — no media_urls provided",
+            )
+        try:
+            return self._attempt_publish(access_token, content, media_urls[0])
+        except _TokenExpiredError:
+            if not refresh_token:
+                return PublishResult(
+                    success=False,
+                    error="TikTok access token expired/invalid and no refresh token is stored",
+                )
+            try:
+                new_tokens = self._refresh_access_token(refresh_token)
+            except Exception as exc:  # noqa: BLE001 - surfaced as PublishResult, not raised
+                return PublishResult(success=False, error=f"TikTok token refresh failed: {exc}")
+
+            try:
+                result = self._attempt_publish(new_tokens.access_token, content, media_urls[0])
+            except Exception as exc:  # noqa: BLE001
+                return PublishResult(
+                    success=False, error=f"TikTok publish failed after token refresh: {exc}"
+                )
+            result.refreshed_tokens = new_tokens
+            return result
+        except Exception as exc:  # noqa: BLE001 - vendor/network errors become failures, not raises
+            return PublishResult(success=False, error=str(exc))
+
+    def _attempt_publish(
+        self, access_token: str, content: str, video_url: str
+    ) -> PublishResult:
+        # Content Posting API's PULL_FROM_URL source lets TikTok fetch the
+        # video itself from our already-durable StorageProvider URL, rather
+        # than this adapter re-uploading the bytes through a chunked PUT —
+        # simplest integration against a public HTTPS video_url, which is
+        # exactly what Generation Engine's stored media URLs already are.
+        with track_integration_call("tiktok", "publish"):
+            response = httpx.post(
+                self.PUBLISH_INIT_URL,
+                headers={
+                    "Authorization": f"Bearer {access_token}",
+                    "Content-Type": "application/json",
+                },
+                json={
+                    "post_info": {"title": content, "privacy_level": "PUBLIC_TO_EVERYONE"},
+                    "source_info": {
+                        "source": "PULL_FROM_URL",
+                        "video_url": video_url,
+                    },
+                },
+                timeout=self.timeout,
+            )
+            if response.status_code == 401:
+                raise _TokenExpiredError("TikTok rejected the access token")
+            response.raise_for_status()
+            data = response.json().get("data", {})
+
+        publish_id = data.get("publish_id")
+        return PublishResult(success=True, platform_post_id=publish_id, platform_post_url=None)
+
+    # -- SocialPublisher: engagement ---------------------------------------
+
+    def get_engagement(self, access_token: str, platform_post_id: str) -> EngagementResult:
+        try:
+            with track_integration_call("tiktok", "get_engagement"):
+                response = httpx.post(
+                    self.VIDEO_QUERY_URL,
+                    headers={
+                        "Authorization": f"Bearer {access_token}",
+                        "Content-Type": "application/json",
+                    },
+                    params={"fields": "id,like_count,comment_count,share_count,view_count"},
+                    json={"filters": {"video_ids": [platform_post_id]}},
+                    timeout=self.timeout,
+                )
+                if response.status_code == 429:
+                    return EngagementResult(
+                        success=False,
+                        error="TikTok rate-limited this engagement request",
+                        rate_limited=True,
+                    )
+                response.raise_for_status()
+                videos = response.json().get("data", {}).get("videos", [])
+                stats = videos[0] if videos else {}
+        except Exception as exc:  # noqa: BLE001 - vendor/network errors become failures, not raises
+            return EngagementResult(success=False, error=str(exc))
+
+        return EngagementResult(
+            success=True,
+            metrics=EngagementMetrics(
+                likes=int(stats.get("like_count", 0)),
+                comments=int(stats.get("comment_count", 0)),
+                shares=int(stats.get("share_count", 0)),
+                impressions=int(stats.get("view_count", 0)),
+            ),
+        )
+
+    def _refresh_access_token(self, refresh_token: str) -> SocialTokens:
+        with track_integration_call("tiktok", "oauth_refresh"):
+            response = httpx.post(
+                self.TOKEN_URL,
+                data={
+                    "client_key": self.client_key,
+                    "client_secret": self.client_secret,
+                    "grant_type": "refresh_token",
+                    "refresh_token": refresh_token,
+                },
+                headers={"Content-Type": "application/x-www-form-urlencoded"},
+                timeout=self.timeout,
+            )
+            response.raise_for_status()
+            data = response.json()
+
+        expires_in = data.get("expires_in")
+        expires_at = (
+            datetime.now(timezone.utc) + timedelta(seconds=expires_in)
+            if expires_in is not None
+            else None
+        )
+        raw_scope = data.get("scope")
+        scopes = raw_scope.split(",") if raw_scope else list(self.SCOPES)
+
+        return SocialTokens(
+            access_token=data["access_token"],
+            # TikTok rotates refresh tokens on every use, same as X.
+            refresh_token=data.get("refresh_token", refresh_token),
+            expires_at=expires_at,
+            scopes=scopes,
+            external_account_id=data.get("open_id"),
+        )

--- a/packages/integrations/social/youtube_provider.py
+++ b/packages/integrations/social/youtube_provider.py
@@ -1,0 +1,282 @@
+import json
+from datetime import datetime, timedelta, timezone
+from urllib.parse import urlencode
+
+import httpx
+
+from packages.integrations.observability import track_integration_call
+from packages.integrations.social.base import (
+    EngagementMetrics,
+    EngagementResult,
+    PublishResult,
+    SocialOAuthProvider,
+    SocialPublisher,
+    SocialTokens,
+)
+
+
+class _TokenExpiredError(Exception):
+    """Internal signal that YouTube/Google rejected access_token as
+    expired/invalid — distinct from other HTTP failures because it's the
+    one case publish() retries after a refresh, rather than surfacing
+    immediately."""
+
+
+class YouTubeProvider(SocialOAuthProvider, SocialPublisher):
+    """The only file in this codebase allowed to call Google's OAuth2 and
+    the YouTube Data API v3 directly.
+
+    Standard Google OAuth2 authorization-code flow (no PKCE needed — this
+    is a confidential/server-side client, same shape as LinkedIn) with
+    `access_type=offline` + `prompt=consent` so Google actually returns a
+    refresh_token (it otherwise only does so on a user's very first
+    consent). Publishing uploads a video via `videos.insert`'s resumable
+    upload protocol: an initial POST to get a per-upload session URL, then
+    a PUT of the raw bytes to that URL — YouTube has no "post text" concept
+    like LinkedIn/X, every publish is a video upload, so `content` here is
+    used as the video's title/description rather than post body text.
+    """
+
+    AUTHORIZE_URL = "https://accounts.google.com/o/oauth2/v2/auth"
+    TOKEN_URL = "https://oauth2.googleapis.com/token"
+    UPLOAD_URL = (
+        "https://www.googleapis.com/upload/youtube/v3/videos"
+        "?uploadType=resumable&part=snippet,status"
+    )
+    VIDEOS_URL = "https://www.googleapis.com/youtube/v3/videos"
+    CHANNELS_URL = "https://www.googleapis.com/youtube/v3/channels"
+    TOKENINFO_URL = "https://oauth2.googleapis.com/tokeninfo"
+
+    SCOPES = (
+        "https://www.googleapis.com/auth/youtube.upload",
+        "https://www.googleapis.com/auth/youtube.readonly",
+    )
+
+    def __init__(self, client_id: str, client_secret: str, timeout: float = 30.0) -> None:
+        self.client_id = client_id
+        self.client_secret = client_secret
+        self.timeout = timeout
+
+    # -- SocialOAuthProvider ---------------------------------------------
+
+    def authorize_url(self, state: str, redirect_uri: str) -> str:
+        params = {
+            "response_type": "code",
+            "client_id": self.client_id,
+            "redirect_uri": redirect_uri,
+            "state": state,
+            "scope": " ".join(self.SCOPES),
+            "access_type": "offline",
+            "prompt": "consent",
+        }
+        return f"{self.AUTHORIZE_URL}?{urlencode(params)}"
+
+    def exchange_code(
+        self, code: str, redirect_uri: str, code_verifier: str | None = None
+    ) -> SocialTokens:
+        with track_integration_call("youtube", "oauth_exchange"):
+            response = httpx.post(
+                self.TOKEN_URL,
+                data={
+                    "grant_type": "authorization_code",
+                    "code": code,
+                    "redirect_uri": redirect_uri,
+                    "client_id": self.client_id,
+                    "client_secret": self.client_secret,
+                },
+                headers={"Content-Type": "application/x-www-form-urlencoded"},
+                timeout=self.timeout,
+            )
+            response.raise_for_status()
+            data = response.json()
+
+        expires_in = data.get("expires_in")
+        expires_at = (
+            datetime.now(timezone.utc) + timedelta(seconds=expires_in)
+            if expires_in is not None
+            else None
+        )
+        raw_scope = data.get("scope")
+        scopes = raw_scope.split(" ") if raw_scope else list(self.SCOPES)
+
+        external_account_id = self._fetch_channel_id(data["access_token"])
+
+        return SocialTokens(
+            access_token=data["access_token"],
+            refresh_token=data.get("refresh_token"),
+            expires_at=expires_at,
+            scopes=scopes,
+            external_account_id=external_account_id,
+        )
+
+    def is_token_valid(self, access_token: str) -> bool:
+        with track_integration_call("youtube", "oauth_status_check"):
+            response = httpx.get(
+                self.TOKENINFO_URL,
+                params={"access_token": access_token},
+                timeout=self.timeout,
+            )
+        return response.status_code == 200
+
+    def _fetch_channel_id(self, access_token: str) -> str | None:
+        with track_integration_call("youtube", "oauth_userinfo"):
+            response = httpx.get(
+                self.CHANNELS_URL,
+                headers={"Authorization": f"Bearer {access_token}"},
+                params={"part": "id", "mine": "true"},
+                timeout=self.timeout,
+            )
+            response.raise_for_status()
+            items = response.json().get("items", [])
+            return items[0]["id"] if items else None
+
+    # -- SocialPublisher ---------------------------------------------------
+
+    def publish(
+        self,
+        access_token: str,
+        content: str,
+        media_urls: list[str] | None = None,
+        refresh_token: str | None = None,
+    ) -> PublishResult:
+        if not media_urls:
+            return PublishResult(
+                success=False,
+                error="YouTube publish requires a video file — no media_urls provided",
+            )
+        try:
+            return self._attempt_publish(access_token, content, media_urls[0])
+        except _TokenExpiredError:
+            if not refresh_token:
+                return PublishResult(
+                    success=False,
+                    error="YouTube access token expired/invalid and no refresh token is stored",
+                )
+            try:
+                new_tokens = self._refresh_access_token(refresh_token)
+            except Exception as exc:  # noqa: BLE001 - surfaced as PublishResult, not raised
+                return PublishResult(success=False, error=f"YouTube token refresh failed: {exc}")
+
+            try:
+                result = self._attempt_publish(new_tokens.access_token, content, media_urls[0])
+            except Exception as exc:  # noqa: BLE001
+                return PublishResult(
+                    success=False, error=f"YouTube publish failed after token refresh: {exc}"
+                )
+            result.refreshed_tokens = new_tokens
+            return result
+        except Exception as exc:  # noqa: BLE001 - vendor/network errors become failures, not raises
+            return PublishResult(success=False, error=str(exc))
+
+    def _attempt_publish(
+        self, access_token: str, content: str, video_url: str
+    ) -> PublishResult:
+        with track_integration_call("youtube", "publish"):
+            video_bytes = httpx.get(video_url, timeout=self.timeout).content
+
+            session = httpx.post(
+                self.UPLOAD_URL,
+                headers={
+                    "Authorization": f"Bearer {access_token}",
+                    "Content-Type": "application/json; charset=UTF-8",
+                    "X-Upload-Content-Type": "video/*",
+                },
+                content=json.dumps(
+                    {
+                        "snippet": {"title": content[:100] or "Untitled", "description": content},
+                        "status": {"privacyStatus": "public"},
+                    }
+                ),
+                timeout=self.timeout,
+            )
+            if session.status_code == 401:
+                raise _TokenExpiredError("YouTube rejected the access token")
+            session.raise_for_status()
+            upload_url = session.headers["Location"]
+
+            response = httpx.put(
+                upload_url,
+                content=video_bytes,
+                headers={"Content-Type": "video/*"},
+                timeout=self.timeout,
+            )
+            if response.status_code == 401:
+                raise _TokenExpiredError("YouTube rejected the access token")
+            response.raise_for_status()
+            data = response.json()
+
+        video_id = data.get("id")
+        return PublishResult(
+            success=True,
+            platform_post_id=video_id,
+            platform_post_url=f"https://youtube.com/watch?v={video_id}" if video_id else None,
+        )
+
+    # -- SocialPublisher: engagement ---------------------------------------
+
+    def get_engagement(self, access_token: str, platform_post_id: str) -> EngagementResult:
+        try:
+            with track_integration_call("youtube", "get_engagement"):
+                response = httpx.get(
+                    self.VIDEOS_URL,
+                    headers={"Authorization": f"Bearer {access_token}"},
+                    params={"id": platform_post_id, "part": "statistics"},
+                    timeout=self.timeout,
+                )
+                if response.status_code == 429:
+                    return EngagementResult(
+                        success=False,
+                        error="YouTube rate-limited this engagement request",
+                        rate_limited=True,
+                    )
+                response.raise_for_status()
+                items = response.json().get("items", [])
+                stats = items[0]["statistics"] if items else {}
+        except Exception as exc:  # noqa: BLE001 - vendor/network errors become failures, not raises
+            return EngagementResult(success=False, error=str(exc))
+
+        return EngagementResult(
+            success=True,
+            metrics=EngagementMetrics(
+                likes=int(stats.get("likeCount", 0)),
+                comments=int(stats.get("commentCount", 0)),
+                shares=0,  # YouTube Data API exposes no share count.
+                impressions=int(stats.get("viewCount", 0)),
+            ),
+        )
+
+    def _refresh_access_token(self, refresh_token: str) -> SocialTokens:
+        with track_integration_call("youtube", "oauth_refresh"):
+            response = httpx.post(
+                self.TOKEN_URL,
+                data={
+                    "grant_type": "refresh_token",
+                    "refresh_token": refresh_token,
+                    "client_id": self.client_id,
+                    "client_secret": self.client_secret,
+                },
+                headers={"Content-Type": "application/x-www-form-urlencoded"},
+                timeout=self.timeout,
+            )
+            response.raise_for_status()
+            data = response.json()
+
+        expires_in = data.get("expires_in")
+        expires_at = (
+            datetime.now(timezone.utc) + timedelta(seconds=expires_in)
+            if expires_in is not None
+            else None
+        )
+        raw_scope = data.get("scope")
+        scopes = raw_scope.split(" ") if raw_scope else list(self.SCOPES)
+
+        return SocialTokens(
+            access_token=data["access_token"],
+            # Google doesn't reissue a refresh_token on refresh — the
+            # original stays valid until revoked, unlike X's rotate-every-
+            # use model.
+            refresh_token=refresh_token,
+            expires_at=expires_at,
+            scopes=scopes,
+            external_account_id=None,
+        )


### PR DESCRIPTION
Closes #138

## Summary
- New adapters implementing `SocialOAuthProvider`/`SocialPublisher` against each platform's real, documented OAuth2 + posting API: `youtube_provider.py` (Google OAuth2 + YouTube Data API v3), `tiktok_provider.py` (TikTok for Developers OAuth2 with real PKCE/S256 + Content Posting API), `pinterest_provider.py` (Pinterest API v5), and `facebook_provider.py`/`instagram_provider.py`/`threads_provider.py` (ported from the not-yet-merged PR #118, adapted onto main's current `social-accounts` page).
- `packages/integrations/social/base.py`: `exchange_code` gains an optional `code_verifier` kwarg (default `None`, ignored by every adapter except TikTok's) — same shape XProvider already uses for "plain" PKCE, needed here because TikTok requires real S256 PKCE.
- `apps/api/routers/social_accounts.py`: generalized the connect/callback pair into a data-driven `_PLATFORM_CONFIG` table (platform → enum member, redirect-uri setting, whether it needs PKCE) instead of one hand-written endpoint pair per platform. Also hardened `_create_state`/`_verify_state` to embed the platform in the signed state's `purpose`, so a state minted for one platform's connect flow can't be replayed against a different platform's callback.
- `registry.py` + `apps/api/config/__init__.py`: all 6 new platforms registered, each with its own env vars (`YOUTUBE_*`, `TIKTOK_*`, `PINTEREST_*`, `META_APP_ID`/`META_APP_SECRET` shared across the 3 Meta platforms) documented in `.env.example`.
- New migration adding `INSTAGRAM`/`THREADS`/`FACEBOOK`/`YOUTUBE`/`TIKTOK`/`PINTEREST` to the `social_platform` Postgres enum (deliberately does not add `X` — that's PR #121's own migration).
- Frontend: `apps/web/app/social-accounts/page.tsx` already read its connectable-platforms list from a small lookup table, so all 6 new platforms are just new entries there plus new `connect*` functions in `lib/api.ts`.

No real app credentials exist yet for YouTube/TikTok/Pinterest — same as LinkedIn/X, the user adds those via env later; every adapter is implemented against the platform's real API so it works the moment credentials land.

**Known overlap with two other open PRs**, flagged for whoever reviews second:
- PR #121 (X OAuth fix) also generalizes `_create_state`/`_verify_state` and adds a `code_verifier` concept — whichever of these two merges second will need a small rebase in `social_accounts.py`/`base.py`.
- PR #118 (Instagram/Threads/Facebook) is effectively superseded by this PR's port of the same 3 providers onto the current page structure — recommend closing #118 in favor of this one once this merges, to avoid the same providers landing twice.

## Test plan
- [x] `pytest apps/api packages` — 493 passed (against an isolated `raindeer_test_issue138` Postgres DB, migrated to this branch's head)
- [x] New tests for every new provider (interface conformance, registry resolution, authorize_url, exchange_code incl. PKCE requirement, is_token_valid, publish incl. requires-media guard, get_engagement incl. rate-limit handling) and new router tests (connect/callback per new platform, cross-platform state rejection, PKCE code_verifier threading, multi-platform upsert isolation)
- [x] `npx tsc --noEmit` clean
- [ ] Frontend vitest suite could not be run in this environment — `window.localStorage.clear is not a function` in `vitest.setup.ts`, reproduced identically on the untouched `auth-gate.test.tsx`, so it's a pre-existing local jsdom/environment issue, not something this change introduced. Should run cleanly in CI's environment; flagging for the reviewer to double-check the actual CI run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WP3zhi1Bqq2psuUPzbqk2n