### PR TITLE
feat(onboarding): real voice recording + Whisper transcription, real uploads, deeper questionnaire

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,6 +36,7 @@ STORAGE_PROVIDER=supabase
 EMBEDDING_PROVIDER=openai
 VIDEO_PROVIDER=runway
 IMAGE_PROVIDER=fal
+SPEECH_PROVIDER=whisper
 
 # Default model every agent passes to the LLM provider (see
 # packages/integrations/llm/). "openrouter/free" is OpenRouter's free-
@@ -52,6 +53,12 @@ SUPABASE_STORAGE_BUCKET=brand-assets
 
 # --- Video/carousel generation (Generation Engine video/carousel branch) ---
 RUNWAY_API_KEY=
+
+# --- Speech-to-text (Aarav's onboarding voice answers, Issue #144) ---
+# faster-whisper — a free, fully open-source, locally-run model. No API
+# key needed. Model size trades off speed/accuracy/RAM; "base" is a good
+# default for short answers on CPU. Options: tiny/base/small/medium/large-v3.
+WHISPER_MODEL_SIZE=base
 
 # --- Error tracking (optional locally — leave blank to disable Sentry) ---
 SENTRY_DSN=

--- a/apps/api/config/__init__.py
+++ b/apps/api/config/__init__.py
@@ -42,6 +42,14 @@ class Settings(BaseSettings):
     embedding_provider: str = "openai"
     video_provider: str = "runway"
     image_provider: str = "fal"
+    speech_provider: str = "whisper"
+
+    # Onboarding's real voice-answer recording (Issue #144) is transcribed
+    # via faster-whisper — a free, fully open-source, locally-run model
+    # (no API key, no per-call cost). Model size trades off
+    # speed/accuracy/RAM; "base" runs acceptably fast on CPU for a short
+    # onboarding answer. See packages/integrations/speech/whisper_provider.py.
+    whisper_model_size: str = "base"
 
     # OpenRouter's free-models router — swap for a paid model slug (e.g.
     # "anthropic/claude-sonnet-4.5") once quality/latency needs outgrow it.

--- a/apps/api/models/__init__.py
+++ b/apps/api/models/__init__.py
@@ -8,8 +8,10 @@ from apps.api.models.content_calendar_event import (
 )
 from apps.api.models.engagement_snapshot import EngagementSnapshot
 from apps.api.models.integration_call import IntegrationCall
+from apps.api.models.onboarding_asset import ONBOARDING_ASSET_SLOTS, OnboardingAsset
 from apps.api.models.onboarding_research import OnboardingResearch
 from apps.api.models.onboarding_response import OnboardingResponse
+from apps.api.models.onboarding_voice_answer import OnboardingVoiceAnswer
 from apps.api.models.organization import Organization
 from apps.api.models.post import PipelineStage, Post
 from apps.api.models.post_version import PostVersion
@@ -19,6 +21,7 @@ from apps.api.models.social_account import SocialAccount, SocialAccountStatus, S
 from apps.api.models.user import User, UserRole
 
 __all__ = [
+    "ONBOARDING_ASSET_SLOTS",
     "SUPPORTED_PLATFORMS",
     "AgentRun",
     "AgentType",
@@ -28,8 +31,10 @@ __all__ = [
     "ContentCalendarEvent",
     "EngagementSnapshot",
     "IntegrationCall",
+    "OnboardingAsset",
     "OnboardingResearch",
     "OnboardingResponse",
+    "OnboardingVoiceAnswer",
     "Organization",
     "PipelineStage",
     "Post",

--- a/apps/api/models/onboarding_asset.py
+++ b/apps/api/models/onboarding_asset.py
@@ -1,0 +1,42 @@
+import uuid
+from datetime import datetime
+
+from sqlalchemy import DateTime, ForeignKey, String, UniqueConstraint, func
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from apps.api.config.database import Base
+
+# Mirrors the interview UI's UPLOAD_SLOTS
+# (apps/web/app/onboarding/interview/page.tsx) — kept as free text rather
+# than a Postgres enum since these are just display buckets, not a value
+# anything else branches on.
+ONBOARDING_ASSET_SLOTS = ("product_photos", "team_photos", "past_social_posts", "style_guide")
+
+
+class OnboardingAsset(Base):
+    """A file uploaded during Aarav's onboarding interview (Issue #144) —
+    product/team photos, past posts, a style guide. One row per (brand,
+    slot): re-uploading to an already-filled slot replaces that slot's row
+    (see apps/api/routers/onboarding.py::upload_onboarding_asset) rather
+    than stacking indefinitely, same "one current value per slot" model
+    Brand.logo_url already uses."""
+
+    __tablename__ = "onboarding_assets"
+    __table_args__ = (UniqueConstraint("brand_id", "slot", name="uq_onboarding_asset_brand_slot"),)
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    brand_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("brands.id"), nullable=False
+    )
+
+    slot: Mapped[str] = mapped_column(String, nullable=False)
+    url: Mapped[str] = mapped_column(nullable=False)
+    filename: Mapped[str] = mapped_column(nullable=False)
+    content_type: Mapped[str] = mapped_column(String, nullable=False)
+
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )

--- a/apps/api/models/onboarding_response.py
+++ b/apps/api/models/onboarding_response.py
@@ -27,6 +27,15 @@ class OnboardingResponse(Base):
     competitors: Mapped[list | None] = mapped_column(JSONB, nullable=True)
     goals: Mapped[list | None] = mapped_column(JSONB, nullable=True)
 
+    # Deeper-questionnaire fields (Issue #144) — optional enrichment on top
+    # of REQUIRED_FIELDS above, feeding packages/agents/onboarding/prompts.py's
+    # synthesis prompt with more to ground the brand_report in. Not added to
+    # REQUIRED_FIELDS: onboarding can still complete without them, same as
+    # the interview UI's existing "optional" assets question.
+    mission: Mapped[str | None] = mapped_column(nullable=True)
+    content_dos_donts: Mapped[list | None] = mapped_column(JSONB, nullable=True)
+    posting_cadence: Mapped[str | None] = mapped_column(nullable=True)
+
     is_complete: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
 
     created_at: Mapped[datetime] = mapped_column(

--- a/apps/api/models/onboarding_voice_answer.py
+++ b/apps/api/models/onboarding_voice_answer.py
@@ -1,0 +1,37 @@
+import uuid
+from datetime import datetime
+
+from sqlalchemy import DateTime, Float, ForeignKey, String, func
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from apps.api.config.database import Base
+
+
+class OnboardingVoiceAnswer(Base):
+    """A single real, recorded voice answer from Aarav's onboarding
+    interview (Issue #144) — the raw audio (via StorageProvider) and its
+    Whisper transcript are both kept, rather than discarding the audio
+    once transcribed, so "everything voice" is durably on file per the
+    issue's ask. Not unique-per-brand (unlike OnboardingResponse) since a
+    brand can re-record the same question, or multiple voice questions
+    may exist — every take is appended, never overwritten."""
+
+    __tablename__ = "onboarding_voice_answers"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    brand_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("brands.id"), nullable=False
+    )
+
+    question_id: Mapped[str] = mapped_column(String, nullable=False)
+    transcript: Mapped[str] = mapped_column(nullable=False)
+    audio_url: Mapped[str] = mapped_column(nullable=False)
+    language: Mapped[str | None] = mapped_column(String, nullable=True)
+    duration_seconds: Mapped[float | None] = mapped_column(Float, nullable=True)
+
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )

--- a/apps/api/requirements.txt
+++ b/apps/api/requirements.txt
@@ -34,6 +34,10 @@ reportlab==5.0.1
 
 openai==1.109.1
 
+# Free, fully open-source, locally-run speech-to-text for Aarav's
+# onboarding voice answers (Issue #144) — no API key, no per-call cost.
+faster-whisper==1.1.1
+
 pytest==8.3.4
 pytest-cov==6.0.0
 httpx==0.28.1

--- a/apps/api/routers/onboarding.py
+++ b/apps/api/routers/onboarding.py
@@ -2,19 +2,32 @@ import json
 import uuid
 from collections.abc import Generator
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, File, Form, HTTPException, UploadFile, status
 from fastapi.responses import StreamingResponse
 from sqlalchemy.orm import Session
 
 from apps.api.auth.dependencies import CurrentUser, get_current_user
 from apps.api.config.database import get_db
 from apps.api.middleware.rbac import require_role
