### PR TITLE
fix(web): point Re-interview with Aarav at the real interview flow

### DIFF
--- a/apps/web/__tests__/brands-page.test.tsx
+++ b/apps/web/__tests__/brands-page.test.tsx
@@ -286,7 +286,7 @@ describe("BrandsPage", () => {
     expect(openSpy).toHaveBeenCalledWith("https://cdn.example.com/report.pdf", "_blank", "noopener,noreferrer");
   });
 
-  it("navigates to onboarding when re-interviewing with Aarav", async () => {
+  it("navigates to the Aarav interview flow when re-interviewing", async () => {
     fetchBrandsMock.mockResolvedValue([makeBrand()]);
     const user = userEvent.setup();
 
@@ -295,6 +295,6 @@ describe("BrandsPage", () => {
 
     await user.click(within(card).getByRole("button", { name: "Re-interview with Aarav" }));
 
-    expect(routerPush).toHaveBeenCalledWith("/onboarding");
+    expect(routerPush).toHaveBeenCalledWith("/onboarding/interview");
   });
 });

--- a/apps/web/app/brands/page.tsx
+++ b/apps/web/app/brands/page.tsx
@@ -148,15 +148,13 @@ export default function BrandsPage() {
     }
   }
 
-  // /onboarding acts on whichever brand is selected in the BrandSwitcher,
-  // not a per-brand URL — re-interviewing brand X from its own card has to
-  // select it first so the onboarding page it lands on is actually X's.
-  //
-  // TODO(#123): once the dedicated Aarav interview flow lands, point this
-  // at that page instead of the general onboarding questionnaire.
+  // /onboarding/interview acts on whichever brand is selected in the
+  // BrandSwitcher, not a per-brand URL — re-interviewing brand X from its
+  // own card has to select it first so the interview it lands on is
+  // actually X's.
   function handleReinterview(brand: Brand) {
     setSelectedBrandId(brand.id);
-    router.push("/onboarding");
+    router.push("/onboarding/interview");
   }
 
   return (


### PR DESCRIPTION
Closes #147

Small stacked fix on top of PR #134, found during the issue #145 audit (a repo-wide sweep for fake/non-functional UI — see that PR/issue for the broader context).

## Problem
PR #134 added a "Re-interview with Aarav" button on the Brand Data page with a `TODO(#123)` noting it should point at the dedicated Aarav interview flow "once it lands" — it routed to the old generic `/onboarding` questionnaire in the meantime. Issue #123 has since landed (PR #132 added `/onboarding/interview`), so the TODO is stale and the button still goes to the wrong place.

## Fix
`handleReinterview` now pushes to `/onboarding/interview` instead of `/onboarding`, and the stale TODO comment is removed. Updated the one test that pinned the old destination.

Based on `feature/issue-128-analytics-branddata-settings` (not `main`) since the affected code doesn't exist on `main` yet — best merged into that branch before PR #134 lands.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01WP3zhi1Bqq2psuUPzbqk2n

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WP3zhi1Bqq2psuUPzbqk2n