-from apps.api.models import Brand, OnboardingResponse, UserRole
+from apps.api.models import (
+    ONBOARDING_ASSET_SLOTS,
+    Brand,
+    OnboardingAsset,
+    OnboardingResponse,
+    OnboardingVoiceAnswer,
+    UserRole,
+)
 from apps.api.schemas.brand import BrandRead
-from apps.api.schemas.onboarding import OnboardingRead, OnboardingUpsert
+from apps.api.schemas.onboarding import (
+    OnboardingAssetRead,
+    OnboardingRead,
+    OnboardingUpsert,
+    OnboardingVoiceAnswerRead,
+)
 from packages.agents.onboarding.embedding import embed_brand_report
 from packages.agents.onboarding.graph import run_onboarding_agent
 from packages.agents.onboarding.research_step import run_onboarding_research, search_brand_overview
+from packages.integrations.registry import get_speech_provider, get_storage_provider
 
 router = APIRouter(prefix="/brands/{brand_id}/onboarding", tags=["onboarding"])
 
@@ -178,3 +191,123 @@ def run_agent(
     # replaces this brand's existing chunks rather than appending to them.
     embed_brand_report(db, brand)
     return brand
+
+
+# --- Real voice recording + free open-source transcription (Issue #144) ---
+# Replaces the interview's old "voice" question, which recorded nothing at
+# all ("Recording is illustrative only — no audio is captured").
+
+
+@router.post("/voice-answers", response_model=OnboardingVoiceAnswerRead)
+def create_voice_answer(
+    brand_id: uuid.UUID,
+    question_id: str = Form(...),
+    file: UploadFile = File(...),
+    db: Session = Depends(get_db),
+    current_user: CurrentUser = Depends(require_role(*WRITE_ROLES)),
+) -> OnboardingVoiceAnswer:
+    """Transcribes a recorded onboarding answer via SpeechToTextProvider
+    (packages/integrations/speech — faster-whisper, free and fully
+    open-source, no API key/cost) and durably stores both the raw audio
+    (via StorageProvider, same as brand logos/generated media) and the
+    transcript — "everything voice" persisted, not discarded once read.
+    Every take is appended as its own row (see OnboardingVoiceAnswer's
+    docstring) rather than overwriting a prior recording for the same
+    question."""
+    brand = _get_org_brand(db, brand_id, current_user.org_id)
+    audio_bytes = file.file.read()
+    content_type = file.content_type or "audio/webm"
+
+    result = get_speech_provider().transcribe(audio_bytes, content_type)
+
+    extension = content_type.split("/")[-1].split(";")[0] or "webm"
+    path = f"onboarding/{brand.id}/voice/{question_id}/{uuid.uuid4().hex}.{extension}"
+    audio_url = get_storage_provider().upload(path, audio_bytes, content_type)
+
+    answer = OnboardingVoiceAnswer(
+        brand_id=brand.id,
+        question_id=question_id,
+        transcript=result.text,
+        audio_url=audio_url,
+        language=result.language,
+        duration_seconds=result.duration_seconds,
+    )
+    db.add(answer)
+    db.flush()
+    db.refresh(answer)
+    return answer
+
+
+@router.get("/voice-answers", response_model=list[OnboardingVoiceAnswerRead])
+def list_voice_answers(
+    brand_id: uuid.UUID,
+    db: Session = Depends(get_db),
+    current_user: CurrentUser = Depends(get_current_user),
+) -> list[OnboardingVoiceAnswer]:
+    _get_org_brand(db, brand_id, current_user.org_id)
+    return (
+        db.query(OnboardingVoiceAnswer)
+        .filter(OnboardingVoiceAnswer.brand_id == brand_id)
+        .order_by(OnboardingVoiceAnswer.created_at)
+        .all()
+    )
+
+
+# --- Real asset uploads (Issue #144) ---
+# Replaces the interview's old 4 upload slots, which were decorative divs
+# wired to no file input at all.
+
+
+@router.post("/assets", response_model=OnboardingAssetRead)
+def upload_onboarding_asset(
+    brand_id: uuid.UUID,
+    slot: str = Form(...),
+    file: UploadFile = File(...),
+    db: Session = Depends(get_db),
+    current_user: CurrentUser = Depends(require_role(*WRITE_ROLES)),
+) -> OnboardingAsset:
+    if slot not in ONBOARDING_ASSET_SLOTS:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Unknown slot {slot!r}. Valid options: {sorted(ONBOARDING_ASSET_SLOTS)}",
+        )
+    brand = _get_org_brand(db, brand_id, current_user.org_id)
+    content = file.file.read()
+    content_type = file.content_type or "application/octet-stream"
+    filename = file.filename or slot
+
+    path = f"onboarding/{brand.id}/assets/{slot}/{uuid.uuid4().hex}-{filename}"
+    url = get_storage_provider().upload(path, content, content_type)
+
+    asset = (
+        db.query(OnboardingAsset)
+        .filter(OnboardingAsset.brand_id == brand.id, OnboardingAsset.slot == slot)
+        .first()
+    )
+    if asset is None:
+        asset = OnboardingAsset(brand_id=brand.id, slot=slot, url=url, filename=filename, content_type=content_type)
+        db.add(asset)
+    else:
+        # Re-uploading to an already-filled slot replaces it — one current
+        # value per slot, same model as Brand.logo_url.
+        asset.url = url
+        asset.filename = filename
+        asset.content_type = content_type
+    db.flush()
+    db.refresh(asset)
+    return asset
+
+
+@router.get("/assets", response_model=list[OnboardingAssetRead])
+def list_onboarding_assets(
+    brand_id: uuid.UUID,
+    db: Session = Depends(get_db),
+    current_user: CurrentUser = Depends(get_current_user),
+) -> list[OnboardingAsset]:
+    _get_org_brand(db, brand_id, current_user.org_id)
+    return (
+        db.query(OnboardingAsset)
+        .filter(OnboardingAsset.brand_id == brand_id)
+        .order_by(OnboardingAsset.created_at)
+        .all()
+    )

--- a/apps/api/schemas/onboarding.py
+++ b/apps/api/schemas/onboarding.py
@@ -10,6 +10,9 @@ class OnboardingUpsert(BaseModel):
     product_catalog: dict | None = None
     competitors: list[str] | None = None
     goals: list[str] | None = None
+    mission: str | None = None
+    content_dos_donts: list[str] | None = None
+    posting_cadence: str | None = None
 
 
 class OnboardingRead(BaseModel):
@@ -22,6 +25,34 @@ class OnboardingRead(BaseModel):
     product_catalog: dict | None
     competitors: list[str] | None
     goals: list[str] | None
+    mission: str | None
+    content_dos_donts: list[str] | None
+    posting_cadence: str | None
     is_complete: bool
     created_at: datetime
     updated_at: datetime
+
+
+class OnboardingVoiceAnswerRead(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    brand_id: uuid.UUID
+    question_id: str
+    transcript: str
+    audio_url: str
+    language: str | None
+    duration_seconds: float | None
+    created_at: datetime
+
+
+class OnboardingAssetRead(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    brand_id: uuid.UUID
+    slot: str
+    url: str
+    filename: str
+    content_type: str
+    created_at: datetime

--- a/apps/api/tests/test_integrations_registry.py
+++ b/apps/api/tests/test_integrations_registry.py
@@ -9,9 +9,11 @@ from packages.integrations.registry import (
     get_llm_provider,
     get_search_provider,
     get_social_oauth_provider,
+    get_speech_provider,
 )
 from packages.integrations.search.tavily import TavilyProvider
 from packages.integrations.social.linkedin_provider import LinkedInProvider
+from packages.integrations.speech.whisper_provider import WhisperSpeechProvider
 
 
 @pytest.fixture(autouse=True)
@@ -63,3 +65,19 @@ def test_unknown_embedding_provider_raises(monkeypatch) -> None:
     monkeypatch.setenv("EMBEDDING_PROVIDER", "cohere")
     with pytest.raises(ValueError, match="Unknown EMBEDDING_PROVIDER"):
         get_embedding_provider()
+
+
+def test_get_speech_provider_defaults_to_whisper() -> None:
+    # Constructing the adapter never loads the actual model — Whisper
+    # model weights are loaded lazily, only on the first transcribe()
+    # call (see whisper_provider.py's module-level _MODEL_CACHE) — so this
+    # stays a fast, offline unit test.
+    provider = get_speech_provider()
+    assert isinstance(provider, WhisperSpeechProvider)
+    assert provider.model_size == "base"
+
+
+def test_unknown_speech_provider_raises(monkeypatch) -> None:
+    monkeypatch.setenv("SPEECH_PROVIDER", "deepgram")
+    with pytest.raises(ValueError, match="Unknown SPEECH_PROVIDER"):
+        get_speech_provider()

--- a/apps/api/tests/test_onboarding.py
+++ b/apps/api/tests/test_onboarding.py
@@ -1,4 +1,4 @@
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from fastapi.testclient import TestClient
@@ -259,3 +259,158 @@ def test_cross_org_onboarding_access_returns_404(db_session) -> None:
     )
 
     assert response.status_code == 404
+
+
+# --- Deeper questionnaire fields (Issue #144) ---
+
+
+@uses_test_session
+def test_upsert_accepts_deeper_questionnaire_fields(db_session) -> None:
+    brand, user = _setup_brand(db_session)
+
+    response = client.put(
+        f"/brands/{brand.id}/onboarding",
+        json={
+            "mission": "Make widgets everyone actually wants.",
+            "content_dos_donts": ["Never mention competitor X by name"],
+            "posting_cadence": "A few times a week",
+        },
+        headers=_auth_headers(user),
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["mission"] == "Make widgets everyone actually wants."
+    assert body["content_dos_donts"] == ["Never mention competitor X by name"]
+    assert body["posting_cadence"] == "A few times a week"
+
+
+# --- Real voice recording + transcription (Issue #144) ---
+
+_SPEECH_PATCH_TARGET = "apps.api.routers.onboarding.get_speech_provider"
+_STORAGE_PATCH_TARGET = "apps.api.routers.onboarding.get_storage_provider"
+
+
+class _FakeTranscription:
+    def __init__(self, text: str) -> None:
+        self.text = text
+        self.language = "en"
+        self.duration_seconds = 3.5
+
+
+@uses_test_session
+def test_voice_answer_transcribes_and_stores_audio(db_session) -> None:
+    brand, user = _setup_brand(db_session)
+
+    fake_speech = MagicMock()
+    fake_speech.transcribe.return_value = _FakeTranscription("We sell widgets to small businesses.")
+    fake_storage = MagicMock()
+    fake_storage.upload.return_value = "https://storage.test/onboarding/voice/audience/take.webm"
+
+    with patch(_SPEECH_PATCH_TARGET, return_value=fake_speech), patch(
+        _STORAGE_PATCH_TARGET, return_value=fake_storage
+    ):
+        response = client.post(
+            f"/brands/{brand.id}/onboarding/voice-answers",
+            data={"question_id": "audience"},
+            files={"file": ("answer.webm", b"fake-audio-bytes", "audio/webm")},
+            headers=_auth_headers(user),
+        )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["transcript"] == "We sell widgets to small businesses."
+    assert body["audio_url"] == "https://storage.test/onboarding/voice/audience/take.webm"
+    assert body["question_id"] == "audience"
+    fake_speech.transcribe.assert_called_once()
+    fake_storage.upload.assert_called_once()
+
+    listed = client.get(f"/brands/{brand.id}/onboarding/voice-answers", headers=_auth_headers(user))
+    assert listed.status_code == 200
+    assert len(listed.json()) == 1
+
+
+@uses_test_session
+def test_voice_answer_requires_write_role(db_session) -> None:
+    brand, viewer = _setup_brand(db_session, UserRole.VIEWER)
+
+    response = client.post(
+        f"/brands/{brand.id}/onboarding/voice-answers",
+        data={"question_id": "audience"},
+        files={"file": ("answer.webm", b"data", "audio/webm")},
+        headers=_auth_headers(viewer),
+    )
+
+    assert response.status_code == 403
+
+
+# --- Real asset uploads (Issue #144) ---
+
+
+@uses_test_session
+def test_upload_onboarding_asset_stores_and_lists(db_session) -> None:
+    brand, user = _setup_brand(db_session)
+
+    fake_storage = MagicMock()
+    fake_storage.upload.return_value = "https://storage.test/onboarding/assets/product_photos/x.png"
+
+    with patch(_STORAGE_PATCH_TARGET, return_value=fake_storage):
+        response = client.post(
+            f"/brands/{brand.id}/onboarding/assets",
+            data={"slot": "product_photos"},
+            files={"file": ("photo.png", b"fake-bytes", "image/png")},
+            headers=_auth_headers(user),
+        )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["slot"] == "product_photos"
+    assert body["url"] == "https://storage.test/onboarding/assets/product_photos/x.png"
+    assert body["filename"] == "photo.png"
+
+    listed = client.get(f"/brands/{brand.id}/onboarding/assets", headers=_auth_headers(user))
+    assert listed.status_code == 200
+    assert len(listed.json()) == 1
+
+
+@uses_test_session
+def test_reuploading_to_same_slot_replaces_it(db_session) -> None:
+    brand, user = _setup_brand(db_session)
+    fake_storage = MagicMock()
+
+    with patch(_STORAGE_PATCH_TARGET, return_value=fake_storage):
+        fake_storage.upload.return_value = "https://storage.test/first.png"
+        client.post(
+            f"/brands/{brand.id}/onboarding/assets",
+            data={"slot": "style_guide"},
+            files={"file": ("first.png", b"data-1", "image/png")},
+            headers=_auth_headers(user),
+        )
+
+        fake_storage.upload.return_value = "https://storage.test/second.png"
+        response = client.post(
+            f"/brands/{brand.id}/onboarding/assets",
+            data={"slot": "style_guide"},
+            files={"file": ("second.png", b"data-2", "image/png")},
+            headers=_auth_headers(user),
+        )
+
+    assert response.status_code == 200
+    assert response.json()["url"] == "https://storage.test/second.png"
+
+    listed = client.get(f"/brands/{brand.id}/onboarding/assets", headers=_auth_headers(user))
+    assert len(listed.json()) == 1
+
+
+@uses_test_session
+def test_upload_onboarding_asset_rejects_unknown_slot(db_session) -> None:
+    brand, user = _setup_brand(db_session)
+
+    response = client.post(
+        f"/brands/{brand.id}/onboarding/assets",
+        data={"slot": "not_a_real_slot"},
+        files={"file": ("photo.png", b"data", "image/png")},
+        headers=_auth_headers(user),
+    )
+
+    assert response.status_code == 400

--- a/apps/web/__tests__/onboarding-interview-page.test.tsx
+++ b/apps/web/__tests__/onboarding-interview-page.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
-import { render, screen, waitFor } from "@testing-library/react";
+import { act, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import OnboardingInterviewPage from "@/app/onboarding/interview/page";
 import { AuthProvider } from "@/lib/auth-context";
@@ -21,6 +21,9 @@ const completeOnboardingMock = vi.fn();
 const uploadBrandLogoMock = vi.fn();
 const fetchSocialAccountsMock = vi.fn();
 const connectLinkedInMock = vi.fn();
+const fetchOnboardingAssetsMock = vi.fn();
+const uploadOnboardingAssetMock = vi.fn();
+const transcribeOnboardingVoiceAnswerMock = vi.fn();
 
 vi.mock("@/lib/api", async () => {
   const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
@@ -35,6 +38,9 @@ vi.mock("@/lib/api", async () => {
     uploadBrandLogo: (...args: unknown[]) => uploadBrandLogoMock(...args),
     fetchSocialAccounts: (...args: unknown[]) => fetchSocialAccountsMock(...args),
     connectLinkedIn: (...args: unknown[]) => connectLinkedInMock(...args),
+    fetchOnboardingAssets: (...args: unknown[]) => fetchOnboardingAssetsMock(...args),
+    uploadOnboardingAsset: (...args: unknown[]) => uploadOnboardingAssetMock(...args),
+    transcribeOnboardingVoiceAnswer: (...args: unknown[]) => transcribeOnboardingVoiceAnswerMock(...args),
   };
 });
 
@@ -77,6 +83,9 @@ describe("OnboardingInterviewPage", () => {
     uploadBrandLogoMock.mockReset();
     fetchSocialAccountsMock.mockReset();
     connectLinkedInMock.mockReset();
+    fetchOnboardingAssetsMock.mockReset();
+    uploadOnboardingAssetMock.mockReset();
+    transcribeOnboardingVoiceAnswerMock.mockReset();
 
     window.localStorage.clear();
     window.localStorage.setItem("raindeer.auth.token", "test-token");
@@ -87,6 +96,7 @@ describe("OnboardingInterviewPage", () => {
     updateBrandMock.mockResolvedValue(BRAND);
     upsertOnboardingMock.mockResolvedValue({});
     completeOnboardingMock.mockResolvedValue({});
+    fetchOnboardingAssetsMock.mockResolvedValue([]);
 
     streamOnboardingResearchMock.mockImplementation(
       async (
@@ -169,6 +179,9 @@ describe("OnboardingInterviewPage", () => {
       "Tell us about your audience, in your own words",
       "What do you sell, and who's it for?",
       "Who are your top competitors?",
+      "What's your brand's mission, in one line?",
+      "Anything your content should never say or show?",
+      "How often do you want to post?",
       "Drop in anything that shows your brand at its best",
     ];
 
@@ -180,5 +193,99 @@ describe("OnboardingInterviewPage", () => {
     expect(await screen.findByText("Connect where you publish")).toBeInTheDocument();
     await user.click(screen.getByRole("button", { name: "Enter Raindeer" }));
     expect(push).toHaveBeenCalledWith("/");
+  });
+
+  async function skipTo(user: ReturnType<typeof userEvent.setup>, title: string) {
+    for (;;) {
+      const current = await screen.findByRole("heading", { level: 2 });
+      if (current.textContent === title) return;
+      await user.click(screen.getByText("Skip"));
+    }
+  }
+
+  it("saves mission via upsertOnboarding", async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    await skipTo(user, "What's your brand's mission, in one line?");
+    await user.type(screen.getByPlaceholderText(/Make professional-grade tools/), "Make widgets everyone loves.");
+    await user.click(screen.getByRole("button", { name: "Continue" }));
+
+    await waitFor(() => {
+      expect(upsertOnboardingMock).toHaveBeenCalledWith("test-token", "brand-1", {
+        mission: "Make widgets everyone loves.",
+      });
+    });
+  });
+
+  it("saves content dos/don'ts as a split list via upsertOnboarding", async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    await skipTo(user, "Anything your content should never say or show?");
+    await user.type(screen.getByPlaceholderText(/Never joke about pricing/), "No pricing jokes, no memes");
+    await user.click(screen.getByRole("button", { name: "Continue" }));
+
+    await waitFor(() => {
+      expect(upsertOnboardingMock).toHaveBeenCalledWith("test-token", "brand-1", {
+        content_dos_donts: ["No pricing jokes", "no memes"],
+      });
+    });
+  });
+
+  it("saves a single selected posting cadence via upsertOnboarding", async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    await skipTo(user, "How often do you want to post?");
+    await user.click(screen.getByRole("button", { name: "Weekly" }));
+    await user.click(screen.getByRole("button", { name: "Continue" }));
+
+    await waitFor(() => {
+      expect(upsertOnboardingMock).toHaveBeenCalledWith("test-token", "brand-1", { posting_cadence: "Weekly" });
+    });
+  });
+
+  it("falls back to the text answer when the mic can't be used (no MediaRecorder in this environment)", async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    await skipTo(user, "Tell us about your audience, in your own words");
+    await user.click(screen.getByRole("button", { name: "Start recording" }));
+
+    // jsdom has no MediaRecorder — startRecording must degrade to the
+    // typed fallback rather than leaving the question unanswerable.
+    const textarea = await screen.findByPlaceholderText("Type your answer — Aarav reads tone, not just words.");
+    await user.type(textarea, "Small business owners who hate spreadsheets.");
+    await user.click(screen.getByRole("button", { name: "Continue" }));
+
+    await waitFor(() => {
+      expect(upsertOnboardingMock).toHaveBeenCalledWith("test-token", "brand-1", {
+        audience: "Small business owners who hate spreadsheets.",
+      });
+    });
+  });
+
+  it("uploads a real asset file and shows it as filled instead of a blank slot", async () => {
+    const user = userEvent.setup();
+    uploadOnboardingAssetMock.mockResolvedValue({
+      id: "asset-1",
+      brand_id: "brand-1",
+      slot: "style_guide",
+      url: "https://storage.test/style-guide.pdf",
+      filename: "style-guide.pdf",
+      content_type: "application/pdf",
+      created_at: "2026-01-01",
+    });
+    renderPage();
+
+    await skipTo(user, "Drop in anything that shows your brand at its best");
+    const file = new File(["guide"], "style-guide.pdf", { type: "application/pdf" });
+    await act(async () => {
+      await user.upload(screen.getByLabelText("Upload Style guide"), file);
+    });
+
+    await waitFor(() => expect(uploadOnboardingAssetMock).toHaveBeenCalledWith("test-token", "brand-1", "style_guide", file));
+    expect(await screen.findByText("style-guide.pdf")).toBeInTheDocument();
   });
 });

--- a/apps/web/app/onboarding/interview/page.tsx
+++ b/apps/web/app/onboarding/interview/page.tsx
@@ -6,10 +6,14 @@ import {
   ApiError,
   completeOnboarding,
   fetchOnboarding,
+  fetchOnboardingAssets,
   streamOnboardingResearch,
+  transcribeOnboardingVoiceAnswer,
   updateBrand,
   uploadBrandLogo,
+  uploadOnboardingAsset,
   upsertOnboarding,
+  type OnboardingAsset,
   type ResearchStreamEvent,
 } from "@/lib/api";
 import { useAuth } from "@/lib/auth-context";
@@ -19,7 +23,7 @@ import { Button } from "@/components/ui/Button";
 import { EmptyState } from "@/components/ui/EmptyState";
 import { SocialConnectionsPanel } from "@/app/social-accounts/social-connections-panel";
 
-type QuestionType = "scrape" | "colors" | "chips" | "text" | "voice" | "upload";
+type QuestionType = "scrape" | "colors" | "chips" | "chipsSingle" | "text" | "voice" | "upload";
 
 interface Question {
   id: string;
@@ -47,6 +51,8 @@ const GOAL_CHIP_OPTIONS = [
   "Product launches",
   "Hiring",
 ];
+
+const CADENCE_OPTIONS = ["Daily", "A few times a week", "Weekly", "A few times a month"];
 
 const PRESET_COLORS = ["#1B4DFF", "#0A1633", "#0E7A4E", "#B46A00", "#6B32C9", "#C9295A"];
 
@@ -94,6 +100,24 @@ const QUESTIONS: Question[] = [
     sub: "Comma-separated is fine — Ved researches how you compare.",
   },
   {
+    id: "mission",
+    type: "text",
+    title: "What's your brand's mission, in one line?",
+    sub: "The thing you'd want on a billboard. Optional, but it sharpens everything Keshav and Kavi write.",
+  },
+  {
+    id: "contentDosDonts",
+    type: "text",
+    title: "Anything your content should never say or show?",
+    sub: "Comma-separated is fine — Neer holds every draft to this list.",
+  },
+  {
+    id: "postingCadence",
+    type: "chipsSingle",
+    title: "How often do you want to post?",
+    sub: "Keshav and Kavi plan around this — you can change it any time.",
+  },
+  {
     id: "assets",
     type: "upload",
     title: "Drop in anything that shows your brand at its best",
@@ -101,7 +125,12 @@ const QUESTIONS: Question[] = [
   },
 ];
 
-const UPLOAD_SLOTS = ["Product photos", "Team photos", "Past social posts", "Style guide"];
+const UPLOAD_SLOTS: { slot: string; label: string }[] = [
+  { slot: "product_photos", label: "Product photos" },
+  { slot: "team_photos", label: "Team photos" },
+  { slot: "past_social_posts", label: "Past social posts" },
+  { slot: "style_guide", label: "Style guide" },
+];
 
 function splitCommaList(value: string): string[] {
   return value
@@ -153,6 +182,9 @@ export default function OnboardingInterviewPage() {
   const [useTextFallback, setUseTextFallback] = useState(false);
   const [productDescription, setProductDescription] = useState("");
   const [competitorsText, setCompetitorsText] = useState("");
+  const [mission, setMission] = useState("");
+  const [contentDosDontsText, setContentDosDontsText] = useState("");
+  const [postingCadence, setPostingCadence] = useState("");
   const [colors, setColors] = useState<string[]>([]);
   const [isUploadingLogo, setIsUploadingLogo] = useState(false);
 
@@ -160,6 +192,22 @@ export default function OnboardingInterviewPage() {
   const [isScraping, setIsScraping] = useState(false);
   const [scrapeDone, setScrapeDone] = useState(false);
   const scrapeAbortRef = useRef<AbortController | null>(null);
+
+  // Real mic recording (Issue #144) — MediaRecorder captures audio
+  // client-side; the recorded blob is uploaded to the backend, which
+  // transcribes it via the free, open-source, self-hosted Whisper
+  // provider (packages/integrations/speech) and returns the transcript.
+  const [isRecording, setIsRecording] = useState(false);
+  const [isTranscribing, setIsTranscribing] = useState(false);
+  const [recordingError, setRecordingError] = useState<string | null>(null);
+  const mediaRecorderRef = useRef<MediaRecorder | null>(null);
+  const audioChunksRef = useRef<Blob[]>([]);
+  const mediaStreamRef = useRef<MediaStream | null>(null);
+
+  // Real asset uploads (Issue #144) — replaces the old decorative "+"
+  // slots with actual file pickers backed by OnboardingAsset rows.
+  const [assets, setAssets] = useState<OnboardingAsset[]>([]);
+  const [uploadingSlot, setUploadingSlot] = useState<string | null>(null);
 
   // Resume in-progress onboarding — prefill whatever's already been saved
   // rather than starting the questionnaire over from scratch. Deliberately
@@ -178,7 +226,10 @@ export default function OnboardingInterviewPage() {
     async function load() {
       if (!token || !selectedBrandId) return;
       try {
-        const [onboarding] = await Promise.all([fetchOnboarding(token, selectedBrandId)]);
+        const [onboarding, existingAssets] = await Promise.all([
+          fetchOnboarding(token, selectedBrandId),
+          fetchOnboardingAssets(token, selectedBrandId).catch(() => []),
+        ]);
         if (cancelled) return;
         if (onboarding) {
           if (onboarding.voice) setVoiceTone(splitCommaList(onboarding.voice));
@@ -188,7 +239,11 @@ export default function OnboardingInterviewPage() {
           }
           if (onboarding.competitors) setCompetitorsText(onboarding.competitors.join(", "));
           if (onboarding.goals) setGoals(onboarding.goals);
+          if (onboarding.mission) setMission(onboarding.mission);
+          if (onboarding.content_dos_donts) setContentDosDontsText(onboarding.content_dos_donts.join(", "));
+          if (onboarding.posting_cadence) setPostingCadence(onboarding.posting_cadence);
         }
+        setAssets(existingAssets);
         if (selectedBrand?.colors) setColors(selectedBrand.colors);
       } finally {
         if (!cancelled) setIsLoaded(true);
@@ -203,6 +258,14 @@ export default function OnboardingInterviewPage() {
   }, [token, selectedBrandId]);
 
   useEffect(() => () => scrapeAbortRef.current?.abort(), []);
+
+  useEffect(
+    () => () => {
+      mediaRecorderRef.current?.stop();
+      mediaStreamRef.current?.getTracks().forEach((track) => track.stop());
+    },
+    []
+  );
 
   const runScrape = useCallback(() => {
     if (!token || !selectedBrandId) return;
@@ -276,7 +339,10 @@ export default function OnboardingInterviewPage() {
     { label: "Audience", done: requiredAnswered.audience },
     { label: "What you offer", done: requiredAnswered.product },
     { label: "Competitors", done: requiredAnswered.competitors },
-    { label: "Brand assets (optional)", done: false, optional: true },
+    { label: "Mission (optional)", done: mission.trim().length > 0, optional: true },
+    { label: "Content dos/don'ts (optional)", done: contentDosDontsText.trim().length > 0, optional: true },
+    { label: "Posting cadence (optional)", done: postingCadence.length > 0, optional: true },
+    { label: "Brand assets (optional)", done: assets.length > 0, optional: true },
   ];
   const trackedCount = memoryItems.filter((item) => !item.optional).length;
   const doneCount = memoryItems.filter((item) => !item.optional && item.done).length;
@@ -307,6 +373,85 @@ export default function OnboardingInterviewPage() {
 
   const currentQuestion = QUESTIONS[stepIndex];
 
+  // Real mic recording + transcription (Issue #144). MediaRecorder
+  // captures audio client-side (no external service needed just to
+  // record); the recorded blob is sent to the backend, which transcribes
+  // it via the free, open-source, self-hosted Whisper provider and
+  // returns the transcript, which becomes this question's answer text —
+  // reviewable/editable before continuing, same as the typed fallback.
+  async function startRecording() {
+    setRecordingError(null);
+    if (typeof navigator === "undefined" || !navigator.mediaDevices?.getUserMedia || typeof MediaRecorder === "undefined") {
+      setUseTextFallback(true);
+      return;
+    }
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      mediaStreamRef.current = stream;
+      const mimeType = MediaRecorder.isTypeSupported("audio/webm") ? "audio/webm" : undefined;
+      const recorder = mimeType ? new MediaRecorder(stream, { mimeType }) : new MediaRecorder(stream);
+      audioChunksRef.current = [];
+      recorder.ondataavailable = (event) => {
+        if (event.data.size > 0) audioChunksRef.current.push(event.data);
+      };
+      recorder.onstop = () => {
+        stream.getTracks().forEach((track) => track.stop());
+        mediaStreamRef.current = null;
+      };
+      mediaRecorderRef.current = recorder;
+      recorder.start();
+      setIsRecording(true);
+    } catch {
+      // Mic permission denied/unavailable — fall back to typing rather
+      // than leaving the question stuck.
+      setUseTextFallback(true);
+    }
+  }
+
+  function stopRecording() {
+    const recorder = mediaRecorderRef.current;
+    if (!recorder) return;
+
+    const finished = new Promise<Blob>((resolve) => {
+      recorder.addEventListener(
+        "stop",
+        () => resolve(new Blob(audioChunksRef.current, { type: recorder.mimeType || "audio/webm" })),
+        { once: true }
+      );
+    });
+    recorder.stop();
+    setIsRecording(false);
+
+    if (!token || !selectedBrandId) return;
+    setIsTranscribing(true);
+    finished
+      .then((blob) => transcribeOnboardingVoiceAnswer(token, selectedBrandId, currentQuestion.id, blob))
+      .then((answer) => {
+        setAudience(answer.transcript);
+      })
+      .catch((err) => {
+        setRecordingError(
+          err instanceof ApiError ? err.message : "Couldn't transcribe that — try again, or type your answer."
+        );
+      })
+      .finally(() => setIsTranscribing(false));
+  }
+
+  async function handleAssetUpload(slot: string, file: File | null) {
+    if (!file || !token || !selectedBrandId) return;
+    setUploadingSlot(slot);
+    try {
+      const asset = await uploadOnboardingAsset(token, selectedBrandId, slot, file);
+      setAssets((current) => [...current.filter((a) => a.slot !== slot), asset]);
+      pushToast("Uploaded.", "success");
+    } catch (err) {
+      pushToast(err instanceof ApiError ? err.message : "Failed to upload file", "error");
+    } finally {
+      setUploadingSlot(null);
+    }
+  }
+
+
   async function saveCurrentAnswer(): Promise<void> {
     if (!token || !selectedBrandId) return;
     setIsSaving(true);
@@ -333,6 +478,18 @@ export default function OnboardingInterviewPage() {
         case "competitors":
           if (competitorsText.trim())
             await upsertOnboarding(token, selectedBrandId, { competitors: splitCommaList(competitorsText) });
+          break;
+        case "mission":
+          if (mission.trim()) await upsertOnboarding(token, selectedBrandId, { mission: mission.trim() });
+          break;
+        case "contentDosDonts":
+          if (contentDosDontsText.trim())
+            await upsertOnboarding(token, selectedBrandId, {
+              content_dos_donts: splitCommaList(contentDosDontsText),
+            });
+          break;
+        case "postingCadence":
+          if (postingCadence) await upsertOnboarding(token, selectedBrandId, { posting_cadence: postingCadence });
           break;
         default:
           break;
@@ -661,14 +818,27 @@ export default function OnboardingInterviewPage() {
                   {!useTextFallback ? (
                     <>
                       <div className="flex items-center gap-[18px] rounded-[14px] border border-brand-100 bg-brand-50 p-5">
-                        <div className="flex h-14 w-14 shrink-0 items-center justify-center rounded-full bg-brand-600 text-xl text-white animate-rd-pulse">
-                          ●
-                        </div>
+                        <button
+                          type="button"
+                          onClick={isRecording ? stopRecording : startRecording}
+                          disabled={isTranscribing}
+                          aria-pressed={isRecording}
+                          aria-label={isRecording ? "Stop recording" : "Start recording"}
+                          className={
+                            "flex h-14 w-14 shrink-0 items-center justify-center rounded-full text-xl text-white transition-colors " +
+                            (isRecording ? "bg-danger animate-rd-pulse" : "bg-brand-600 hover:bg-brand-700")
+                          }
+                        >
+                          {isRecording ? "■" : "●"}
+                        </button>
                         <div className="flex h-11 flex-1 items-center gap-[3px]">
                           {Array.from({ length: 32 }).map((_, index) => (
                             <i
                               key={index}
-                              className="flex-1 animate-rd-wave rounded-sm bg-brand-600 opacity-55"
+                              className={
+                                "flex-1 rounded-sm bg-brand-600 " +
+                                (isRecording ? "animate-rd-wave opacity-55" : "opacity-15")
+                              }
                               style={{
                                 height: `${20 + ((index * 37) % 60)}%`,
                                 animationDelay: `${(index % 8) * 0.1}s`,
@@ -678,7 +848,11 @@ export default function OnboardingInterviewPage() {
                         </div>
                       </div>
                       <p className="mt-3 text-xs text-ink-300">
-                        Recording is illustrative only — no audio is captured.{" "}
+                        {isTranscribing
+                          ? "Transcribing your answer…"
+                          : isRecording
+                            ? "Recording — tap the square to stop."
+                            : "Tap the mic to record your answer. Transcribed on our own server via an open-source model — nothing leaves our infrastructure."}{" "}
                         <button
                           type="button"
                           className="font-semibold text-brand-600"
@@ -687,6 +861,16 @@ export default function OnboardingInterviewPage() {
                           Prefer typing? Answer in text instead
                         </button>
                       </p>
+                      {recordingError && (
+                        <p role="alert" className="mt-2 text-xs font-medium text-danger">
+                          {recordingError}
+                        </p>
+                      )}
+                      {audience.trim() && (
+                        <div className="mt-3 rounded-[13px] border border-line-soft bg-white p-3.5 text-sm leading-relaxed text-ink-800">
+                          {audience}
+                        </div>
+                      )}
                     </>
                   ) : (
                     <textarea
@@ -701,32 +885,92 @@ export default function OnboardingInterviewPage() {
 
               {currentQuestion.type === "text" ? (
                 <textarea
-                  value={currentQuestion.id === "product" ? productDescription : competitorsText}
-                  onChange={(e) =>
+                  value={
                     currentQuestion.id === "product"
-                      ? setProductDescription(e.target.value)
-                      : setCompetitorsText(e.target.value)
+                      ? productDescription
+                      : currentQuestion.id === "competitors"
+                        ? competitorsText
+                        : currentQuestion.id === "mission"
+                          ? mission
+                          : contentDosDontsText
                   }
+                  onChange={(e) => {
+                    const value = e.target.value;
+                    if (currentQuestion.id === "product") setProductDescription(value);
+                    else if (currentQuestion.id === "competitors") setCompetitorsText(value);
+                    else if (currentQuestion.id === "mission") setMission(value);
+                    else setContentDosDontsText(value);
+                  }}
                   placeholder={
                     currentQuestion.id === "competitors"
                       ? "e.g. Acme Corp, Widgetron"
-                      : "Type your answer — Aarav reads tone, not just words."
+                      : currentQuestion.id === "contentDosDonts"
+                        ? "e.g. Never joke about pricing, don't show competitor logos"
+                        : currentQuestion.id === "mission"
+                          ? "e.g. Make professional-grade tools every small team can afford."
+                          : "Type your answer — Aarav reads tone, not just words."
                   }
                   className="h-[132px] w-full resize-none rounded-[13px] border border-line bg-white p-3.5 text-sm leading-relaxed outline-none focus:border-brand-500"
                 />
               ) : null}
 
+              {currentQuestion.type === "chipsSingle" ? (
+                <div className="flex flex-wrap gap-2.5">
+                  {CADENCE_OPTIONS.map((option) => (
+                    <ChipButton
+                      key={option}
+                      label={option}
+                      selected={postingCadence === option}
+                      onClick={() => setPostingCadence(option)}
+                    />
+                  ))}
+                </div>
+              ) : null}
+
               {currentQuestion.type === "upload" ? (
                 <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
-                  {UPLOAD_SLOTS.map((label) => (
-                    <div
-                      key={label}
-                      className="flex aspect-square flex-col items-center justify-center gap-1.5 rounded-[13px] border-[1.5px] border-dashed border-ink-100 bg-canvas p-2.5 text-center"
-                    >
-                      <span className="text-lg text-ink-100">＋</span>
-                      <span className="text-[11.5px] font-semibold leading-tight text-ink-500">{label}</span>
-                    </div>
-                  ))}
+                  {UPLOAD_SLOTS.map(({ slot, label }) => {
+                    const uploaded = assets.find((a) => a.slot === slot);
+                    const isUploading = uploadingSlot === slot;
+                    const isImage = uploaded?.content_type.startsWith("image/");
+                    return (
+                      <label
+                        key={slot}
+                        className={
+                          "flex aspect-square cursor-pointer flex-col items-center justify-center gap-1.5 overflow-hidden rounded-[13px] border-[1.5px] p-2.5 text-center " +
+                          (uploaded ? "border-solid border-brand-200 bg-brand-50" : "border-dashed border-ink-100 bg-canvas")
+                        }
+                      >
+                        {isUploading ? (
+                          <span className="text-[11.5px] font-semibold text-ink-500">Uploading…</span>
+                        ) : uploaded ? (
+                          isImage ? (
+                            // eslint-disable-next-line @next/next/no-img-element
+                            <img src={uploaded.url} alt={uploaded.filename} className="h-full w-full object-cover" />
+                          ) : (
+                            <>
+                              <span className="text-lg">✓</span>
+                              <span className="line-clamp-2 text-[11px] font-semibold leading-tight text-ink-600">
+                                {uploaded.filename}
+                              </span>
+                            </>
+                          )
+                        ) : (
+                          <>
+                            <span className="text-lg text-ink-100">＋</span>
+                            <span className="text-[11.5px] font-semibold leading-tight text-ink-500">{label}</span>
+                          </>
+                        )}
+                        <input
+                          type="file"
+                          className="hidden"
+                          disabled={isUploading}
+                          aria-label={`Upload ${label}`}
+                          onChange={(e) => handleAssetUpload(slot, e.target.files?.[0] ?? null)}
+                        />
+                      </label>
+                    );
+                  })}
                 </div>
               ) : null}
 

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -555,6 +555,9 @@ export interface OnboardingUpsertInput {
   product_catalog?: Record<string, unknown> | null;
   competitors?: string[] | null;
   goals?: string[] | null;
+  mission?: string | null;
+  content_dos_donts?: string[] | null;
+  posting_cadence?: string | null;
 }
 
 // Mirrors apps/api/schemas/onboarding.py::OnboardingRead.
@@ -566,9 +569,36 @@ export interface OnboardingResponseData {
   product_catalog: Record<string, unknown> | null;
   competitors: string[] | null;
   goals: string[] | null;
+  mission: string | null;
+  content_dos_donts: string[] | null;
+  posting_cadence: string | null;
   is_complete: boolean;
   created_at: string;
   updated_at: string;
+}
+
+// Mirrors apps/api/schemas/onboarding.py::OnboardingVoiceAnswerRead.
+export interface OnboardingVoiceAnswer {
+  id: string;
+  brand_id: string;
+  question_id: string;
+  transcript: string;
+  audio_url: string;
+  language: string | null;
+  duration_seconds: number | null;
+  created_at: string;
+}
+
+// Mirrors apps/api/schemas/onboarding.py::OnboardingAssetRead. `slot` is
+// one of apps/api/models/onboarding_asset.py::ONBOARDING_ASSET_SLOTS.
+export interface OnboardingAsset {
+  id: string;
+  brand_id: string;
+  slot: string;
+  url: string;
+  filename: string;
+  content_type: string;
+  created_at: string;
 }
 
 // Mirrors apps/api/schemas/brand.py::BrandReportExport.
@@ -713,6 +743,72 @@ export async function streamOnboardingResearch(
       }
     }
   }
+}
+
+// --- Real voice recording + free open-source transcription (Issue #144) ---
+// apps/api/routers/onboarding.py::create_voice_answer takes a multipart
+// "file" field (the recorded audio) plus a "question_id" form field, same
+// convention as uploadBrandLogo's single "file" field above.
+export async function transcribeOnboardingVoiceAnswer(
+  token: string,
+  brandId: string,
+  questionId: string,
+  audioBlob: Blob
+): Promise<OnboardingVoiceAnswer> {
+  const formData = new FormData();
+  formData.append("question_id", questionId);
+  formData.append("file", audioBlob, "answer.webm");
+
+  const res = await fetch(onboardingUrl(brandId, "/voice-answers"), {
+    method: "POST",
+    headers: authHeaders(token),
+    body: formData,
+  });
+
+  if (!res.ok) {
+    throw new ApiError(await parseErrorDetail(res), res.status);
+  }
+
+  return res.json();
+}
+
+// --- Real asset uploads (Issue #144) ---
+// `slot` is one of apps/api/models/onboarding_asset.py::ONBOARDING_ASSET_SLOTS
+// — re-uploading to an already-filled slot replaces it (same "one current
+// value per slot" model as the brand logo).
+export async function uploadOnboardingAsset(
+  token: string,
+  brandId: string,
+  slot: string,
+  file: File
+): Promise<OnboardingAsset> {
+  const formData = new FormData();
+  formData.append("slot", slot);
+  formData.append("file", file);
+
+  const res = await fetch(onboardingUrl(brandId, "/assets"), {
+    method: "POST",
+    headers: authHeaders(token),
+    body: formData,
+  });
+
+  if (!res.ok) {
+    throw new ApiError(await parseErrorDetail(res), res.status);
+  }
+
+  return res.json();
+}
+
+export async function fetchOnboardingAssets(token: string, brandId: string): Promise<OnboardingAsset[]> {
+  const res = await fetch(onboardingUrl(brandId, "/assets"), {
+    headers: authHeaders(token),
+  });
+
+  if (!res.ok) {
+    throw new ApiError(await parseErrorDetail(res), res.status);
+  }
+
+  return res.json();
 }
 
 export async function exportBrandReport(

--- a/migrations/versions/a3f7c9e1d204_onboarding_voice_assets_and_deeper_.py
+++ b/migrations/versions/a3f7c9e1d204_onboarding_voice_assets_and_deeper_.py
@@ -1,0 +1,87 @@
+"""onboarding voice answers, assets, and deeper questionnaire fields
+
+Revision ID: a3f7c9e1d204
+Revises: 5b29b584c4fa
+Create Date: 2026-09-06 16:05:00.000000
+
+Issue #144 — Aarav's onboarding interview previously had a "voice"
+question that recorded nothing ("Recording is illustrative only — no
+audio is captured") and 4 upload slots wired to nothing. This adds
+somewhere for both to actually land:
+
+  * onboarding_voice_answers — one row per recorded take (raw audio via
+    StorageProvider + its Whisper transcript); never overwritten, same
+    "append, don't overwrite" convention post_versions/agent_runs use.
+  * onboarding_assets — one row per (brand, slot) upload; a re-upload to
+    an already-filled slot replaces that slot's row (unique constraint),
+    same "one current value per slot" model as Brand.logo_url.
+  * onboarding_responses gains mission/content_dos_donts/posting_cadence
+    — optional deeper-questionnaire fields feeding
+    packages/agents/onboarding/prompts.py's synthesis prompt, not added
+    to REQUIRED_FIELDS so existing onboarding flows aren't blocked.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'a3f7c9e1d204'
+down_revision: Union[str, None] = '5b29b584c4fa'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        'onboarding_voice_answers',
+        sa.Column('id', sa.UUID(), nullable=False),
+        sa.Column('brand_id', sa.UUID(), nullable=False),
+        sa.Column('question_id', sa.String(), nullable=False),
+        sa.Column('transcript', sa.String(), nullable=False),
+        sa.Column('audio_url', sa.String(), nullable=False),
+        sa.Column('language', sa.String(), nullable=True),
+        sa.Column('duration_seconds', sa.Float(), nullable=True),
+        sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.text('now()'), nullable=False),
+        sa.ForeignKeyConstraint(['brand_id'], ['brands.id']),
+        sa.PrimaryKeyConstraint('id'),
+    )
+    op.create_index(
+        'onboarding_voice_answers_brand_id_idx',
+        'onboarding_voice_answers',
+        ['brand_id'],
+    )
+
+    op.create_table(
+        'onboarding_assets',
+        sa.Column('id', sa.UUID(), nullable=False),
+        sa.Column('brand_id', sa.UUID(), nullable=False),
+        sa.Column('slot', sa.String(), nullable=False),
+        sa.Column('url', sa.String(), nullable=False),
+        sa.Column('filename', sa.String(), nullable=False),
+        sa.Column('content_type', sa.String(), nullable=False),
+        sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.text('now()'), nullable=False),
+        sa.ForeignKeyConstraint(['brand_id'], ['brands.id']),
+        sa.PrimaryKeyConstraint('id'),
+        sa.UniqueConstraint('brand_id', 'slot', name='uq_onboarding_asset_brand_slot'),
+    )
+
+    op.add_column('onboarding_responses', sa.Column('mission', sa.String(), nullable=True))
+    op.add_column(
+        'onboarding_responses',
+        sa.Column('content_dos_donts', postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+    )
+    op.add_column('onboarding_responses', sa.Column('posting_cadence', sa.String(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column('onboarding_responses', 'posting_cadence')
+    op.drop_column('onboarding_responses', 'content_dos_donts')
+    op.drop_column('onboarding_responses', 'mission')
+
+    op.drop_table('onboarding_assets')
+
+    op.drop_index('onboarding_voice_answers_brand_id_idx', table_name='onboarding_voice_answers')
+    op.drop_table('onboarding_voice_answers')

--- a/packages/agents/onboarding/graph.py
+++ b/packages/agents/onboarding/graph.py
@@ -99,6 +99,9 @@ def run_onboarding_agent(
             "product_catalog": onboarding_response.product_catalog,
             "competitors": onboarding_response.competitors,
             "goals": onboarding_response.goals,
+            "mission": onboarding_response.mission,
+            "content_dos_donts": onboarding_response.content_dos_donts,
+            "posting_cadence": onboarding_response.posting_cadence,
         },
         research={
             "brand_overview": research.brand_overview if research else [],

--- a/packages/agents/onboarding/prompts.py
+++ b/packages/agents/onboarding/prompts.py
@@ -28,6 +28,9 @@ Audience: {onboarding_response.get("audience")}
 Product catalog: {json.dumps(onboarding_response.get("product_catalog"))}
 Competitors: {", ".join(onboarding_response.get("competitors") or [])}
 Goals: {", ".join(onboarding_response.get("goals") or [])}
+Mission: {onboarding_response.get("mission") or "(not provided)"}
+Content dos and don'ts: {", ".join(onboarding_response.get("content_dos_donts") or []) or "(none given)"}
+Preferred posting cadence: {onboarding_response.get("posting_cadence") or "(not specified)"}
 
 ## Web research
 Brand overview: {json.dumps(research.get("brand_overview"))}
@@ -35,11 +38,16 @@ Competitor positioning: {json.dumps(research.get("competitor_positioning"))}
 
 ## Task
 Produce a JSON object with exactly these top-level string keys:
-- "voice_and_tone": 2-3 sentences describing the brand's voice and tone
+- "voice_and_tone": 2-3 sentences describing the brand's voice and tone —
+  incorporate the stated mission and any content dos/don'ts so this reads
+  as this brand's actual voice, not a generic tone description
 - "audience": 2-3 sentences describing the target audience
 - "product_catalog_summary": a summary of the product catalog
 - "competitive_positioning": how this brand is positioned against its
   competitors, grounded in the web research above
+
+If a preferred posting cadence was given, factor it into how ambitious
+"competitive_positioning" assumes this brand's content output can be.
 
 Respond with ONLY the JSON object. No markdown code fences, no extra text.
 """

--- a/packages/integrations/registry.py
+++ b/packages/integrations/registry.py
@@ -11,6 +11,8 @@ from packages.integrations.search.tavily import TavilyProvider
 from packages.integrations.social.base import SocialOAuthProvider, SocialPublisher
 from packages.integrations.social.linkedin_provider import LinkedInProvider
 from packages.integrations.social.x_provider import XProvider
+from packages.integrations.speech.base import SpeechToTextProvider
+from packages.integrations.speech.whisper_provider import WhisperSpeechProvider
 from packages.integrations.storage.base import StorageProvider
 from packages.integrations.storage.supabase_provider import SupabaseStorageProvider
 from packages.integrations.video_gen.base import VideoProvider
@@ -72,6 +74,10 @@ _IMAGE_PROVIDERS = {
 
 _VIDEO_PROVIDERS = {
     "runway": lambda settings: RunwayProvider(api_key=settings.runway_api_key or ""),
+}
+
+_SPEECH_PROVIDERS = {
+    "whisper": lambda settings: WhisperSpeechProvider(model_size=settings.whisper_model_size),
 }
 
 
@@ -174,5 +180,17 @@ def get_video_provider() -> VideoProvider:
         raise ValueError(
             f"Unknown VIDEO_PROVIDER '{settings.video_provider}'. "
             f"Valid options: {sorted(_VIDEO_PROVIDERS)}"
+        ) from None
+    return factory(settings)
+
+
+def get_speech_provider() -> SpeechToTextProvider:
+    settings = get_settings()
+    try:
+        factory = _SPEECH_PROVIDERS[settings.speech_provider]
+    except KeyError:
+        raise ValueError(
+            f"Unknown SPEECH_PROVIDER '{settings.speech_provider}'. "
+            f"Valid options: {sorted(_SPEECH_PROVIDERS)}"
         ) from None
     return factory(settings)

--- a/packages/integrations/speech/base.py
+++ b/packages/integrations/speech/base.py
@@ -1,0 +1,20 @@
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+
+
+@dataclass
+class TranscriptionResult:
+    text: str
+    language: str | None = None
+    duration_seconds: float | None = None
+
+
+class SpeechToTextProvider(ABC):
+    """Interface every speech-to-text adapter implements. Business/router
+    code must only ever depend on this interface — never import a vendor
+    SDK or model runtime directly outside the adapter that implements it,
+    same contract as every other package under packages/integrations/."""
+
+    @abstractmethod
+    def transcribe(self, audio_bytes: bytes, content_type: str) -> TranscriptionResult:
+        ...

--- a/packages/integrations/speech/whisper_provider.py
+++ b/packages/integrations/speech/whisper_provider.py
@@ -1,0 +1,76 @@
+import logging
+import os
+import tempfile
+from typing import Any
+
+from packages.integrations.observability import track_integration_call
+from packages.integrations.speech.base import SpeechToTextProvider, TranscriptionResult
+
+logger = logging.getLogger(__name__)
+
+# Guesses a reasonable file extension for whatever container the browser's
+# MediaRecorder produced, purely so the temp file we hand to faster-whisper
+# (which shells out to ffmpeg/PyAV for decoding) has a hint to work with —
+# ffmpeg mostly sniffs the real container anyway, this is a best-effort.
+_EXTENSION_BY_CONTENT_TYPE = {
+    "audio/webm": ".webm",
+    "audio/ogg": ".ogg",
+    "audio/wav": ".wav",
+    "audio/x-wav": ".wav",
+    "audio/mp4": ".m4a",
+    "audio/mpeg": ".mp3",
+}
+
+# Module-level cache: faster-whisper's WhisperModel loads model weights
+# from disk (downloading them once, on first use, into its own cache dir)
+# — expensive enough that every adapter instance must share one loaded
+# model rather than reloading per-request/per-instance.
+_MODEL_CACHE: dict[str, Any] = {}
+
+
+def _load_model(model_size: str):
+    if model_size not in _MODEL_CACHE:
+        # Imported lazily (not at module import time) so importing this
+        # module — e.g. from registry.py, which is imported broadly —
+        # never requires faster-whisper's fairly heavy dependency chain
+        # (torch/ctranslate2) unless a WhisperProvider is actually
+        # constructed and used.
+        from faster_whisper import WhisperModel
+
+        logger.info("Whisper speech provider: loading model size=%r (first use)", model_size)
+        _MODEL_CACHE[model_size] = WhisperModel(model_size, device="cpu", compute_type="int8")
+    return _MODEL_CACHE[model_size]
+
+
+class WhisperSpeechProvider(SpeechToTextProvider):
+    """Free, fully open-source, locally-run speech-to-text via
+    faster-whisper (CTranslate2's reimplementation of OpenAI's Whisper) —
+    no API key, no per-call cost, no network dependency once the model
+    weights are cached locally. The only file allowed to import
+    faster_whisper directly; every other module reaches it only through
+    SpeechToTextProvider, resolved via
+    packages.integrations.registry.get_speech_provider(), same
+    interface-only contract as every other adapter in this repo."""
+
+    def __init__(self, model_size: str = "base") -> None:
+        self.model_size = model_size
+
+    def transcribe(self, audio_bytes: bytes, content_type: str) -> TranscriptionResult:
+        model = _load_model(self.model_size)
+        suffix = _EXTENSION_BY_CONTENT_TYPE.get(content_type, ".webm")
+
+        with track_integration_call("whisper", "speech_to_text"):
+            fd, temp_path = tempfile.mkstemp(suffix=suffix)
+            try:
+                with os.fdopen(fd, "wb") as temp_file:
+                    temp_file.write(audio_bytes)
+
+                segments, info = model.transcribe(temp_path, beam_size=5)
+                text = " ".join(segment.text.strip() for segment in segments).strip()
+                return TranscriptionResult(
+                    text=text,
+                    language=getattr(info, "language", None),
+                    duration_seconds=getattr(info, "duration", None),
+                )
+            finally:
+                os.remove(temp_path)


### PR DESCRIPTION
Closes #144

## Summary
Aarav's onboarding interview (`apps/web/app/onboarding/interview/page.tsx`) had two places that only *looked* functional:
- The "voice" question rendered an animated waveform but its own copy admitted "Recording is illustrative only — no audio is captured."
- The 4 upload slots (Product photos / Team photos / Past social posts / Style guide) were decorative divs with no file input wired to anything.

This PR makes onboarding fully real end-to-end:

- **Real voice recording + free open-source transcription**: `MediaRecorder`-based mic capture in the browser, transcribed server-side via a new `packages/integrations/speech/` provider backed by `faster-whisper` — free, fully open-source, runs locally on CPU, no API key or per-call cost (chosen specifically per the ask for a "free opensource model" rather than a paid hosted STT API). Both the raw audio (via `StorageProvider`) and the transcript (`OnboardingVoiceAnswer`, one row per take) are durably stored rather than discarded. Falls back to the existing typed-answer path when the mic is unavailable/denied.
- **Real asset uploads**: the 4 slots now use actual file pickers, uploading through `StorageProvider` and persisting metadata in a new `OnboardingAsset` table (one row per brand+slot; re-uploading replaces it). The UI shows a thumbnail or filename once a slot is filled instead of a blank "+".
- **Deeper questionnaire**: added mission, content dos/don'ts, and preferred posting cadence questions — optional (not required to complete onboarding), and fed into `packages/agents/onboarding/prompts.py`'s synthesis prompt so `brand_report` is grounded in the deeper answers.
- New Alembic migration (`onboarding_voice_answers`, `onboarding_assets` tables; `mission`/`content_dos_donts`/`posting_cadence` columns on `onboarding_responses`).

Based on `feature/issue-123-onboarding-flow` (not `main`) since the interview page it modifies only exists on that not-yet-merged branch — same stacking as PR #141 on `feature/issue-124-content-arena`.

## Test plan
- [x] Backend: 412/412 tests pass (`pytest apps/api/tests packages/agents/tests`), including new coverage for the speech provider registry entry, the voice-answer/asset endpoints (happy path, role gating, unknown-slot rejection, slot-replacement), and the deeper questionnaire fields.
- [x] `npx tsc --noEmit` clean.
- [x] Frontend: all onboarding-interview tests pass (10/10, including new coverage for mission/dos-donts/cadence saving, mic-unavailable fallback, and real asset upload), full suite otherwise green except one pre-existing, unrelated flaky test in `social-accounts-page.test.tsx` (passes in isolation — same flake class documented in PR #118's history, not touched by this change).
- [ ] Manual: needs a live browser + a real mic to verify end-to-end (out of scope for this sandbox) — the transcription pipeline itself is exercised by mocked backend tests.

Note for reviewer: `faster-whisper` downloads its model weights on first real use (not during tests, which mock the provider) — first real transcription in a fresh environment will be slower while that download happens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WP3zhi1Bqq2psuUPzbqk2n